### PR TITLE
Fix issue 169

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
@@ -30,7 +30,7 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
 
   private[typing] def ghostMemberType(typeMember: GhostTypeMember): Type = typeMember match {
     case MPredicateImpl(decl, ctx) => FunctionT(decl.args map ctx.typ, AssertionT)
-    case MPredicateSpec(decl, _) => FunctionT(decl.args map miscType, AssertionT)
+    case MPredicateSpec(decl, ctx) => FunctionT(decl.args map ctx.typ, AssertionT)
     case _: SymbolTable.GhostStructMember => ???
   }
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
@@ -29,7 +29,7 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
   }
 
   private[typing] def ghostMemberType(typeMember: GhostTypeMember): Type = typeMember match {
-    case MPredicateImpl(decl, _) => FunctionT(decl.args map miscType, AssertionT)
+    case MPredicateImpl(decl, ctx) => FunctionT(decl.args map ctx.typ, AssertionT)
     case MPredicateSpec(decl, _) => FunctionT(decl.args map miscType, AssertionT)
     case _: SymbolTable.GhostStructMember => ???
   }

--- a/src/test/resources/regressions/issues/000169.gobra
+++ b/src/test/resources/regressions/issues/000169.gobra
@@ -7,5 +7,5 @@ package pkg
 
 import "pkg2"
 
-requires t.fPred(y)
+requires t.mpred(y)
 pure func f(t* pkg2.T, y int) int

--- a/src/test/resources/regressions/issues/000169.gobra
+++ b/src/test/resources/regressions/issues/000169.gobra
@@ -1,0 +1,11 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// ##(-I src/test/resources/regressions/issues/000169/)
+
+import "pkg2"
+
+requires t.fPred(y)
+pure func f(t* pkg2.T, y int) int

--- a/src/test/resources/regressions/issues/000169/pkg2/imported.gobra
+++ b/src/test/resources/regressions/issues/000169/pkg2/imported.gobra
@@ -1,0 +1,8 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg2
+
+type T struct {}
+
+pred (t *T)fPred(x int)

--- a/src/test/resources/regressions/issues/000169/pkg2/imported.gobra
+++ b/src/test/resources/regressions/issues/000169/pkg2/imported.gobra
@@ -5,4 +5,4 @@ package pkg2
 
 type T struct {}
 
-pred (t *T)fPred(x int)
+pred (t *T) mpred(x int)


### PR DESCRIPTION
Fixes issue #169.

Regarding the case for `MPredicateSpec` in the `GhostMiscTyping.scala`, I did not find an example where Gobra crashes without my change. Nevertheless, I decided to add it for consistency and to avoid any unforeseen bugs due to the use of a wrong context