### PR TITLE
Additional test cases for per-file imports

### DIFF
--- a/src/test/resources/regressions/features/import/multi_import/bar/bar.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/bar/bar.gobra
@@ -1,0 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package bar
+
+const Answer = 42

--- a/src/test/resources/regressions/features/import/multi_import/foo/foo.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/foo/foo.gobra
@@ -1,0 +1,7 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package foo
+
+const IsFoo = true
+const Answer = 42

--- a/src/test/resources/regressions/features/import/multi_import/main1.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main1.gobra
@@ -1,0 +1,16 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+// ##(-I src/test/resources/regressions/features/import/multi_import)
+// import of same package but with different qualifiers should be possible:
+import b "bar"
+import bar "bar"
+import . "bar"
+
+func foo() {
+  assert(b.Answer == 42)
+  assert(bar.Answer == 42)
+  assert(Answer == 42)
+}

--- a/src/test/resources/regressions/features/import/multi_import/main2.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main2.gobra
@@ -1,0 +1,11 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+// ##(-I src/test/resources/regressions/features/import/multi_import)
+// import of same package with same qualifier is forbidden:
+//:: ExpectedOutput(type_error)
+import b "bar"
+//:: ExpectedOutput(type_error)
+import b "bar"

--- a/src/test/resources/regressions/features/import/multi_import/main3.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main3.gobra
@@ -1,0 +1,11 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+// ##(-I src/test/resources/regressions/features/import/multi_import)
+// import of different packages but with same qualifier is forbidden:
+//:: ExpectedOutput(type_error)
+import b "bar"
+//:: ExpectedOutput(type_error)
+import b "foo"

--- a/src/test/resources/regressions/features/import/multi_import/main4.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main4.gobra
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+// ##(-I src/test/resources/regressions/features/import/multi_import)
+// unqualified import of same package is forbidden:
+import . "bar"
+import . "bar"
+
+func foo() {
+  //:: ExpectedOutput(type_error)
+  assert(Answer == 42)
+}

--- a/src/test/resources/regressions/features/import/multi_import/main5.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main5.gobra
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+// ##(-I src/test/resources/regressions/features/import/multi_import)
+// unqualified import of bar and foo should not work as they both define a constant with the same identifier:
+import . "bar"
+import . "foo"
+
+func foo() {
+  //:: ExpectedOutput(type_error)
+  assert(Answer == 42)
+}


### PR DESCRIPTION
Cases described in #40 are already handled by Gobra. However, this PR adds additional test cases to explicitly test these cases.

Note that duplicate identifiers are only lazily detected (see `main4.gobra` and `main5.gobra`)

Closes #40
