### PR TITLE
Fix to issue 184

### DIFF
--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -71,7 +71,11 @@ object PackageResolver {
     includeDirs.map(FileResource)
   }
 
-  private lazy val getStubResources: Vector[InputResource] = {
+  // getStubResources must be a def instead of a val because it may be called multiple times, one for each call to resolve.
+  // If this was a val, the return value would consist of the same values in every call. This is not desirable when one
+  // of the resources has a jar URI scheme. In such a case, the obtained BaseJarResource would be effectively shared and any
+  // modification to its state would affect any other methods that called resolve.
+  private def getStubResources: Vector[InputResource] = {
     // get path to stubs
     stubDirectories.flatMap(stubDir => {
       val nullableResourceUri = getClass.getClassLoader.getResource(stubDir).toURI

--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -71,10 +71,10 @@ object PackageResolver {
     includeDirs.map(FileResource)
   }
 
-  // getStubResources must be a def instead of a val because it may be called multiple times, one for each call to resolve.
-  // If this was a val, the return value would consist of the same values in every call. This is not desirable when one
-  // of the resources has a jar URI scheme. In such a case, the obtained BaseJarResource would be effectively shared and any
-  // modification to its state would affect any other methods that called resolve.
+  // getStubResources must be a def instead of a val because a new instance of `BaseJarResource` should be created for
+  // each call. This is important as the managed file system used internally of BaseJarResource keeps track of the number
+  // of instance creations (i.e. calls to retain) and calls to close (i.e. calls to release) to decide when to close
+  // the underlying FileSystem.
   private def getStubResources: Vector[InputResource] = {
     // get path to stubs
     stubDirectories.flatMap(stubDir => {


### PR DESCRIPTION
This PR was proposed by @ArquintL. He identified the root cause of the problem and showed me the solution. 

The bug was triggered because every call to `PackageResolver.resolve` would reuse the same stub resources. In the case that the resource was of type `BaseJarResource`, in the second call to `resolve`, the underlying file system would already be closed (due to the reference counting mechanism of `BaseJarResource`) and Gobra would crash in the first call to `retain`, with the message `managed file system can no longer be retained when it is already closed`.

I did not write any test cases for this bug because it was not caught in our testing framework in the first place.