### PR TITLE
Binary Search Tree Example and some Ghost Erasure Fixes

### DIFF
--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -140,7 +140,8 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
 
   def showVarDecl(decl: PVarDecl): Doc = decl match {
     case PVarDecl(typ, right, left, addressable) =>
-      "var" <+> showList(left zip addressable){ case (v, a) => showAddressable(a, v) } <> opt(typ)(space <> showType(_)) <+> "=" <+> showExprList(right)
+      val rhs: Doc = if (right.isEmpty) "" else space <> "=" <+> showExprList(right)
+      "var" <+> showList(left zip addressable){ case (v, a) => showAddressable(a, v) } <> opt(typ)(space <> showType(_)) <> rhs
   }
 
   def showConstDecl(decl: PConstDecl): Doc = decl match {

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -187,7 +187,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
       case PAssignment(right, left) => showExprList(left) <+> "=" <+> showExprList(right)
       case PAssignmentWithOp(right, op, left) => showExpr(left) <+> showAssOp(op) <> "=" <+> showExpr(right)
       case PIfStmt(ifs, els) =>
-        ssep(ifs map showIfClause, line) <>
+        ssep(ifs map showIfClause, space <> "else" <> space) <>
           opt(els)(space <> "else" <+> showStmt(_) <> line)
       case PExprSwitchStmt(pre, _, cases, dflt) =>
         "switch" <> showPreStmt(pre) <+> block(

--- a/src/main/scala/viper/gobra/ast/internal/utility/GobraStrategy.scala
+++ b/src/main/scala/viper/gobra/ast/internal/utility/GobraStrategy.scala
@@ -156,6 +156,7 @@ object GobraStrategy {
       case (p: Parameter.In, Seq()) => Parameter.In(p.id, p.typ)(meta)
       case (p: Parameter.Out, Seq()) => Parameter.Out(p.id, p.typ)(meta)
       case (l: LocalVar, Seq()) => LocalVar(l.id, l.typ)(meta)
+      case (g: GlobalConst.Val, Seq()) => GlobalConst.Val(g.id, g.typ)(meta)
       case (_: Addressable.Var, Seq(v: LocalVar)) => Addressable.Var(v)
       case (_: Addressable.Pointer, Seq(v: Deref)) => Addressable.Pointer(v)
       case (_: Addressable.Field, Seq(v: FieldRef)) => Addressable.Field(v)

--- a/src/main/scala/viper/gobra/ast/internal/utility/Nodes.scala
+++ b/src/main/scala/viper/gobra/ast/internal/utility/Nodes.scala
@@ -144,6 +144,7 @@ object Nodes {
         case Parameter.In(_, _) => Seq()
         case Parameter.Out(_, _) => Seq()
         case LocalVar(_, _) => Seq()
+        case GlobalConst.Val(_, _) => Seq()
       }
       case Trigger(exprs) => exprs
       case a: Addressable => Seq(a.op)

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -122,6 +122,14 @@ object Parser {
     })
   }
 
+  def parseProgram(source: Source, specOnly: Boolean = false)(config: Config): Either[Messages, PProgram] = {
+    val preprocessedSource = SemicolonPreprocessor.preprocess(source)(config)
+    val positions = new Positions
+    val pom = new PositionManager(positions)
+    val parsers = new SyntaxAnalyzer(pom, specOnly)
+    translateParseResult(pom)(parsers.parseAll(parsers.program, preprocessedSource))
+  }
+
   def parseMember(source: Source, specOnly: Boolean = false): Either[Messages, Vector[PMember]] = {
     val positions = new Positions
     val pom = new PositionManager(positions)

--- a/src/main/scala/viper/gobra/frontend/info/base/BuiltInMemberTag.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/BuiltInMemberTag.scala
@@ -84,9 +84,10 @@ object BuiltInMemberTag {
 
   /** Built-in Function Tags */
 
-  case object CloseFunctionTag extends BuiltInFunctionTag with GhostBuiltInMember {
+  case object CloseFunctionTag extends BuiltInFunctionTag {
     override def identifier: String = "close"
     override def name: String = "CloseFunctionTag"
+    override def ghost: Boolean = false
     override def isPure: Boolean = false
 
     override def typ(config: Config): AbstractType = AbstractType(
@@ -100,6 +101,8 @@ object BuiltInMemberTag {
 
     override def argGhostTyping(args: Vector[Type])(config: Config): GhostType =
       GhostType.ghostTuple(Vector(false, true, true /* true */, true))
+
+    override def returnGhostTyping(args: Vector[Type])(config: Config): GhostType = ghostArgs(0)
   }
 
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
@@ -37,12 +37,6 @@ trait Enclosing { this: TypeInfoImpl =>
   lazy val isEnclosingExplicitGhost: PNode => Boolean =
     down(false){ case _: PGhostifier[_] => true }
 
-  lazy val isEnclosingPure: PNode => Boolean =
-    down(false){
-      case PFunctionDecl(_, _, _, spec, _) => spec.isPure
-      case PMethodDecl(_, _, _, _, spec, _) => spec.isPure
-    }
-
   def typeSwitchConstraints(id: PIdnNode): Vector[PType] =
     typeSwitchConstraintsLookup(id)(id)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
@@ -37,6 +37,12 @@ trait Enclosing { this: TypeInfoImpl =>
   lazy val isEnclosingExplicitGhost: PNode => Boolean =
     down(false){ case _: PGhostifier[_] => true }
 
+  lazy val isEnclosingPure: PNode => Boolean =
+    down(false){
+      case PFunctionDecl(_, _, _, spec, _) => spec.isPure
+      case PMethodDecl(_, _, _, _, spec, _) => spec.isPure
+    }
+
   def typeSwitchConstraints(id: PIdnNode): Vector[PType] =
     typeSwitchConstraintsLookup(id)(id)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
@@ -53,7 +53,8 @@ trait IdTyping extends BaseTyping { this: TypeInfoImpl =>
       }) else cyclicMsg
 
     case SingleLocalVariable(exp, opt, _, _, _) => unsafeMessage(! {
-      opt.exists(wellDefAndType.valid) || exp.exists(e => wellDefAndExpr.valid(e) && Single.unapply(exprType(e)).nonEmpty)
+      // exp has to be well-def if it exists (independently on the existance of opt) as we need it for ghost typing
+      opt.forall(wellDefAndType.valid) && exp.forall(e => wellDefAndExpr.valid(e) && Single.unapply(exprType(e)).nonEmpty)
     })
 
     case MultiLocalVariable(idx, exp, _, _, _) => unsafeMessage(! {

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
@@ -53,8 +53,7 @@ trait IdTyping extends BaseTyping { this: TypeInfoImpl =>
       }) else cyclicMsg
 
     case SingleLocalVariable(exp, opt, _, _, _) => unsafeMessage(! {
-      // exp has to be well-def if it exists (independently on the existance of opt) as we need it for ghost typing
-      opt.forall(wellDefAndType.valid) && exp.forall(e => wellDefAndExpr.valid(e) && Single.unapply(exprType(e)).nonEmpty)
+      opt.exists(wellDefAndType.valid) || exp.exists(e => wellDefAndExpr.valid(e) && Single.unapply(exprType(e)).nonEmpty)
     })
 
     case MultiLocalVariable(idx, exp, _, _, _) => unsafeMessage(! {

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostAssignability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostAssignability.scala
@@ -104,14 +104,14 @@ trait GhostAssignability {
 
   /** ghost type of the result of a callee */
   private[separation] def calleeReturnGhostTyping(callee: PExpression): GhostType = {
-    def resultTyping(result: PResult, context: ExternalTypeInfo): GhostType = {
-      GhostType.ghostTuple(result.outs.map(context.isParamGhost))
+    def resultTyping(result: PResult, isMemberGhost: Boolean, context: ExternalTypeInfo): GhostType = {
+      GhostType.ghostTuple(result.outs.map(p => isMemberGhost || context.isParamGhost(p)))
     }
 
     resolve(callee) match {
-      case Some(p: ap.Function) => resultTyping(p.symb.result, p.symb.context)
-      case Some(p: ap.ReceivedMethod) => resultTyping(p.symb.result, p.symb.context)
-      case Some(p: ap.MethodExpr) => resultTyping(p.symb.result, p.symb.context)
+      case Some(p: ap.Function) => resultTyping(p.symb.result, p.symb.ghost, p.symb.context)
+      case Some(p: ap.ReceivedMethod) => resultTyping(p.symb.result, p.symb.ghost, p.symb.context)
+      case Some(p: ap.MethodExpr) => resultTyping(p.symb.result, p.symb.ghost, p.symb.context)
       case Some(_: ap.PredicateKind) => GhostType.isGhost
       case _ => GhostType.isGhost // conservative choice
     }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostAssignability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostAssignability.scala
@@ -20,13 +20,13 @@ trait GhostAssignability {
   /** checks that ghost arguments are not assigned to non-ghost arguments  */
   private[separation] def ghostAssignableToCallExpr(right: PExpression*)(callee: PExpression): Messages = {
 
-    val isPure = resolve(callee) match {
-      case Some(p: ap.Function) => p.symb.isPure
-      case Some(p: ap.MethodExpr) => p.symb.isPure
-      case Some(p: ap.ReceivedMethod) => p.symb.isPure
+    val isPureOrGhost = resolve(callee) match {
+      case Some(p: ap.Function) => p.symb.isPure || p.symb.ghost
+      case Some(p: ap.MethodExpr) => p.symb.isPure || p.symb.ghost
+      case Some(p: ap.ReceivedMethod) => p.symb.isPure || p.symb.ghost
       case _ => false
     }
-    if (isPure) {return noMessages}
+    if (isPureOrGhost) {return noMessages}
 
     val argTyping = calleeArgGhostTyping(callee).toTuple
     generalGhostAssignableTo[PExpression, Boolean](ghostExprTyping){

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostAssignability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostAssignability.scala
@@ -12,6 +12,7 @@ import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.ast.frontend.{AstPattern => ap}
 import viper.gobra.frontend.info.ExternalTypeInfo
 import viper.gobra.frontend.info.implementation.property.{AssignMode, NonStrictAssignModi}
+import viper.gobra.frontend.info.implementation.typing.ghost.separation.GhostType.ghost
 import viper.gobra.util.Violation
 
 trait GhostAssignability {
@@ -20,26 +21,26 @@ trait GhostAssignability {
   /** checks that ghost arguments are not assigned to non-ghost arguments  */
   private[separation] def ghostAssignableToCallExpr(call: ap.FunctionCall): Messages = {
 
-    val isPureOrGhost = call.callee match {
-      case p: ap.Function => p.symb.isPure || p.symb.ghost
-      case p: ap.MethodExpr => p.symb.isPure || p.symb.ghost
-      case p: ap.ReceivedMethod => p.symb.isPure || p.symb.ghost
-      case p: ap.BuiltInFunction => p.symb.isPure || p.symb.ghost
-      case p: ap.BuiltInMethodExpr => p.symb.isPure || p.symb.ghost
-      case p: ap.BuiltInReceivedMethod => p.symb.isPure || p.symb.ghost
+    val isPure = call.callee match {
+      case p: ap.Function => p.symb.isPure
+      case p: ap.MethodExpr => p.symb.isPure
+      case p: ap.ReceivedMethod => p.symb.isPure
+      case p: ap.BuiltInFunction => p.symb.isPure
+      case p: ap.BuiltInMethodExpr => p.symb.isPure
+      case p: ap.BuiltInReceivedMethod => p.symb.isPure
       case _ => false
     }
-    if (isPureOrGhost) {return noMessages}
+    if (isPure) {return noMessages}
 
     val argTyping = calleeArgGhostTyping(call).toTuple
-    generalGhostAssignableTo[PExpression, Boolean](ghostExprTyping){
+    generalGhostAssignableTo[PExpression, Boolean](ghostExprResultTyping){
       case (g, l) => error(call.callee.id, "ghost error: ghost cannot be assigned to non-ghost", g && !l)
     }(call.args: _*)(argTyping: _*)
   }
 
   /** conservative ghost separation assignment check */
   private[separation] def ghostAssignableToAssignee(exprs: PExpression*)(lefts: PAssignee*): Messages =
-    generalGhostAssignableTo(ghostExprTyping)(ghostAssigneeAssignmentMsg)(exprs: _*)(lefts: _*)
+    generalGhostAssignableTo(ghostExprResultTyping)(ghostAssigneeAssignmentMsg)(exprs: _*)(lefts: _*)
 
 
   private def ghostAssigneeAssignmentMsg(isRightGhost: Boolean, left: PAssignee): Messages = left match {
@@ -49,7 +50,7 @@ trait GhostAssignability {
 
     case PIndexedExp(_, index) => // a[i] := e ~ !ghost(i) && !ghost(e)
       error(left, "ghost error: ghost cannot be assigned to index expressions", isRightGhost) ++
-        error(left, "ghost error: ghost index are not permitted in index expressions", ghostExprClassification(index))
+        error(left, "ghost error: ghost index are not permitted in index expressions", ghostExprResultClassification(index))
 
     case PNamedOperand(id) => // x := e ~ ghost(e) ==> ghost(x)
       error(left, "ghost error: ghost cannot be assigned to non-ghost", isRightGhost && !ghostIdClassification(id))
@@ -57,7 +58,7 @@ trait GhostAssignability {
     case n: PDot => exprOrType(n.base) match {
       case Left(base) => // x.f := e ~ (ghost(x) || ghost(e)) ==> ghost(f)
         error(left, "ghost error: ghost cannot be assigned to non-ghost field", isRightGhost && !ghostIdClassification(n.id)) ++
-          error(left, "ghost error: cannot assign to non-ghost field of ghost reference", ghostExprClassification(base) && !ghostIdClassification(n.id))
+          error(left, "ghost error: cannot assign to non-ghost field of ghost reference", ghostExprResultClassification(base) && !ghostIdClassification(n.id))
 
       case _ => error(left, "ghost error: selections on types are not assignable")
     }
@@ -67,11 +68,11 @@ trait GhostAssignability {
 
   /** conservative ghost separation assignment check */
   private[separation] def ghostAssignableToId(exprs: PExpression*)(lefts: PIdnNode*): Messages =
-    generalGhostAssignableTo(ghostExprTyping)(dfltGhostAssignableMsg(ghostIdClassification))(exprs: _*)(lefts: _*)
+    generalGhostAssignableTo(ghostExprResultTyping)(dfltGhostAssignableMsg(ghostIdClassification))(exprs: _*)(lefts: _*)
 
   /** conservative ghost separation assignment check */
   private[separation] def ghostAssignableToParam(exprs: PExpression*)(lefts: PParameter*): Messages =
-    generalGhostAssignableTo(ghostExprTyping)(dfltGhostAssignableMsg(ghostParameterClassification))(exprs: _*)(lefts: _*)
+    generalGhostAssignableTo(ghostExprResultTyping)(dfltGhostAssignableMsg(ghostParameterClassification))(exprs: _*)(lefts: _*)
 
   private def dfltGhostAssignableMsg[L <: PNode](ghost: L => Boolean): (Boolean, L) => Messages = {
     case (g, l) => error(l, "ghost error: ghost cannot be assigned to non-ghost", g && !ghost(l))
@@ -93,13 +94,14 @@ trait GhostAssignability {
 
   /** ghost type of the arguments of a callee */
   private[separation] def calleeArgGhostTyping(call: ap.FunctionCall): GhostType = {
-    def argTyping(args: Vector[PParameter], context: ExternalTypeInfo): GhostType =
-      GhostType.ghostTuple(args.map(context.isParamGhost))
+    // a parameter of a ghost member is ghost (even if such a explicit declaration is missing)
+    def argTyping(args: Vector[PParameter], isMemberGhost: Boolean, context: ExternalTypeInfo): GhostType =
+      GhostType.ghostTuple(args.map(p => isMemberGhost || context.isParamGhost(p)))
 
     call.callee match {
-      case p: ap.Function => argTyping(p.symb.args, p.symb.context)
-      case p: ap.ReceivedMethod => argTyping(p.symb.args, p.symb.context)
-      case p: ap.MethodExpr => GhostType.ghostTuple(false +: argTyping(p.symb.args, p.symb.context).toTuple)
+      case p: ap.Function => argTyping(p.symb.args, p.symb.ghost, p.symb.context)
+      case p: ap.ReceivedMethod => argTyping(p.symb.args, p.symb.ghost, p.symb.context)
+      case p: ap.MethodExpr => GhostType.ghostTuple(false +: argTyping(p.symb.args, p.symb.ghost, p.symb.context).toTuple)
       case _: ap.PredicateKind => GhostType.isGhost
       case ap.BuiltInFunction(_, symb) => symb.tag.argGhostTyping(call.args.map(typ))(config)
       case ap.BuiltInReceivedMethod(recv, _, _, symb) => symb.tag.argGhostTyping(Vector(typ(recv)))(config)
@@ -108,8 +110,21 @@ trait GhostAssignability {
     }
   }
 
+  /* ghost type of the callee itself (not considering its arguments or results) */
+  private[separation] def calleeGhostTyping(call: ap.FunctionCall): GhostType = call.callee match {
+    case p: ap.Function => ghost(p.symb.ghost)
+    case p: ap.ReceivedMethod => ghost(p.symb.ghost)
+    case p: ap.MethodExpr => ghost(p.symb.ghost)
+    case _: ap.PredicateKind => GhostType.isGhost
+    case p: ap.BuiltInFunction => ghost(p.symb.ghost)
+    case p: ap.BuiltInReceivedMethod => ghost(p.symb.ghost)
+    case p: ap.BuiltInMethodExpr => ghost(p.symb.ghost)
+    case _ => GhostType.isGhost // conservative choice
+  }
+
   /** ghost type of the result of a callee */
   private[separation] def calleeReturnGhostTyping(call: ap.FunctionCall): GhostType = {
+    // a result of a ghost member is ghost (even if such a explicit declaration is missing)
     def resultTyping(result: PResult, isMemberGhost: Boolean, context: ExternalTypeInfo): GhostType = {
       GhostType.ghostTuple(result.outs.map(p => isMemberGhost || context.isParamGhost(p)))
     }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostClassifier.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostClassifier.scala
@@ -31,4 +31,6 @@ trait GhostClassifier {
   def expectedReturnGhostTyping(ret: PReturn): GhostType
 
   def expectedArgGhostTyping(invk: PInvoke): GhostType
+
+  def isExprPure(expr: PExpression): Boolean
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
@@ -91,13 +91,15 @@ class GhostLessPrinter(classifier: GhostClassifier) extends DefaultPrettyPrinter
 
   override def showExpr(expr: PExpression): Doc = expr match {
 
+    // invokes of ghost functions and methods should not be printed
+    case n: PInvoke if classifier.isExprGhost(n) => emptyDoc
     case n: PInvoke =>
       val gt = classifier.expectedArgGhostTyping(n)
       val aArgs = n.args.zip(gt.toTuple).filter(!_._2).map(_._1)
       super.showExpr(n.copy(args = aArgs))
 
     case e: PActualExprProofAnnotation => showExpr(e.op)
-    case e if classifier.isExprGhost(e) => "<removed expr>" // should not be printed
+    case e if classifier.isExprGhost(e) => emptyDoc
     case e => super.showExpr(e)
   }
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostTyping.scala
@@ -30,9 +30,7 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
       StrictAssignModi(left.size, right.size) match {
         case AssignMode.Single =>
           left.map(Some(_)).zipAll(right.map(Some(_)), None, None).forall {
-            case (Some(l), Some(r)) => ghostIdClassification(l) || ghostExprClassification(r)
-            case (Some(l), _) => ghostIdClassification(l)
-            case (_, Some(r)) => ghostExprClassification(r)
+            case (l, r) => l.exists(ghostIdClassification) || r.exists(ghostExprClassification)
           }
 
         case AssignMode.Multi =>

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostTyping.scala
@@ -30,13 +30,13 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
       StrictAssignModi(left.size, right.size) match {
         case AssignMode.Single =>
           left.map(Some(_)).zipAll(right.map(Some(_)), None, None).forall {
-            case (l, r) => l.exists(ghostIdClassification) || r.exists(ghostExprClassification)
+            case (l, r) => l.exists(ghostIdClassification) || r.exists(ghostExprResultClassification)
           }
 
         case AssignMode.Multi =>
           // right should be a singleton vector
-          val isRightGhost = right.exists(ghostExprClassification)
-          left.forall(l => isRightGhost || ghostIdClassification(l))
+          val isRightResultGhost = right.exists(ghostExprResultClassification)
+          left.forall(l => isRightResultGhost || ghostIdClassification(l))
 
         case AssignMode.Error if right.isEmpty => left.forall(ghostIdClassification)
 
@@ -54,11 +54,21 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
     }
   }
 
-  /** returns true iff expression is classified as ghost */
+  /**
+    * returns true iff expression is classified as ghost, i.e. whether ghost erasure should remove an expression.
+    * note the difference to ghostExprResultClassification in particular for function calls:
+    * `ghostExprClassification` returns true iff callee is ghost. On the other hand, `ghostExprResultClassification` returns true iff the
+    * callee's result is ghost.
+    **/
   private[separation] lazy val ghostExprClassification: PExpression => Boolean =
     createGhostClassification[PExpression](e => ghostExprTyping(e).isGhost)
 
-  /** returns ghost typing of expression */
+  /**
+    * returns ghost typing of expression, i.e. whether ghost erasure should remove an expression.
+    * note the difference to ghostExprResultTyping in particular for function calls:
+    * `ghostExprTyping` returns the ghost typing of the callee. On the other hand, `ghostExprResultTyping` returns the
+    * ghost typing of the callee's results
+    */
   private[separation] lazy val ghostExprTyping: PExpression => GhostType = {
     import GhostType._
 
@@ -70,7 +80,7 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
 
       case n: PInvoke => (exprOrType(n.base), resolve(n)) match {
         case (Right(_), Some(_: ap.Conversion)) => notGhost // conversions cannot be ghost (for now)
-        case (Left(_), Some(call: ap.FunctionCall)) => calleeReturnGhostTyping(call)
+        case (Left(_), Some(call: ap.FunctionCall)) => calleeGhostTyping(call)
         case (Left(_), Some(_: ap.PredicateCall)) => isGhost
         case _ => Violation.violation("expected conversion, function call, or predicate call")
       }
@@ -80,6 +90,26 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
 
       // catches ghost field reads, method calls, function calls since their id is ghost
       case exp => ghost(!noGhostPropagationFromChildren(exp))
+    }
+  }
+
+  /** returns true iff expression is classified as ghost */
+  private[separation] lazy val ghostExprResultClassification: PExpression => Boolean =
+    createGhostClassification[PExpression](e => ghostExprResultTyping(e).isGhost)
+
+  /** returns ghost typing of expression */
+  private[separation] lazy val ghostExprResultTyping: PExpression => GhostType = {
+    import GhostType._
+
+    createGhostTyping[PExpression]{
+      case n: PInvoke => (exprOrType(n.base), resolve(n)) match {
+        case (Right(_), Some(_: ap.Conversion)) => notGhost // conversions cannot be ghost (for now)
+        case (Left(_), Some(call: ap.FunctionCall)) => calleeReturnGhostTyping(call)
+        case (Left(_), Some(_: ap.PredicateCall)) => isGhost
+        case _ => Violation.violation("expected conversion, function call, or predicate call")
+      }
+
+      case e => ghostExprTyping(e)
     }
   }
 
@@ -94,8 +124,8 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
   /** returns true iff identifier is classified as ghost */
   private[separation] lazy val ghostIdClassification: PIdnNode => Boolean = createGhostClassification[PIdnNode]{
     id => entity(id) match {
-      case r: SingleLocalVariable => r.ghost || r.exp.exists(ghostExprClassification)
-      case r: MultiLocalVariable => r.ghost || exprGhostTyping(r.exp).isIdxGhost(r.idx)
+      case r: SingleLocalVariable => r.ghost || r.exp.exists(ghostExprResultClassification)
+      case r: MultiLocalVariable => r.ghost || ghostExprResultTyping(r.exp).isIdxGhost(r.idx)
       case r: Regular => r.ghost
       case _ => Violation.violation("expected Regular Entity")
     }
@@ -108,7 +138,7 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
   }
 
   /** returns true iff node is contained in ghost code */
-  private[separation] def enclosingGhostContext(n: PNode): Boolean = isEnclosingExplicitGhost(n) || isEnclosingPure(n)
+  private[separation] def enclosingGhostContext(n: PNode): Boolean = isEnclosingExplicitGhost(n)
 
   /** returns true iff node does not contain ghost expression or id that is not contained in another statement */
   private[separation] lazy val noGhostPropagationFromChildren: PNode => Boolean =
@@ -127,11 +157,11 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
     }
 
   private[separation] def createGhostTyping[X <: PNode](typing: X => GhostType): X => GhostType =
-    createWellDefInference[X, GhostType](selfWellDefined)(typing) // TODO: could use wellGhostSeparation as safety condition
+    createWellDefInference[X, GhostType](wellGhostSeparated.valid)(typing)
       .andThen(_.getOrElse(Violation.violation("ghost typing on unsafe node")))
 
   private[separation] def createGhostClassification[X <: PNode](classification: X => Boolean): X => Boolean =
-    createWellDefInference[X, Boolean](selfWellDefined)(classification)
+    createWellDefInference[X, Boolean](wellGhostSeparated.valid)(classification)
       .andThen(_.getOrElse(Violation.violation("ghost classification on unsafe node")))
 
 
@@ -180,4 +210,6 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
       case p => Violation.violation(s"expected conversion, function call, or predicate call, but got $p")
     }
   }
+
+  override def isExprPure(expr: PExpression): Boolean = isPureExpr(expr).isEmpty
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
@@ -10,9 +10,15 @@ import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error, noMessages
 import viper.gobra.ast.frontend._
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.ast.frontend.{AstPattern => ap}
+import viper.gobra.frontend.info.base.SymbolTable.SingleLocalVariable
 import viper.gobra.util.Violation.violation
 
 trait GhostWellDef { this: TypeInfoImpl =>
+
+  private def selfWellGhostSeparated(n: PNode): Boolean = n match {
+    case i: PIdnNode => idGhostSeparation(i).valid
+    case n => wellGhostSeparated.valid(n)
+  }
 
   lazy val wellGhostSeparated: WellDefinedness[PNode] = createIndependentWellDef[PNode]{
     case m: PMember => memberGhostSeparation(m)
@@ -20,7 +26,7 @@ trait GhostWellDef { this: TypeInfoImpl =>
     case e: PExpression => exprGhostSeparation(e)
     case t: PType => typeGhostSeparation(t)
     case m: PMisc => miscGhostSeparation(m)
-  }{ n => selfWellDefined(n) && children(n).forall(wellGhostSeparated.valid) }
+  }{ n => selfWellDefined(n) && children(n).forall(selfWellGhostSeparated) }
 
   private def memberGhostSeparation(member: PMember): Messages = member match {
     case m: PExplicitGhostMember => m.actual match {
@@ -134,6 +140,18 @@ trait GhostWellDef { this: TypeInfoImpl =>
         isTypeGhost(f.typ) && !enclosingGhostContext(f))
     })
     case n: PType => error(n, "ghost error: Found ghost child expression, but expected none", !noGhostPropagationFromChildren(n))
+  }
+
+  private lazy val idGhostSeparation: WellDefinedness[PIdnNode] = createWellDefWithValidityMessages {
+    id =>
+      entity(id) match {
+        case SingleLocalVariable(exp, _, _, _, _) =>
+          unsafeMessage(! {
+            // exp has to be well-def if it exists (independently on the existence of opt) as we need it for ghost typing
+            exp.forall(e => wellGhostSeparated.valid(e))
+          })
+        case _ => LocalMessages(noMessages)
+      }
   }
 
   private def miscGhostSeparation(misc : PMisc) : Messages = misc match {

--- a/src/test/resources/regressions/examples/binary_search_tree.gobra
+++ b/src/test/resources/regressions/examples/binary_search_tree.gobra
@@ -1,0 +1,391 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// some high-level ideas are inspired by Nagini's iap_bst.py example
+
+package main
+
+type Tree struct {
+    root *node
+}
+
+type node struct {
+  value int
+  left *node
+  right *node
+}
+
+pred (t *Tree) tree() {
+    acc(&t.root) &&
+    (t.root != nil ==> t.root.tree() && t.root.sorted(none[int], none[int]))
+}
+
+pred (n *node) tree() {
+    acc(&n.value) && acc(&n.left) && acc(&n.right) &&
+    (n.left != nil ==> n.left.tree()) &&
+    (n.right != nil ==> n.right.tree())
+}
+
+ghost
+requires n.tree()
+pure func (n *node) sorted(lowerBound, upperBound option[int]) bool {
+    return unfolding n.tree() in (lowerBound != none[int] ==> get(lowerBound) < n.value) &&
+        (upperBound != none[int] ==> n.value < get(upperBound)) &&
+        (n.left != nil ==> n.left.sorted(lowerBound, some(n.value))) &&
+        (n.right != nil ==> n.right.sorted(some(n.value), upperBound))
+}
+
+ghost
+requires n.tree()
+requires n.sorted(oldLowerBound, oldUpperBound)
+requires (oldLowerBound == none[int]) ==> (newLowerBound == none[int])
+requires (oldUpperBound == none[int]) ==> (newUpperBound == none[int])
+requires newLowerBound != none[int] ==> oldLowerBound != none[int] && get(oldLowerBound) >= get(newLowerBound)
+requires newUpperBound != none[int] ==> oldUpperBound != none[int] && get(oldUpperBound) <= get(newUpperBound)
+ensures n.tree()
+ensures n.sorted(oldLowerBound, oldUpperBound) && n.sorted(newLowerBound, newUpperBound)
+ensures n.sortedValues(oldLowerBound, oldUpperBound) == n.sortedValues(newLowerBound, newUpperBound)
+func (n *node) convert(oldLowerBound, oldUpperBound, newLowerBound, newUpperBound option[int]) {
+    unfold n.tree()
+    assert newLowerBound != none[int] ==> get(newLowerBound) < n.value
+    assert newUpperBound != none[int] ==> get(newUpperBound) > n.value
+    if (n.left != nil) {
+        assert n.left.sorted(oldLowerBound, some(n.value))
+        n.left.convert(oldLowerBound, some(n.value), newLowerBound, some(n.value))
+        assert n.left.sorted(newLowerBound, some(n.value))
+    }
+    if (n.right != nil) {
+        assert n.right.sorted(some(n.value), oldUpperBound)
+        n.right.convert(some(n.value), oldUpperBound, some(n.value), newUpperBound)
+        assert n.right.sorted(some(n.value), newUpperBound)
+    }
+    fold n.tree()
+}
+
+ghost
+requires t.tree()
+ensures forall i int :: (0 <= i && i + 1 < len(res) ==> res[i] < res[i + 1]) // ordered
+pure func (t *Tree) sortedValues() (res seq[int]) {
+    return unfolding t.tree() in (t.root == nil) ? seq[int] { } : t.root.sortedValues(none[int], none[int])
+}
+
+ghost
+requires n.tree() && n.sorted(lowerBound, upperBound)
+ensures n.sorted(lowerBound, upperBound)
+ensures forall i int :: (0 <= i && i < len(res) ==> ((lowerBound != none[int] ==> res[i] > get(lowerBound)) && (upperBound != none[int] ==> res[i] < get(upperBound))))
+ensures forall i int :: (0 <= i && i + 1 < len(res) ==> res[i] < res[i + 1]) // ordered
+pure func (n *node) sortedValues(lowerBound, upperBound option[int]) (res seq[int]) {
+    return unfolding n.tree() in (n.left == nil ? seq[int]{ } : n.left.sortedValues(lowerBound, some(n.value))) ++ seq[int]{ n.value } ++ (n.right == nil ? seq[int]{ } : n.right.sortedValues(some(n.value), upperBound))
+}
+
+ensures t.tree() && t.IsEmpty()
+func NewTree() (t *Tree) {
+    t = new(Tree)
+    fold t.tree()
+    return t
+}
+
+requires t.tree()
+ensures res == unfolding t.tree() in t.root == nil
+pure func (t *Tree) IsEmpty() (res bool) {
+    return unfolding t.tree() in t.root == nil
+}
+
+requires dividend > 0
+requires acc(t.tree(), 1/dividend)
+ensures acc(t.tree(), 1/dividend)
+ensures res == unfolding acc(t.tree(), 1/dividend) in t.root != nil && value in t.root.sortedValues(none[int], none[int])
+func (t *Tree) Contains(value, dividend int) (res bool) {
+    unfold acc(t.tree(), 1/dividend)
+    if (t.root == nil) {
+        res = false
+    } else {
+        res = t.root.contains(value, dividend, none[int], none[int])
+    }
+    fold acc(t.tree(), 1/dividend)
+    return res
+}
+
+requires dividend > 0
+requires acc(n.tree(), 1/dividend) && n.sorted(lowerBound, upperBound)
+ensures acc(n.tree(), 1/dividend) && n.sorted(lowerBound, upperBound)
+ensures res == value in n.sortedValues(lowerBound, upperBound) // res is correct
+func (n *node) contains(value int, ghost dividend int, ghost lowerBound, upperBound option[int]) (res bool) {
+    unfold acc(n.tree(), 1/dividend)
+    if (n.value == value) {
+        res = true
+    } else if (value < n.value && n.left != nil) {
+        res = n.left.contains(value, dividend, lowerBound, some(n.value))
+    } else if (value > n.value && n.right != nil){
+        res = n.right.contains(value, dividend, some(n.value), upperBound)
+    } else {
+        res = false
+    }
+    fold acc(n.tree(), 1/dividend)
+    return res
+}
+
+requires t.tree()
+ensures t.tree()
+ensures value in t.sortedValues()
+ensures len(t.sortedValues()) == old(len(t.sortedValues())) + (value in old(t.sortedValues()) ? 0 : 1)
+ensures forall i int :: (i in old(t.sortedValues()) ==> i in t.sortedValues())
+ensures value in old(t.sortedValues()) ==> old(t.sortedValues()) == t.sortedValues()
+func (t *Tree) Insert(value int) {
+    unfold t.tree()
+    if (t.root == nil) {
+        t.root = &node{value: value}
+        fold t.root.tree()
+    } else {
+        t.root.insert(value, none[int], none[int])
+    }
+    fold t.tree()
+}
+
+requires lowerBound != none[int] ==> get(lowerBound) < value
+requires upperBound != none[int] ==> get(upperBound) > value
+requires n.tree() && n.sorted(lowerBound, upperBound)
+ensures n.tree() && n.sorted(lowerBound, upperBound)
+ensures value in n.sortedValues(lowerBound, upperBound)
+ensures len(n.sortedValues(lowerBound, upperBound)) == old(len(n.sortedValues(lowerBound, upperBound))) + (value in old(n.sortedValues(lowerBound, upperBound)) ? 0 : 1)
+ensures forall i int :: (i in old(n.sortedValues(lowerBound, upperBound)) ==> i in n.sortedValues(lowerBound, upperBound))
+ensures value in old(n.sortedValues(lowerBound, upperBound)) ==> old(n.sortedValues(lowerBound, upperBound)) == n.sortedValues(lowerBound, upperBound)
+func (n *node) insert(value int, ghost lowerBound, upperBound option[int]) {
+    unfold n.tree()
+    if (value < n.value) {
+        if (n.left == nil) {
+            n.left = &node{value: value}
+            fold n.left.tree()
+        } else {
+            n.left.insert(value, lowerBound, some(n.value))
+        }
+    } else if (value > n.value) {
+        if (n.right == nil) {
+            n.right = &node{value: value}
+            fold n.right.tree()
+        } else {
+            n.right.insert(value, some(n.value), upperBound)
+        }
+    }
+    fold n.tree()
+}
+
+requires t.tree()
+ensures t.tree()
+ensures !(value in t.sortedValues())
+func (t *Tree) Delete(value int) {
+    unfold t.tree()
+    if (t.root != nil) {
+        t.root = t.root.delete(value, none[int], none[int])
+        assert t.root != nil ==> t.root.sorted(none[int], none[int])
+    }
+    fold t.tree()
+}
+
+requires lowerBound != none[int] ==> get(lowerBound) < value
+requires upperBound != none[int] ==> get(upperBound) > value
+requires n.tree() && n.sorted(lowerBound, upperBound)
+ensures res != nil ==> res.tree() && res.sorted(lowerBound, upperBound)
+ensures res != nil ==> !(value in res.sortedValues(lowerBound, upperBound))
+func (n *node) delete(value int, ghost lowerBound, upperBound option[int]) (res *node) {
+    unfold n.tree()
+    if (value < n.value && n.left != nil) {
+        n.left = n.left.delete(value, lowerBound, some(n.value))
+        assert n.left != nil ==> n.left.tree() && n.left.sorted(lowerBound, some(n.value))
+        fold n.tree()
+        assert n.tree() && n.sorted(lowerBound, upperBound)
+        res = n
+    } else if (value > n.value && n.right != nil) {
+        n.right = n.right.delete(value, some(n.value), upperBound)
+        fold n.tree()
+        assert n.tree() && n.sorted(lowerBound, upperBound)
+        res = n
+    } else if (value == n.value) {
+        // delete this node
+        if (n.left != nil && n.right != nil) {
+            // find minimum in right subtree (i.e. the leftmost node in the right subtree)
+            // use the minimum as new value for the current node
+            // delete old node storing minimum
+            var minValue int
+            n.right, minValue = n.right.deleteMinimum(some(n.value), upperBound)
+            assert n.right != nil ==> !(minValue in n.right.sortedValues(some(minValue), upperBound))
+            assert n.right != nil ==> n.right.sorted(some(minValue), upperBound)
+            assert n.left != nil ==> n.left.sorted(lowerBound, some(n.value))
+            ghost if (n.left != nil) {
+                n.left.convert(lowerBound, some(n.value), lowerBound, some(minValue))
+            }
+            assert n.left != nil ==> n.left.sorted(lowerBound, some(minValue))
+            // overwrite value that should be deleted:
+            n.value = minValue
+            fold n.tree()
+            assert n.tree() && n.sorted(lowerBound, upperBound)
+            assert !(value in n.sortedValues(lowerBound, upperBound))
+            res = n
+        } else if (n.left != nil) {
+            // this node has a single child thus replace this node by its child:
+            res = n.left
+            assert !(value in res.sortedValues(lowerBound, some(n.value)))
+            assert res.tree() && res.sorted(lowerBound, some(n.value))
+            ghost res.convert(lowerBound, some(n.value), lowerBound, upperBound)
+            assert res.tree() && res.sorted(lowerBound, upperBound)
+        } else if (n.right != nil) {
+            // this node has a single child thus replace this node by its child:
+            res = n.right
+            ghost res.convert(some(n.value), upperBound, lowerBound, upperBound)
+        } else {
+            // this node does not have children
+            // simply delete it by returning nil
+            res = nil
+        }
+    }
+    return res
+}
+
+requires n.tree() && n.sorted(lowerBound, upperBound)
+ensures res != nil ==> res.tree() && res.sorted(some(minimum), upperBound)
+ensures res != nil ==> !(minimum in res.sortedValues(some(minimum), upperBound))
+ensures lowerBound != none[int] ==> get(lowerBound) < minimum
+ensures upperBound != none[int] ==> get(upperBound) > minimum
+func (n *node) deleteMinimum(ghost lowerBound, upperBound option[int]) (res *node, minimum int) {
+    unfold n.tree()
+    if (n.left != nil) {
+        // follow into left subtree as the minimum is the left most node
+        n.left, minimum = n.left.deleteMinimum(lowerBound, some(n.value))
+        fold n.tree()
+        assert n.tree() && n.sorted(some(minimum), upperBound)
+        res = n
+    } else if (n.right != nil) {
+        // n.value is the minimum but it has a right subtree
+        // thus, replace n by its right subtree
+        res, minimum = n.right, n.value
+    } else {
+        // n.value is the minimum and it does not have any subtrees
+        // simply delete it by returning nil
+        res, minimum = nil, n.value
+    }
+    return res, minimum
+}
+
+requires n.tree() && n.sorted(lowerBound, upperBound)
+ensures n.tree() && n.sorted(lowerBound, upperBound)
+ensures lowerBound != none[int] ==> res > get(lowerBound)
+ensures upperBound != none[int] ==> res < get(upperBound)
+ensures res == (n.sortedValues(lowerBound, upperBound))[0]
+func (n *node) getMinimum(ghost lowerBound, upperBound option[int]) (res int) {
+    unfold n.tree()
+    if (n.left == nil) {
+        res = n.value
+    } else {
+        res = n.left.getMinimum(lowerBound, some(n.value))
+    }
+    fold n.tree()
+    return res
+}
+/*
+ghost
+requires !(value in s)
+requires forall i int :: (0 <= i && i + 1 < len(s) ==> s[i] < s[i + 1]) // sorted
+ensures value in res
+ensures len(res) == len(s) + 1
+ensures forall i int :: (0 <= i && i + 1 < len(res) ==> res[i] < res[i + 1]) // sorted
+pure func insertIntoSortedSeq(ghost s seq[int], value int) (res seq[int]) {
+    return len(s) == 0 ? seq[int]{ value } : (value < s[0] ? (seq[int]{ value } ++ s) : (s[:1] ++ insertIntoSortedSeq(s[1:], value)))
+}
+*/
+func main() {
+    value0 := 2
+    value1 := 5
+    value2 := 42
+    t := client0(value0)
+    client1(t, value1)
+    client2(t, value2)
+    // t.print()
+    t.Insert(0)
+    t.Insert(100)
+    t.Insert(50)
+    t.Insert(25)
+    t.Insert(5)
+    t.Insert(1)
+    t.Insert(99)
+    t.Insert(-1)
+    t.Insert(45)
+    // t.print()
+    t.Delete(0)
+    // fmt.Println("----")
+    // t.print()
+}
+
+ensures t.tree()
+func client0(value int) (t *Tree) {
+    t = NewTree()
+    assert !t.Contains(value, 2)
+    t.Insert(value)
+    assert t.sortedValues() == seq[int]{ value }
+    t.Delete(value)
+    assert !t.Contains(value, 2)
+    return t
+}
+
+requires t.tree()
+ensures t.tree()
+func client1(t *Tree, value int) {
+    var oldValues = t.sortedValues()
+    t.Contains(value, 2) // passing a fractional permission of t.tree() enables proof that the tree values remain unchanged
+    var newValues = t.sortedValues()
+    assert oldValues == newValues
+}
+
+requires t.tree()
+ensures t.tree()
+func client2(t *Tree, value int) {
+    var oldValues = t.sortedValues()
+    // insert a new value
+    t.Insert(value)
+    var newValues = t.sortedValues()
+    assert t.Contains(value, 2)
+    ghost if (value in oldValues) {
+        assert oldValues == newValues
+    } else {
+        // this cannot be proven:
+        // assert newValues == insertIntoSortedSeq(oldValues, value)
+    }
+}
+/*
+// prints tree
+func (t *Tree) print() {
+  if (t.root == nil) { fmt.Println("empty") } else {
+    strings := t.root.toString()
+    for _, s := range strings {
+      fmt.Println(s)
+    }
+  }
+}
+
+// prints content of subtree
+func (n *node) toString() []string {
+  var left, right []string
+  if (n.left != nil) {
+    left = n.left.toString()
+  }
+  if (n.right != nil) {
+    right = n.right.toString()
+  }
+  res := make([]string, 1 + max(len(right), len(left)))
+  res[0] = fmt.Sprintf("%d", n.value)
+  for i := 1; i < len(res); i++ {
+    var leftString, rightString string
+    if len(left) > i - 1 {
+      leftString = left[i - 1]
+    }
+    if len(right) > i - 1 {
+      rightString = right[i - 1]
+    }
+    res[i] = fmt.Sprintf("|%s %s|", leftString, rightString)
+  }
+  return res
+}
+
+func max(a, b int) (res int) {
+  if a > b { return a } else { return b }
+}
+*/

--- a/src/test/resources/regressions/examples/binary_search_tree.gobra
+++ b/src/test/resources/regressions/examples/binary_search_tree.gobra
@@ -281,17 +281,19 @@ func (n *node) getMinimum(ghost lowerBound, upperBound option[int]) (res int) {
     fold n.tree()
     return res
 }
+
 /*
 ghost
 requires !(value in s)
 requires forall i int :: (0 <= i && i + 1 < len(s) ==> s[i] < s[i + 1]) // sorted
 ensures value in res
 ensures len(res) == len(s) + 1
-ensures forall i int :: (0 <= i && i + 1 < len(res) ==> res[i] < res[i + 1]) // sorted
+ensures forall i int :: (0 <= i && i + 1 < len(res) ==> res[i] < res[i + 1]) // sorted; this postcondition does not hold
 pure func insertIntoSortedSeq(ghost s seq[int], value int) (res seq[int]) {
     return len(s) == 0 ? seq[int]{ value } : (value < s[0] ? (seq[int]{ value } ++ s) : (s[:1] ++ insertIntoSortedSeq(s[1:], value)))
 }
 */
+
 func main() {
     value0 := 2
     value1 := 5
@@ -350,7 +352,8 @@ func client2(t *Tree, value int) {
         // assert newValues == insertIntoSortedSeq(oldValues, value)
     }
 }
-/*
+
+/* helper functions for printing the tree when this example is executed
 // prints tree
 func (t *Tree) print() {
   if (t.root == nil) { fmt.Println("empty") } else {

--- a/src/test/resources/regressions/examples/tour/Test1.gobra
+++ b/src/test/resources/regressions/examples/tour/Test1.gobra
@@ -13,6 +13,7 @@ func max(x, y int) (r int) {
 ensures s <= l;
 ensures s == x || s == y;
 ensures l == x || l == y;
+ensures x < y ? s == x && l == y : s == y && l == x;
 func sort(x, y int) (s, l int) {
   if (x < y) { s = x; l = y;
   } else { s = y; l = x; };
@@ -24,26 +25,22 @@ func client1() {
   r := max(a, b);
   assert r == 7;
 
-  /* the following leads to a crash (reported)
   var s, l int;
   s, l = sort(a, b);
   assert s == 5 && l == 7;
-  */
 };
 
-/* constants are not supported yet
 const five, seven = 5, 7;
 
 func client2() {
   r := max(five, seven);
   assert r == 7;
 };
-*/
 
-/* uint is not supported yet
 func type1(a uint) {
-  assert 0 <= a;
-};*/
+  // the following assertion cannot be proven yet (issue #192):
+  // assert 0 <= a;
+};
 
 func init() {
   var a int;

--- a/src/test/resources/regressions/features/ghost_members/ghost-overflows.gobra
+++ b/src/test/resources/regressions/features/ghost_members/ghost-overflows.gobra
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+// constants have arbitrary precision, thus this declaration is valid:
+const large = 21342134123412341234132452314213
+
+func main() {
+    // non-ghost and ghost code should behave the same in terms of overflows:
+    //:: ExpectedOutput(type_error)
+    tooLarge := large + 1 // overflow can statically be detected
+    ghost gTooLarge := large + 1 // overflow can statically be detected
+}

--- a/src/test/resources/regressions/features/ghost_members/ghost-overflows.gobra
+++ b/src/test/resources/regressions/features/ghost_members/ghost-overflows.gobra
@@ -10,5 +10,6 @@ func main() {
     // non-ghost and ghost code should behave the same in terms of overflows:
     //:: ExpectedOutput(type_error)
     tooLarge := large + 1 // overflow can statically be detected
+    //:: ExpectedOutput(type_error)
     ghost gTooLarge := large + 1 // overflow can statically be detected
 }

--- a/src/test/resources/regressions/features/ghost_members/ghost-pure-function.gobra
+++ b/src/test/resources/regressions/features/ghost_members/ghost-pure-function.gobra
@@ -1,0 +1,80 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+func foo() {
+  s := seq[int] { 1 }
+  res3 := test3(s)
+  res4 := test4(s)
+  res5 := test5(s)
+  ghost gRes5 := test5(s)
+  assert res5 == gRes5
+
+  // the following calls should all fails since res3 to res5 are ghost:
+  //:: ExpectedOutput(type_error)
+  isNonGhost(res3)
+  //:: ExpectedOutput(type_error)
+  isNonGhost(res4)
+  //:: ExpectedOutput(type_error)
+  isNonGhost(res5)
+  //:: ExpectedOutput(type_error)
+  isNonGhost(gRes5)
+}
+
+func bar() {
+    s := seq[int] { 1 }
+
+    // we declare variables as non-ghost:
+    var res3, res4, res5 int
+    ghost var gRes3, gRes4, gRes5 int
+
+    //:: ExpectedOutput(type_error)
+    res3 = test3(s) // fails as result is not assignable to actual variable
+    gRes3 = test3(s)
+    //:: ExpectedOutput(type_error)
+    res4 = test4(s) // fails as result is not assignable to actual variable
+    gRes4 = test4(s)
+    //:: ExpectedOutput(type_error)
+    res5 = test5(s) // fails as result is not assignable to actual variable
+    gRes5 = test5(s)
+
+    isNonGhost(res3)
+    isNonGhost(res4)
+    isNonGhost(res5)
+
+    //:: ExpectedOutput(type_error)
+    isNonGhost(gRes3)
+    //:: ExpectedOutput(type_error)
+    isNonGhost(gRes4)
+    //:: ExpectedOutput(type_error)
+    isNonGhost(gRes5)
+}
+
+//:: ExpectedOutput(type_error)
+pure func test1(s seq[int]) int { // parameter has to be ghost
+    return 1
+}
+
+//:: ExpectedOutput(type_error)
+pure func test2(ghost s seq[int]) int { // result has to be ghost
+    return len(s)
+}
+
+func test3(ghost s seq[int]) (ghost res int) {
+    return len(s)
+}
+
+// this function is fine as parameter and result are implicitly ghost
+ghost func test4(s seq[int]) int {
+    return len(s)
+}
+
+// this function is fine as parameter and result are implicitly ghost
+ghost pure func test5(s seq[int]) int {
+    return len(s)
+}
+
+// calling this function with an argument of ghost type leads to a type-error
+// thus, no type error at call site implies that the argument is non-ghost
+func isNonGhost(n int)

--- a/src/test/resources/regressions/features/multisets/multiset-literal-fail1.gobra
+++ b/src/test/resources/regressions/features/multisets/multiset-literal-fail1.gobra
@@ -4,7 +4,12 @@
 package pkg
 
 func foo() {
-  // fails: mixing ghost and non-ghost code
+  m := mset[int] { }
   //:: ExpectedOutput(type_error)
-	m := mset[int] { }
+  test(m)
+}
+
+//:: ExpectedOutput(type_error)
+func test(m mset[int]) {
+
 }

--- a/src/test/resources/regressions/features/multisets/multiset-literal-fail1.gobra
+++ b/src/test/resources/regressions/features/multisets/multiset-literal-fail1.gobra
@@ -5,11 +5,10 @@ package pkg
 
 func foo() {
   m := mset[int] { }
-  //:: ExpectedOutput(type_error)
   test(m)
 }
 
 //:: ExpectedOutput(type_error)
-func test(m mset[int]) {
+func test(m mset[int]) { // parameter of ghost type is used without ghost keyword
 
 }

--- a/src/test/resources/regressions/features/no_semicolons/ternary_operator/ternary-operator2.gobra
+++ b/src/test/resources/regressions/features/no_semicolons/ternary_operator/ternary-operator2.gobra
@@ -5,5 +5,5 @@ package pkg
 
 func test() {
   //:: ExpectedOutput(type_error)
-  v := 1 == 1 ? 5 : 6
+  v := 1 == 1 ? 5 : true
 }

--- a/src/test/resources/regressions/features/sequences/seq-contains-fail3.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-contains-fail3.gobra
@@ -4,7 +4,10 @@
 package pkg
 
 func foo() {
-  // fails: assigning ghost expression to non-ghost variable
-  //:: ExpectedOutput(type_error)
   b := 42 in seq[1..100]
+  // fails: assigning ghost expression to non-ghost parameter
+  //:: ExpectedOutput(type_error)
+  test(b)
 }
+
+func test(b bool)

--- a/src/test/resources/regressions/features/sequences/seq-convert-fail4.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-convert-fail4.gobra
@@ -12,18 +12,18 @@ func foo() {
   test4(len(xs))
 }
 
-func test1(ghost s seq[int]) {
-
-}
-
-ghost func test2(s seq[int]) {
-
-}
-
-pure func test3(s seq[int]) int {
+func test1(ghost s seq[int]) (ghost res int) {
     return len(s)
 }
 
-func test4(n int) {
+ghost func test2(s seq[int]) int {
+    return len(s)
+}
 
+ghost func test3(ghost s seq[int]) int {
+    return len(s)
+}
+
+ghost pure func test4(s seq[int]) int {
+    return len(s)
 }

--- a/src/test/resources/regressions/features/sequences/seq-convert-fail4.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-convert-fail4.gobra
@@ -4,6 +4,26 @@
 package pkg
 
 func foo() {
-  //:: ExpectedOutput(type_error)
   xs := seq(seq[int] { 42 })
+  test1(xs)
+  test2(xs)
+  test3(xs)
+  //:: ExpectedOutput(type_error)
+  test4(len(xs))
+}
+
+func test1(ghost s seq[int]) {
+
+}
+
+ghost func test2(s seq[int]) {
+
+}
+
+pure func test3(s seq[int]) int {
+    return len(s)
+}
+
+func test4(n int) {
+
 }

--- a/src/test/resources/regressions/features/sequences/seq-length-fail2.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-length-fail2.gobra
@@ -4,7 +4,12 @@
 package pkg
 
 func foo(ghost xs seq[int]) {
-  // fails: cannot assign ghost expression to actual variable
-  //:: ExpectedOutput(type_error)
   n := len(xs)
+  // fails: cannot assign ghost expression to actual parameter
+  //:: ExpectedOutput(type_error)
+  test(n)
+}
+
+func test(n int) {
+
 }

--- a/src/test/resources/regressions/features/sequences/seq-literal-fail1.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-literal-fail1.gobra
@@ -4,7 +4,12 @@
 package pkg
 
 func foo() {
+  xs := seq[int] { }
   // ghost error
   //:: ExpectedOutput(type_error)
-  xs := seq[int] { }
+  test(0 in xs)
+}
+
+func test(b bool) {
+
 }

--- a/src/test/resources/regressions/features/sequences/seq-range-fail3.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-range-fail3.gobra
@@ -4,7 +4,12 @@
 package pkg
 
 func foo(b bool) {
-  // fails: cannot assign a ghost expression to a non-ghost variable
-  //:: ExpectedOutput(type_error)
   xs := seq[1 .. 4]
+  // fails: cannot assign a ghost expression to a non-ghost parameter
+  //:: ExpectedOutput(type_error)
+  test(1 in xs)
+}
+
+func test(b bool) {
+
 }

--- a/src/test/resources/regressions/features/sequences/seq-slice-fail1.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-slice-fail1.gobra
@@ -4,7 +4,12 @@
 package pkg
 
 func foo(ghost xs seq[int]) {
-  // fails: cannot assign ghost expression to non-ghost (local) variable
-  //:: ExpectedOutput(type_error)
   ys := xs[2:3]
+  // fails: cannot assign ghost expression to non-ghost parameter
+  //:: ExpectedOutput(type_error)
+  test(0 in ys)
+}
+
+func test(b bool) {
+
 }

--- a/src/test/resources/regressions/features/sets/set-literal-fail1.gobra
+++ b/src/test/resources/regressions/features/sets/set-literal-fail1.gobra
@@ -4,7 +4,12 @@
 package pkg
 
 func foo() {
-  // fails: `s` isn't ghost
-  //:: ExpectedOutput(type_error)
   s := set[int] { }
+  // fails: `s` is ghost so is the result of `in`
+  //:: ExpectedOutput(type_error)
+  test(5 in s)
+}
+
+func test(b bool) {
+
 }

--- a/src/test/resources/regressions/features/ternary_operator/ternary-operator2.gobra
+++ b/src/test/resources/regressions/features/ternary_operator/ternary-operator2.gobra
@@ -4,6 +4,7 @@
 package pkg;
 
 func test() {
+  // int and bool are not mergeable:
   //:: ExpectedOutput(type_error)
-  v := 1 == 1 ? 5 : 6;
+  v := 1 == 1 ? 5 : true;
 };

--- a/src/test/resources/regressions/issues/000128-2.gobra
+++ b/src/test/resources/regressions/issues/000128-2.gobra
@@ -32,8 +32,9 @@ type T4 struct {
 // fst's type and snd's type have different underlying types (field names differ), leading to a type error
 func diffStructError1() {
   var fst T3 = T3{x: 1, z: 2}
+  var snd T2
   //:: ExpectedOutput(type_error)
-  var snd T2 = T2(fst)
+  snd = T2(fst)
   assert snd.x == 1 && snd.y == 2
 }
 
@@ -44,4 +45,24 @@ func diffStructError2() {
 	//:: ExpectedOutput(type_error)
 	var snd T4 = T4(fst)
 	assert snd.x == 1 && snd.y == 2
+}
+
+// the same type error as above should be detected when using a variable declaration without type
+func diffStructError3() {
+    var fst T1 = T1{x: 1, y: 2}
+	//:: ExpectedOutput(type_error)
+	var snd = T4(fst)
+	// the following assertion will fail as well as the type of `snd` cannot be inferred
+	//:: ExpectedOutput(type_error)
+	assert snd.x == 1
+}
+
+// the same type error as above should be detected when using a short variable declaration
+func diffStructError4() {
+    var fst T1 = T1{x: 1, y: 2}
+	//:: ExpectedOutput(type_error)
+	snd := T4(fst)
+	// the following assertion will fail as well as the type of `snd` cannot be inferred
+    //:: ExpectedOutput(type_error)
+	assert snd.x == 1
 }

--- a/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
+++ b/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
@@ -1,0 +1,136 @@
+package viper.gobra.erasing
+
+import org.bitbucket.inkytonik.kiama.util.{Positions, StringSource}
+import org.scalatest.Inside
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import viper.gobra.ast.frontend._
+import viper.gobra.frontend.{Config, Parser}
+import viper.gobra.frontend.info.Info
+import viper.gobra.frontend.info.implementation.TypeInfoImpl
+import viper.gobra.frontend.info.implementation.typing.ghost.separation.GhostLessPrinter
+
+class GhostErasureUnitTests extends AnyFunSuite with Matchers with Inside {
+  val frontend = new TestFrontend()
+
+  test("Ghost Erasure: variable declaration should not have a trailing equal sign") {
+    // var value int
+    val decl = PVarDecl(Some(PIntType()), Vector(), Vector(PIdnDef("value")), Vector(false))
+    frontend.ghostLessStmt(decl)() should matchPattern {
+      case d: PVarDecl if d == decl =>
+    }
+  }
+
+  test("Ghost Erasure: calls to (pure) ghost functions should be removed") {
+    // ghost (pure) func test() (res bool) {
+    //    return true
+    // }
+    // func main() {
+    //     test()
+    //     var t1 = test()
+    //     t2 := test()
+    // }
+    val modes: Set[Boolean] = Set(false, true)
+    modes.foreach(isPure => {
+      val testFunc = PExplicitGhostMember(PFunctionDecl(
+        PIdnDef("test"),
+        Vector(),
+        PResult(Vector(PNamedParameter(PIdnDef("res"), PBoolType()))),
+        PFunctionSpec(Vector(), Vector(), isPure),
+        Some((
+          PBodyParameterInfo(Vector()),
+          PBlock(Vector(PReturn(Vector(PBoolLit(true))))))
+        )))
+      val inputMainFunc = PFunctionDecl(
+        PIdnDef("main"),
+        Vector(),
+        PResult(Vector()),
+        PFunctionSpec(Vector(), Vector(), false),
+        Some((
+          PBodyParameterInfo(Vector()),
+          PBlock(Vector(
+            PExpressionStmt(PInvoke(PNamedOperand(PIdnUse("test")), Vector())),
+            PVarDecl(None, Vector(PInvoke(PNamedOperand(PIdnUse("test")), Vector())), Vector(PIdnDef("test1")), Vector(false)),
+            PShortVarDecl(Vector(PInvoke(PNamedOperand(PIdnUse("test")), Vector())), Vector(PIdnUnk("test2")), Vector(false))
+          ))
+        )))
+      val inputProgram = PProgram(
+        PPackageClause(PPkgDef("pkg")),
+        Vector(),
+        Vector(testFunc, inputMainFunc)
+      )
+      frontend.ghostLessProg(inputProgram) should matchPattern {
+        case PProgram(_, _, Vector(PFunctionDecl(PIdnDef("main"), _, _, _, Some((_, b))))) if b.nonEmptyStmts == Vector() =>
+      }
+    })
+  }
+
+
+  /* ** Stubs, mocks, and other test setup  */
+
+  class TestFrontend {
+    def stubProgram(inArgs: Vector[(PParameter, Boolean)], body : PStatement) : PProgram = PProgram(
+      PPackageClause(PPkgDef("pkg")),
+      Vector(),
+      Vector(PFunctionDecl(
+        PIdnDef("foo"),
+        inArgs.map(_._1),
+        PResult(Vector()),
+        PFunctionSpec(Vector(), Vector(), true),
+        Some(PBodyParameterInfo(inArgs.collect{ case (n: PNamedParameter, true) => PIdnUse(n.id.name) }), PBlock(Vector(body)))
+      ))
+    )
+
+    def ghostLessProg(program: PProgram): PProgram = {
+      val positions = new Positions
+      val pkg = PPackage(
+        PPackageClause(PPkgDef("pkg")),
+        Vector(program),
+        new PositionManager(positions)
+      )
+      val tree = new Info.GoTree(pkg)
+      val context = new Info.Context()
+      val config = Config(Vector())
+      val info = new TypeInfoImpl(tree, context)(config)
+
+      val ghostLess = new GhostLessPrinter(info).format(pkg)
+      // try to parse ghostLess string:
+      val parseRes = Parser.parseProgram(StringSource(ghostLess, "Ghostless Program"), false)(config)
+      parseRes match {
+        case Right(prog) => prog
+        case Left(messages) => fail(s"Parsing failed: $messages")
+      }
+    }
+
+    def ghostLessStmt(stmt: PStatement)(inArgs: Vector[(PParameter, Boolean)] = Vector()): PStatement = {
+      val program = stubProgram(inArgs, stmt)
+      val ghostLess = ghostLessProg(program)
+      val block = ghostLess match {
+        case PProgram(_, _, Vector(PFunctionDecl(PIdnDef("foo"), _, _, _, Some((_, b))))) => b
+        case p => fail(s"Parsing succeeded but with an unexpected program $p")
+      }
+      getSingleStmt(block.stmts)
+    }
+
+    def getSingleStmt(stmts: Vector[PStatement]): PStatement = {
+      val nonEmptyStmts = stmts.filter(s => s match {
+        case _: PEmptyStmt => false
+        case _ => true
+      })
+      nonEmptyStmts match {
+        case Vector(PSeq(s)) => getSingleStmt(s)
+        case Vector(s) => s
+        case s => fail(s"Parsing succeeded but with unexpected stmts $s")
+      }
+    }
+
+    def ghostLessExpr(expr: PExpression)(inArgs: Vector[(PParameter, Boolean)] = Vector()): PExpression = {
+      val stmt = PShortVarDecl(Vector(expr), Vector(PIdnUnk("n")), Vector(false))
+      val ghostLess = ghostLessStmt(stmt)(inArgs)
+      ghostLess match {
+        case PShortVarDecl(Vector(e), _, _) => e
+        case stmt => fail(s"Parsing succeeded but with unexpected stmt $stmt")
+      }
+    }
+  }
+}

--- a/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
+++ b/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
@@ -1,3 +1,9 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
 package viper.gobra.erasing
 
 import org.bitbucket.inkytonik.kiama.util.{Positions, StringSource}

--- a/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
+++ b/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
@@ -2500,6 +2500,19 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
     }
   }
 
+
+  /* ** Parser tests related to explicit ghost statements */
+
+  test("Parser: should be able to parse an exlicit short var decl") {
+    frontend.parseStmtOrFail("ghost res := test(s)") should matchPattern {
+      case PExplicitGhostStatement(PShortVarDecl(
+        Vector(PInvoke(PNamedOperand(PIdnUse("test")), Vector(PNamedOperand(PIdnUse("s"))))),
+        Vector(PIdnUnk("res")),
+        Vector(false))) =>
+    }
+  }
+
+
   /* ** Parser tests related to channels */
   test("Parser: should parse channel send statement") {
     frontend.parseStmtOrFail("c <- v") should matchPattern {


### PR DESCRIPTION
Adds a binary search tree example with Contains, Insert, and Delete operations.
The example can successfully be ghost erased using the included fixes.
`GhostErasureUnitTests` offers the possibility to write unit tests for ghost erasure and contains test cases for the fixed bugs