### PR TITLE
Fixed parsing error mentioned on issue #97

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -902,7 +902,7 @@ object Parser {
         exactWord("uint64") ^^^ PUInt64Type() |
         exactWord("uintptr") ^^^ PUIntPtr()
 
-    private def exactWord(s: String): Regex = (s ++ "\\b").r
+    private def exactWord(s: String): Regex = ("\\b" ++ s ++ "\\b").r
 
     lazy val qualifiedType: Parser[PDot] =
       declaredType ~ ("." ~> idnUse) ^^ PDot

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -15,6 +15,8 @@ import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, message}
 import viper.gobra.ast.frontend._
 import viper.gobra.reporting.{ParsedInputMessage, ParserError, ParserErrorMessage, PreprocessedInputMessage, VerifierError}
 
+import scala.util.matching.Regex
+
 object Parser {
 
   /**
@@ -883,22 +885,24 @@ object Parser {
         declaredType
 
     lazy val predeclaredType: Parser[PPredeclaredType] =
-      "bool" ^^^ PBoolType() |
+      exactWord("bool") ^^^ PBoolType() |
         // signed integer types
-        "rune" ^^^ PRune() |
-        "int8" ^^^ PInt8Type() |
-        "int16" ^^^ PInt16Type() |
-        "int32" ^^^ PInt32Type() |
-        "int64" ^^^ PInt64Type() |
-        "int" ^^^ PIntType() | // 'int' must come after all 'intX' parsers, otherwise parsing will stop at 'int'
+        exactWord("rune") ^^^ PRune() |
+        exactWord("int") ^^^ PIntType() |
+        exactWord("int8") ^^^ PInt8Type() |
+        exactWord("int16") ^^^ PInt16Type() |
+        exactWord("int32") ^^^ PInt32Type() |
+        exactWord("int64") ^^^ PInt64Type() |
         // unsigned integer types
-        "byte" ^^^ PByte() |
-        "uint8" ^^^ PUInt8Type() |
-        "uint16" ^^^ PUInt16Type() |
-        "uint32" ^^^ PUInt32Type() |
-        "uint64" ^^^ PUInt64Type() |
-        "uintptr" ^^^ PUIntPtr() |
-        "uint" ^^^ PUIntType()
+        exactWord("byte") ^^^ PByte() |
+        exactWord("uint") ^^^ PUIntType() |
+        exactWord("uint8") ^^^ PUInt8Type() |
+        exactWord("uint16") ^^^ PUInt16Type() |
+        exactWord("uint32") ^^^ PUInt32Type() |
+        exactWord("uint64") ^^^ PUInt64Type() |
+        exactWord("uintptr") ^^^ PUIntPtr()
+
+    private def exactWord(s: String): Regex = (s ++ "\\b").r
 
     lazy val qualifiedType: Parser[PDot] =
       declaredType ~ ("." ~> idnUse) ^^ PDot

--- a/src/test/resources/regressions/issues/000097.gobra
+++ b/src/test/resources/regressions/issues/000097.gobra
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg;
+
+type intPair struct {
+    a int;
+    b int;
+};
+
+func test(t intPair) (res int) {
+    return t.a + t.b
+}


### PR DESCRIPTION
I changed the parser so that it does not eagerly parse type names and stops too early. For example, the parser now correctly parses the type identifier `intPair` instead of only accepting the prefix `int` and leaving `Pair` to be consumed.