### PR TITLE
Exception Handling for ViperServer Backend

### DIFF
--- a/src/main/scala/viper/gobra/backend/ViperServer.scala
+++ b/src/main/scala/viper/gobra/backend/ViperServer.scala
@@ -35,12 +35,16 @@ object ViperServer {
         sender ! verificationPromise
 
       case msg: Message =>
-        reporter.report(msg)
+        try {
+          reporter.report(msg)
 
-        msg match {
-          case msg: OverallFailureMessage => verificationPromise success msg.result
-          case _: OverallSuccessMessage   => verificationPromise success Success
-          case _ =>
+          msg match {
+            case msg: OverallFailureMessage => verificationPromise success msg.result
+            case _: OverallSuccessMessage   => verificationPromise success Success
+            case _ =>
+          }
+        } catch {
+          case e: Throwable => verificationPromise failure e
         }
 
       case e: Throwable => verificationPromise failure e


### PR DESCRIPTION
Executing for example the program from #109 currently results in an exception during back-translation.
When using the ViperServer backend (as it is the case for the Gobra IDE) this exception crashes the Akka actor without propagating the exception using the verification promise. Hence, there is no way to gracefully handle such an exception by clients.

This PR catches exceptions during back-translation (when using the ViperServer backend) and propagates them using the verification promise. It is then up to the client to handle the exception.