### PR TITLE
Support for Stubs

### DIFF
--- a/.github/license-check/config.json
+++ b/.github/license-check/config.json
@@ -4,7 +4,8 @@
       "**/*.scala",
       "**/*.vpr",
       "**/*.go",
-      "build.sbt"
+      "build.sbt",
+      "src/main/**/*.gobra"
     ],
     "exclude": [
       "carbon/**",
@@ -51,7 +52,8 @@
     "exclude": [
       "project/project/**",
       "project/target/**",
-      "target/**"
+      "target/**",
+      "src/main/**"
     ],
     "license": "./.github/license-check/headers/CC0.txt"
   },

--- a/src/main/resources/README.md
+++ b/src/main/resources/README.md
@@ -2,7 +2,7 @@
 This folder contains resources that are included in the Gobra jar file.
 
 ## Stubs
-In particular noteworthy are `.gobra` files contained in the `stubs` folder:
+The `.gobra` files contained in the `stubs` folder are particularly noteworthy:
 Gobra uses them when resolving package imports.
 Hence, predefined specification for imported libraries can be provided this way.
 Note that the `-I` command line option takes higher precendence in the package resolution and might overrule the provided stubs.

--- a/src/main/resources/README.md
+++ b/src/main/resources/README.md
@@ -1,0 +1,18 @@
+# Resources
+This folder contains resources that are included in the Gobra jar file.
+
+## Stubs
+In particular noteworthy are `.gobra` files contained in the `stubs` folder:
+Gobra uses them when resolving package imports.
+Hence, predefined specification for imported libraries can be provided this way.
+Note that the `-I` command line option takes higher precendence in the package resolution and might overrule the provided stubs.
+
+### Example
+The directory `stubs/github.com/scionproto/scion/go/lib/assert` provides a very simple assertion library, similar to the one SCION has used in the past.
+This library can be imported as follows:
+```
+import stubAssert "github.com/scionproto/scion/go/lib/assert"
+``` 
+Note that the import path directly corresponds to the directory structure in `stubs`.
+As `assert` is a reserved keyword in Gobra and the implicit qualifier would be `assert`, the library is imported with the qualifier `stubAssert`.
+The implicit qualifier corresponds to the last path component (here `assert`) and is not related to the package clause used in Gobra files located in the `assert` folder.

--- a/src/main/resources/stubs/github.com/scionproto/scion/go/lib/assert/assert.gobra
+++ b/src/main/resources/stubs/github.com/scionproto/scion/go/lib/assert/assert.gobra
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+package assertPkg // note that assert is a reserved keyword
+
+const On = true
+
+requires condition
+ensures condition
+func Must(condition bool) // more arguments (e.g. a reason) are currently not supported

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -121,7 +121,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
 
   private def performParsing(input: Vector[File], config: Config): Either[Vector[VerifierError], PPackage] = {
     if (config.shouldParse) {
-      Parser.parse(input)(config)
+      Parser.parse(input.map(_.toPath))(config)
     } else {
       Left(Vector())
     }

--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -6,18 +6,26 @@
 
 package viper.gobra.frontend
 
-import java.io.File
-import java.nio.file.{Files, Path, Paths}
+import java.io.{Closeable, File, InputStream}
+import java.net.URI
+import java.nio.file.{FileSystems, Files, Path, Paths}
+import java.util.Collections
 
 import org.apache.commons.io.FilenameUtils
 import org.apache.commons.lang3.SystemUtils
 import viper.gobra.ast.frontend.PImplicitQualifiedImport
 
+import scala.io.BufferedSource
 import scala.util.Properties
+import scala.jdk.CollectionConverters._
 
 object PackageResolver {
 
   val extension = """gobra"""
+  /** directory paths containing stubs relative to src/main/resources */
+  val stubDirectories = Vector("stubs")
+  val fileUriScheme = "file"
+  val jarUriScheme = "jar"
 
   /**
     * Resolves a package name (i.e. import path) to specific input files
@@ -26,11 +34,11 @@ object PackageResolver {
     * @return list of files belonging to the package (right) or an error message (left) if no directory could be found
     *         or the directory contains input files having different package clauses
     */
-  def resolve(importPath: String, includeDirs: Vector[File]): Either[String, Vector[File]] = {
+  def resolve(importPath: String, includeDirs: Vector[File]): Either[String, Vector[InputResource]] = {
     for {
       // pkgDir stores the path to the directory that should contain source files belonging to the desired package
       pkgDir <- getLookupPath(importPath, includeDirs)
-      sourceFiles = getSourceFiles(pkgDir.toFile)
+      sourceFiles = getSourceFiles(pkgDir)
       // check whether all found source files belong to the same package (the name used in the package clause can
       // be absolutely independent of the import path)
       _ <- checkPackageClauses(sourceFiles, importPath)
@@ -50,52 +58,86 @@ object PackageResolver {
     for {
       // pkgDir stores the path to the directory that should contain source files belonging to the desired package
       pkgDir <- getLookupPath(n.importPath, includeDirs)
-      sourceFiles = getSourceFiles(pkgDir.toFile)
+      sourceFiles = getSourceFiles(pkgDir)
       // check whether all found source files belong to the same package (the name used in the package clause can
       // be absolutely independent of the import path)
       pkgName <- checkPackageClauses(sourceFiles, n.importPath)
+      // close all files as we do not need them anymore:
+      _ = sourceFiles.foreach(_.close())
     } yield pkgName
+  }
+
+  private def getIncludeResources(includeDirs: Vector[File]): Vector[InputResource] = {
+    includeDirs.map(FileResource)
+  }
+
+  private lazy val getStubResources: Vector[InputResource] = {
+    // get path to stubs
+    stubDirectories.flatMap(stubDir => {
+      val nullableResourceUri = getClass.getClassLoader.getResource(stubDir).toURI
+      for {
+        resourceUri <- Option.when(nullableResourceUri != null)(nullableResourceUri)
+        resource <- resourceUri.getScheme match {
+          case s if s == fileUriScheme => Some(FileResource(Paths.get(resourceUri).toFile))
+          case s if s == jarUriScheme => Some(BaseJarResource(resourceUri, stubDir))
+          case _ => None
+        }
+      } yield resource
+    })
+  }
+
+  private def getGoPathResources: Vector[InputResource] = {
+    // run `go help gopath` to get a detailed explanation of package resolution in go
+    val path = Properties.envOrElse("GOPATH", "")
+    val paths = (if (SystemUtils.IS_OS_WINDOWS) path.split(";") else path.split(":")).filter(_.nonEmpty)
+    paths
+      .map(Paths.get(_))
+      // for now, we restrict our search to the "src" subdirectory:
+      .map(_.resolve("src"))
+      .map(p => FileResource(p.toFile))
+      .toVector
   }
 
   /**
     * Resolves importPath using includeDirs to a directory which exists and from which source files should be retrieved
     */
-  private def getLookupPath(importPath: String, includeDirs: Vector[File]): Either[String, Path] = {
-    // run `go help gopath` to get a detailed explanation of package resolution in go
-    val path = Properties.envOrElse("GOPATH", "")
-    val paths = (if (SystemUtils.IS_OS_WINDOWS) path.split(";") else path.split(":")).filter(_.nonEmpty)
-    // take the parent of importPath and add it to includeDirs if it exists
-    val includePaths = includeDirs.map(_.toPath)
-      .map(_.resolve(importPath))
-    // prepend includePaths before paths that have been derived based on $GOPATH:
-    val packagePaths = includePaths ++ paths.map(p => Paths.get(p))
-      // for now, we restrict our search to the "src" subdirectory:
-      .map(_.resolve("src"))
-      // the desired package should now be located in a subdirectory named after the package name:
-      .map(_.resolve(importPath))
-    val pkgDirOpt = packagePaths.collectFirst { case p if Files.exists(p) => p }
+  private def getLookupPath(importPath: String, includeDirs: Vector[File]): Either[String, InputResource] = {
+    val resources = getIncludeResources(includeDirs) ++ getStubResources ++ getGoPathResources
+    // the desired package should now be located in a subdirectory named after the package name:
+    val packageDirs = resources.map(_.resolve(importPath))
+    // take first one that exists:
+    val pkgDirOpt = packageDirs.collectFirst { case p if p.exists() => p }
+    // close all resources that we no longer need:
+    (resources ++ packageDirs).foreach {
+      case resource if !pkgDirOpt.contains(resource) => resource.close()
+      case _ =>
+    }
     pkgDirOpt.toRight(s"No existing directory found for import path '$importPath'")
   }
 
   /**
-    * Returns all source files with file extension 'extension' in a specific directory `dir`
+    * Returns all source files with file extension 'extension' in the input resource
     */
-  private def getSourceFiles(dir: File): Vector[File] = {
-    dir
-      .listFiles
-      .filter(_.isFile)
-      // only consider file extensions "go"
-      .filter(f => FilenameUtils.getExtension(f.getName) == extension)
-      .toVector
+  private def getSourceFiles(input: InputResource): Vector[InputResource] = {
+    val dirContent = input.listContent()
+    val res = dirContent
+      .filter(resource => Files.isRegularFile(resource.path))
+      // only consider files with the particular extension
+      .filter(resource => FilenameUtils.getExtension(resource.path.toString) == extension)
+    (dirContent :+ input).foreach({
+      case resource if !res.contains(resource) => resource.close()
+      case _ =>
+    })
+    res
   }
 
   /**
     * Looks up the package clauses for all files and checks whether they match.
     * Returns right with the package name used in the package clause if they do, otherwise returns left with an error message
     */
-  def checkPackageClauses(files: Vector[File], importPath: String): Either[String, String] = {
+  def checkPackageClauses(files: Vector[InputResource], importPath: String): Either[String, String] = {
     // importPath is only used to create an error message that is similar to the error message of the official Go compiler
-    def getPackageClauses(files: Vector[File]): Either[String, Vector[(File, String)]] = {
+    def getPackageClauses(files: Vector[InputResource]): Either[String, Vector[(InputResource, String)]] = {
       val pkgClauses = files.map(f => {
         getPackageClause(f) match {
           case Some(pkgClause) => Right(f -> pkgClause)
@@ -103,15 +145,15 @@ object PackageResolver {
         }
       })
       val (failedFiles, validFiles) = pkgClauses.partitionMap(identity)
-      if (failedFiles.nonEmpty) Left(s"Parsing package clause for these files has failed: ${failedFiles.map(_.getPath).mkString(", ")}")
+      if (failedFiles.nonEmpty) Left(s"Parsing package clause for these files has failed: ${failedFiles.mkString(", ")}")
       else Right(validFiles)
     }
 
-    def isEqual(pkgClauses: Vector[(File, String)]): Either[String, String] = {
+    def isEqual(pkgClauses: Vector[(InputResource, String)]): Either[String, String] = {
       val differingClauses = pkgClauses.filter(_._2 != pkgClauses.head._2)
       if (differingClauses.isEmpty) Right(pkgClauses.head._2)
       else {
-        val foundPackages = differingClauses.collect { case (f, clause) => s"$clause (${f.getPath})" }.mkString(", ")
+        val foundPackages = differingClauses.collect { case (f, clause) => s"$clause (${f})" }.mkString(", ")
         Left(s"Found packages $foundPackages in $importPath")
       }
     }
@@ -124,13 +166,140 @@ object PackageResolver {
 
   private lazy val pkgClauseRegex = """(?:\/\/.*|\/\*(?:.|\n)*\*\/|package(?:\s|\n)+([a-zA-Z_][a-zA-Z0-9_]*))""".r
 
-  private def getPackageClause(file: File): Option[String] = {
-    val bufferedSource = scala.io.Source.fromFile(file)
+  private def getPackageClause(file: InputResource): Option[String] = {
+    val inputStream = file.asStream()
+    val bufferedSource = new BufferedSource(inputStream)
     val content = bufferedSource.mkString
     bufferedSource.close()
+
     // TODO is there a way to perform the regex lazily on the file's content?
     pkgClauseRegex
       .findAllMatchIn(content)
       .collectFirst { case m if m.group(1) != null => m.group(1) }
+  }
+
+  trait InputResource extends Closeable {
+    val path: Path
+
+    def resolve(pathComponent: String): InputResource
+
+    def exists(): Boolean = Files.exists(path)
+
+    private var stream: Option[InputStream] = None
+    /**
+      * stream has to be closed after use either by calling `close` on the resource or directly on the stream.
+      * In case the resource (if applicable incl. its file system) is continued to be used by the stream is no
+      * longer needed, it is recommended to directly call `close` on the stream as soon as possible and call `close`
+      * on the resource when it is no longer needed.
+      */
+    def asStream(): InputStream = {
+      val inputStream = Files.newInputStream(path)
+      stream = Some(inputStream)
+      inputStream
+    }
+
+    /** returns files that are part of this directory */
+    def listContent(): Vector[InputResource]
+
+    /** closes stream and filesystem (if applicable) */
+    override def close(): Unit = stream match {
+      case Some(s) => {
+        s.close()
+        stream = None
+      }
+      case _ =>
+    }
+  }
+
+  case class FileResource(file: File) extends InputResource {
+    override lazy val path: Path = file.toPath
+
+    def resolve(pathComponent: String): FileResource =
+      FileResource(path.resolve(pathComponent).toFile)
+
+    override def listContent(): Vector[FileResource] = {
+      Files.newDirectoryStream(path).asScala.toVector
+        .map(p => FileResource(p.toFile))
+    }
+  }
+
+  trait JarResource extends InputResource with Closeable {
+    protected val filesystem: ManagedFileSystem[JarResource]
+
+    override def resolve(pathComponent: String): JarFileResource =
+      JarFileResource(filesystem, path.resolve(pathComponent).toString)
+
+    override def listContent(): Vector[JarFileResource] = {
+      Files.newDirectoryStream(path).asScala.toVector
+        .map(p => JarFileResource(filesystem, p.toString))
+    }
+
+    override def close(): Unit = {
+      super.close()
+      filesystem.release(this)
+    }
+  }
+
+  /**
+    *
+    * @param baseUri URI to a resource in a JAR
+    * @param rootPath Path relative to the resource directory. Note that rootPath occurs as the last path components in baseUrl
+    */
+  case class BaseJarResource(baseUri: URI, rootPath: String) extends JarResource {
+    if (baseUri.getScheme != jarUriScheme) {
+      throw new IllegalArgumentException(s"BaseJarResource expects an URI to a JAR but got $baseUri")
+    }
+    override protected lazy val filesystem = new ManagedFileSystem(baseUri, this)
+    override val path: Path = filesystem.getPath(rootPath)
+  }
+
+  /**
+    *
+    * @param filesystem Filesystem in which this resource is located
+    * @param pathString Path to the resource relative to the resource directory.
+    */
+  case class JarFileResource(override protected val filesystem: ManagedFileSystem[JarResource],
+                             pathString: String) extends JarResource {
+    // retain the filesystem when constructing an instance:
+    filesystem.retain(this)
+
+    override val path: Path = filesystem.getPath(pathString)
+  }
+
+  /**
+    * Wrapper around FileSystem to ensure that the same file system is reused if it already exists.
+    * Calls to retain and release keep track of the number of clients currently using this file system.
+    * After construction, one client exists (i.e. the one that constructed it). As soon as no clients exist, the
+    * file system is closed and can no longer be used.
+    */
+  class ManagedFileSystem[T](val baseUri: URI, firstClient: T) {
+    private val filesystem = FileSystems.newFileSystem(baseUri, Collections.emptyMap[String, Any]())
+    private var clients: Set[T] = Set(firstClient)
+
+    def retain(client: T): Unit = {
+      if (!filesystem.isOpen) {
+        throw new IllegalStateException("managed file system can no longer be retained when it is already closed")
+      }
+      clients = clients + client
+    }
+
+    def release(client: T): Unit = {
+      val oldCount = clients.size
+      clients = clients - client
+      val newCount = clients.size
+      if (newCount + 1 != oldCount) {
+        throw new IllegalStateException("managed file system was double-released or released with a client that did not retain it")
+      }
+      if (newCount == 0 && filesystem.isOpen) {
+        filesystem.close()
+      }
+    }
+
+    def getPath(component: String): Path = {
+      if (!filesystem.isOpen) {
+        throw new IllegalStateException("managed file system is already closed")
+      }
+      filesystem.getPath(component)
+    }
   }
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -180,11 +180,13 @@ trait MemberResolution { this: TypeInfoImpl =>
         nonEmptyPkgFiles <- if (pkgFiles.isEmpty)
           Left(Vector(NotFoundError(s"No source files for package '$importPath' found")))
           else Right(pkgFiles)
-        parsedProgram <- Parser.parse(nonEmptyPkgFiles, specOnly = true)(config)
+        parsedProgram <- Parser.parse(nonEmptyPkgFiles.map(_.path), specOnly = true)(config)
         // TODO maybe don't check whole file but only members that are actually used/imported
         // By parsing only declarations and their specification, there shouldn't be much left to type check anyways
         // Info.check would probably need some restructuring to type check only certain members
         info <- Info.check(parsedProgram, context)(config)
+        // we do no longer need them, so we close them:
+        _ = pkgFiles.map(_.close())
       } yield info
       res.fold(
         errs => context.addErrenousPackage(importPath, errs),

--- a/src/test/resources/regressions/features/stubs/assert/assert-fail1.gobra
+++ b/src/test/resources/regressions/features/stubs/assert/assert-fail1.gobra
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+import stubAssert "github.com/scionproto/scion/go/lib/assert"
+
+func foo() {
+  if stubAssert.On {
+    //:: ExpectedOutput(precondition_error:assertion_error)
+    stubAssert.Must(5 == 6)
+  }
+}

--- a/src/test/resources/regressions/features/stubs/assert/assert-simple1.gobra
+++ b/src/test/resources/regressions/features/stubs/assert/assert-simple1.gobra
@@ -1,0 +1,12 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+import stubAssert "github.com/scionproto/scion/go/lib/assert"
+
+func foo() {
+  if stubAssert.On {
+    stubAssert.Must(5 == 5)
+  }
+}


### PR DESCRIPTION
This PR adds `src/main/resources/stubs` to store and use stubs. A simple assertion library taken from (an old version of) SCION is used for demonstration purposes and test cases.
`src/main/resources/README.md` provides a short explanation of the feature and how it influences Gobra's operation

First part of #140