### PR TITLE
Better SBT Caching

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,9 @@
 
 name: test
 
-on: [push]
+on:
+  push: # run this workflow on every push
+  pull_request: # run this workflow on every pull_request
 
 jobs:
   setup-and-test:
@@ -67,12 +69,27 @@ jobs:
         run: ln --symbolic ../silver; ln --symbolic ../silicon; ln --symbolic ../carbon; ln --symbolic ../viperserver
         working-directory: gobra
 
+      - name: Set sbt cache variables
+        run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV
+        # note that the cache path is relative to the directory in which sbt is invoked.
+
       - name: Cache SBT
         uses: actions/cache@v2
         with:
           path: |
-            ~/.ivy2/cache
-            ~/.sbt
+            gobra/sbt-cache/.sbtboot
+            gobra/sbt-cache/.boot
+            gobra/sbt-cache/.ivy/cache
+            gobra/project/target
+            gobra/target
+            viperserver/project/target
+            viperserver/target
+            carbon/project/target
+            carbon/target
+            silicon/project/target
+            silicon/target
+            silver/project/target
+            silver/target
           key: ${{ runner.os }}-sbt-${{ hashFiles('**/build.sbt') }}
 
       - name: Execute all tests


### PR DESCRIPTION
Speeds up compilation of Gobra by caching the sbt version (avoids re-downloading the right sbt version) and by caching compilation output from gobra, viperserver, silicon, carbon, and silver. 
Rerunning the action resulted in a reduction of `sbt test` from 483s to 333s