### PR TITLE
Correct type error reporting for short variable declarations

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/BaseTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/BaseTyping.scala
@@ -56,6 +56,10 @@ trait BaseTyping { this: TypeInfoImpl =>
     case n: PExpressionAndType => wellDefExprAndType.valid(n)
     case e: PExpression => wellDefExpr.valid(e)
     case t: PType => wellDefType.valid(t)
+    // skip well-definedness checks for defined identifiers. This enables the parent node, e.g. the declaration
+    // statement, to perform the necessary checks as the parent is not skipped due to an unsafe message from the
+    // identifier well-definedness check. See issue #185
+    case _: PIdnDef | i: PIdnUnk if isDef(i) => true
     case i: PIdnNode => wellDefID.valid(i)
     case o: PMisc => wellDefMisc.valid(o)
     case s: PSpecification => wellDefSpec.valid(s)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/BaseTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/BaseTyping.scala
@@ -59,7 +59,8 @@ trait BaseTyping { this: TypeInfoImpl =>
     // skip well-definedness checks for defined identifiers. This enables the parent node, e.g. the declaration
     // statement, to perform the necessary checks as the parent is not skipped due to an unsafe message from the
     // identifier well-definedness check. See issue #185
-    case _: PIdnDef | i: PIdnUnk if isDef(i) => true
+    case _: PIdnDef => true
+    case i: PIdnUnk if isDef(i) => true
     case i: PIdnNode => wellDefID.valid(i)
     case o: PMisc => wellDefMisc.valid(o)
     case s: PSpecification => wellDefSpec.valid(s)

--- a/src/test/resources/regressions/issues/000185.gobra
+++ b/src/test/resources/regressions/issues/000185.gobra
@@ -1,0 +1,12 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+func test() (res1 bool, res2 int)
+
+func client() {
+    // in earlier Gobra versions this assignment would silently pass type checking
+    //:: ExpectedOutput(type_error)
+    b := test()
+}


### PR DESCRIPTION
Fixes type checker to not silently skip well-definedness check for declarations if identifier definition is invalid

Fixes #185 
