### PR TITLE
Fixes IllegalStateException of ViperServer VerificationPromise

### DIFF
--- a/src/main/scala/viper/gobra/backend/ViperServer.scala
+++ b/src/main/scala/viper/gobra/backend/ViperServer.scala
@@ -39,15 +39,15 @@ object ViperServer {
           reporter.report(msg)
 
           msg match {
-            case msg: OverallFailureMessage => verificationPromise success msg.result
-            case _: OverallSuccessMessage   => verificationPromise success Success
+            case msg: OverallFailureMessage => verificationPromise trySuccess msg.result
+            case _: OverallSuccessMessage   => verificationPromise trySuccess Success
             case _ =>
           }
         } catch {
-          case e: Throwable => verificationPromise failure e
+          case e: Throwable => verificationPromise tryFailure e
         }
 
-      case e: Throwable => verificationPromise failure e
+      case e: Throwable => verificationPromise tryFailure e
     }
   }
 }


### PR DESCRIPTION
Calling `success` or `failure` on a completed promise results in an IllegalStateException.
Because an exception could occur while reporting any message, the `verificationPromise` might already be completed when the `OverallSuccessMessage` or `OverallFailureMessage` is received.
This PR switches to `trySuccess` and `tryFailure` that result in a no-op if the promise is already completed