### PR TITLE
Mutex and waitgroup example

### DIFF
--- a/src/main/resources/stubs/sync/waitgroup.gobra
+++ b/src/main/resources/stubs/sync/waitgroup.gobra
@@ -60,9 +60,16 @@ func (g *WaitGroup) PayDebt(ghost P pred())
 // Simplified version of the debt redistribution rule, instantiated with P == { PredTrue!<!> } and Q == { R }.
 // This is the only rule that generates a Token.
 ghost
-requires R() && g.UnitDebt(PredTrue!<!>)
+requires g.UnitDebt(PredTrue!<!>)
 ensures g.UnitDebt(R) && g.Token(R)
 func (g *WaitGroup) GenerateToken(ghost R pred())
+
+/* TODO: rename previous mehtod to GenerateTokenAndDebt
+ghost
+requires R()
+ensures g.Token(R)
+func (g *WaitGroup) GenerateToken(ghost R pred())
+*/
 
 // Simplified version of Add as proposed in page 8 of Martin's latest document (as of 21/01/2021)
 requires dividend >= 0 && divisor > 0 // p >= 0
@@ -83,10 +90,18 @@ func (g *WaitGroup) Done()
 requires dividend > 0 && divisor > 0 // p > 0
 requires acc(g.WaitGroupP(), dividend/divisor)
 requires g.WaitMode()
-requires g.Token(P)
-ensures P()
+requires forall i int :: 0 <= i && i < len(P) ==> g.TokenById(P[i], i) 
+ensures forall i int :: 0 <= i && i < len(P) ==> InjEval(P[i], i)
 ensures acc(g.WaitGroupP(), dividend/divisor)
-func (g *WaitGroup) Wait(ghost dividend int, ghost divisor int, ghost P pred())
+func (g *WaitGroup) Wait(ghost dividend int, ghost divisor int, ghost P seq[pred()])
+
+pred (g *WaitGroup) TokenById(ghost P pred(), ghost i int) {
+	g.Token(P)
+}
+
+pred InjEval(ghost P pred(), ghost i int) {
+	P()
+}
 
 pred CollectFractions(ghost P seq[pred()], ghost dividends seq[int], ghost divisors seq[int]) {
 	len(P) == len(dividends) && len(dividends) == len(divisors) &&

--- a/src/main/resources/stubs/sync/waitgroup.gobra
+++ b/src/main/resources/stubs/sync/waitgroup.gobra
@@ -62,14 +62,12 @@ func (g *WaitGroup) PayDebt(ghost P pred())
 ghost
 requires g.UnitDebt(PredTrue!<!>)
 ensures g.UnitDebt(R) && g.Token(R)
-func (g *WaitGroup) GenerateToken(ghost R pred())
+func (g *WaitGroup) GenerateTokenAndDebt(ghost R pred())
 
-/* TODO: rename previous mehtod to GenerateTokenAndDebt
 ghost
 requires R()
 ensures g.Token(R)
 func (g *WaitGroup) GenerateToken(ghost R pred())
-*/
 
 // Simplified version of Add as proposed in page 8 of Martin's latest document (as of 21/01/2021)
 requires dividend >= 0 && divisor > 0 // p >= 0

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
@@ -94,7 +94,7 @@ trait StmtTyping extends BaseTyping { this: TypeInfoImpl =>
       multiAssignableTo.errors(Vector(miscType(exp)), lefts map exprType)(n) ++
         lefts.flatMap(t => addressable.errors(t)(t))
 
-    case n@PGoStmt(exp) => wellDefAndExpr(exp).out ++ isExecutable.errors(exp)(n)
+    case n@PGoStmt(exp) => isExpr(exp).out ++ isExecutable.errors(exp)(n)
 
     case n: PSelectStmt =>
       n.aRec.flatMap(rec =>

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
@@ -94,7 +94,7 @@ trait StmtTyping extends BaseTyping { this: TypeInfoImpl =>
       multiAssignableTo.errors(Vector(miscType(exp)), lefts map exprType)(n) ++
         lefts.flatMap(t => addressable.errors(t)(t))
 
-    case n@PGoStmt(exp) => isExpr(exp).out ++ isExecutable.errors(exp)(n)
+    case n@PGoStmt(exp) => wellDefAndExpr(exp).out ++ isExecutable.errors(exp)(n)
 
     case n: PSelectStmt =>
       n.aRec.flatMap(rec =>

--- a/src/test/resources/regressions/examples/parallel_search_replace.gobra
+++ b/src/test/resources/regressions/examples/parallel_search_replace.gobra
@@ -1,0 +1,130 @@
+
+package pkg
+
+import "sync"
+
+// Proof Utility: dump a slice into a sequence
+ghost
+requires forall j int :: 0 <= j && j < len(s) ==> acc(&s[j],_)
+ensures len(res) == len(s)
+ensures forall j int :: {s[j]} {res[j]} 0 <= j && j < len(s) ==> s[j] == res[j]
+pure func toSeq(ghost s []int) (res seq[int]) {
+  return (len(s) == 0 ? seq[int]{} :
+                        toSeq(s[:len(s)-1]) ++ seq[int]{s[len(s) - 1]})
+}
+
+pred replacedPerm(ghost s0 seq[int], ghost s [] int, ghost x, y int) {
+  len(s0) == len(s) &&
+  (forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])) &&
+  forall i int :: {s[i]} 0 <= i && i < len(s) ==>
+    s[i] == (s0[i] == x ? y : s0[i])
+}
+
+pred messagePerm(ghost wg *sync.WaitGroup, s []int, ghost x, y int) {
+  (forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])) &&
+  wg.UnitDebt(replacedPerm!<toSeq(s),s,x,y!>)
+}
+
+requires acc(c.RecvChannel(),_)
+requires c.RecvGivenPerm() == PredTrue!<!>;
+requires c.RecvGotPerm() == messagePerm!<wg,_,x,y!>;
+func worker(c <- chan[]int, wg *sync.WaitGroup, x, y int) {
+  fold acc(PredTrue!<!>(),2/1);
+  invariant PredTrue!<!>() && acc(c.RecvChannel(),_)
+  invariant c.RecvGivenPerm() == PredTrue!<!>;
+  invariant c.RecvGotPerm() == messagePerm!<wg,_,x,y,!>;
+  invariant ok ==> messagePerm!<wg,_,x,y!>(s)
+  for s, ok := <- c; ok; s, ok := <-c {
+    unfold messagePerm!<wg,_,x,y!>(s)
+    ghost s0 := toSeq(s)
+    invariant 0 <= i && i <= len(s)
+    invariant forall j int :: 0 <= j && j < len(s) ==> acc(&s[j])
+    invariant forall j int :: {s[j]} 0 <= j && j < len(s) ==>
+      s[j] == (s0[j] == x && j < i ? y : s0[j])
+    for i := 0; i != len(s); i++ {
+      if(s[i] == x) { s[i] = y }
+    }
+    fold replacedPerm!<s0,s,x,y!>()
+    wg.PayDebt(replacedPerm!<s0,s,x,y!>)
+    wg.Done()
+    fold PredTrue!<!>()
+  }
+}
+
+requires forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
+ensures forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
+ensures forall i int :: {s[i]} 0 <= i && i < len(s) ==>
+  s[i] == (old(s[i]) == x ? y : old(s[i]))
+func SearchReplace(s []int, x, y int) {
+  if(len(s) == 0) { return }
+  workers := 8
+  workRange := 1000
+  assert workers > 0
+  assert workRange > 0
+  ghost s0 := toSeq(s)
+  c := make(chan []int,4)
+  var wg@ sync.WaitGroup
+  ghost pr := messagePerm!<&wg,_,x,y!>;
+  c.Init(4,pr,PredTrue!<!>,PredTrue!<!>,pr)
+  wg.Init()
+  ghost seqs := seq[seq[int]] {}
+  ghost pseqs := seq[pred()] {}
+  invariant acc(c.RecvChannel(),_)
+  invariant c.RecvGivenPerm() == PredTrue!<!> && c.RecvGotPerm() == pr
+  for i := 0; i != workers; i++ { go worker(c,&wg,x,y) }
+  invariant acc(c.SendChannel()) && c.SendGivenPerm() == pr
+  invariant acc(wg.WaitGroupP(),1/2) && !wg.WaitMode()
+  invariant (offset == 0 ? acc(wg.WaitGroupP(),1/2) : acc(wg.WaitGroupStarted(),1/2))
+  invariant 0 <= offset && offset <= len(s)
+  invariant forall i int :: offset <= i && i < len(s) ==> acc(&s[i])
+  invariant forall i int :: offset <= i && i < len(s) ==> s[i] == s0[i]
+  invariant offset != len(s) ==> offset == len(seqs) * workRange
+  invariant offset == len(s) ==> len(seqs) > 0 &&
+    len(s) == (len(seqs) - 1) * workRange + len(seqs[len(seqs) - 1])
+  invariant forall i int :: {seqs[i]} 0 <= i &&
+    i < len(seqs) - (offset == len(s) ? 1 : 0) ==> len(seqs[i]) == workRange
+  invariant forall i, j int :: {seqs[i][j]} 0 <= i && i < len(seqs) &&
+    0 <= j && j < len(seqs[i]) ==> seqs[i][j] == s0[i * workRange + j]
+  invariant len(pseqs) == len(seqs)
+  invariant forall i int :: {pseqs[i]} 0 <= i && i < len(pseqs) ==>
+    pseqs[i] == replacedPerm!<seqs[i],s[i * workRange:i * workRange + len(seqs[i])],x,y!>;
+  invariant forall i int :: 0 <= i && i < len(pseqs) ==> wg.TokenById(pseqs[i],i)
+  for offset := 0; offset != len(s); {
+    nextOffset := offset + workRange;
+    if(nextOffset > len(s)) { nextOffset = len(s) }
+    section := s[offset:nextOffset]
+    assert forall i int :: {&section[i]} 0 <= i && i < len(s) ==>
+      &section[i] == &s[i + offset]
+    ghost s1 := toSeq(section)
+    ghost wpr := replacedPerm!<s1,section,x,y!>;
+    wg.Add(1,1,2,PredTrue!<!>)
+    ghost if(offset == 0) { wg.Start(1,2,PredTrue!<!>) }
+    wg.GenerateTokenAndDebt(wpr)
+    fold wg.TokenById(wpr,len(pseqs))
+    seqs = seqs ++ seq[seq[int]]{ s1 }
+    pseqs = pseqs ++ seq[pred()] { wpr }
+    fold messagePerm!<&wg,_,x,y!>(section)
+    c <- section
+    offset = nextOffset
+  }
+  wg.SetWaitMode(1,2,1,2)
+  wg.Wait(1,2,pseqs)
+  ghost {
+    invariant 0 <= i && i <= len(seqs)
+    invariant forall j int :: i <= j && j < len(seqs) ==>
+      sync.InjEval(pseqs[j],j)
+    invariant forall j int :: 0 <= j &&
+      j < (i == len(seqs) ? len(s) : i * workRange) ==>
+      acc(&s[j]) && s[j] == (s0[j] == x ? y : s0[j])
+    for i := 0; i != len(pseqs); i++ {
+      unfold sync.InjEval(pseqs[i],i)
+      low := i * workRange
+      up := low + len(seqs[i])
+      s1 := s[low:up]
+      unfold replacedPerm!<seqs[i],s1,x,y!>()
+      assert forall j int :: {&s[j]} low <= j && j < up ==> &s[j] == &s1[j-low]
+    }
+  }
+}
+
+

--- a/src/test/resources/regressions/examples/parallel_search_replace.gobra
+++ b/src/test/resources/regressions/examples/parallel_search_replace.gobra
@@ -1,3 +1,5 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
 
 package pkg
 

--- a/src/test/resources/regressions/examples/parallel_sum.gobra
+++ b/src/test/resources/regressions/examples/parallel_sum.gobra
@@ -16,6 +16,7 @@ pred AccInv(x *int, seenSlice []int) {
 
 // TODO: change `c.m.state == 0 && c.m.stema == 0` to *(c.m) == sync.Mutex{} after
 //       fixing issue #190
+ghost
 requires acc(c) && acc(c.sum) && acc(c.m) && c.m.state == 0 && c.m.stema == 0
 requires *c.sum == 0
 requires forall i int :: 0 <= i && i < len(seenSlice) ==> acc(&seenSlice[i], 1/2)

--- a/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
+++ b/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
@@ -17,15 +17,14 @@ pred sumSliceIndex(s []int, sum int, startIndex int) {
 type Accum struct {
 	sum *int
 	m *sync.Mutex
-	// TODO: add ghost slices that keep track of the counted nodes
 }
 
 pred AccInv(x *int, seenSlice []int) {
 	acc(x) && (forall i int :: 0 <= i && i < len(seenSlice) ==> (acc(&seenSlice[i], 1/2))) && Sum(seenSlice) == *x
 }
 
-// TODO: debug this
-// requires acc(c) && acc(c.sum) && acc(c.m) && *(c.m) == sync.Mutex{}
+// TODO: change `c.m.state == 0 && c.m.stema == 0` to *(c.m) == sync.Mutex{} after
+//       fixing issue #190
 requires acc(c) && acc(c.sum) && acc(c.m) && c.m.state == 0 && c.m.stema == 0
 requires *c.sum == 0
 requires forall i int :: 0 <= i && i < len(seenSlice) ==> acc(&seenSlice[i], 1/2)
@@ -37,8 +36,6 @@ func (c *Accum) Init(ghost seenSlice []int) {
 	c.m.SetInv(AccInv!<c.sum, seenSlice!>)
 }
 
-// TODO: change names of vars and types
-// TODO: define a specific predicate for the post condition
 /* Creates a worker thread per element in the slice and concurrently computes the sum of all the elements */
 requires forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
 ensures res == old(Sum(s))
@@ -47,7 +44,6 @@ func ParallelSum(s []int) (res int) {
 		return 0
 	}
 
-	// { len(s) > 0 }
 	count@ := 0
 	m := &sync.Mutex{}
 	c := &Accum{sum: &count, m: m}
@@ -55,9 +51,7 @@ func ParallelSum(s []int) (res int) {
 	c.Init(seenSlice)
 	w := &sync.WaitGroup{}
 	w.Init()
-
 	n := len(s)
-
 	ghost tokens := seq[pred()]{}
 
 	invariant 0 <= i && i <= n
@@ -76,16 +70,13 @@ func ParallelSum(s []int) (res int) {
 	invariant forall j int :: i <= j && j < n ==> acc(&seenSlice[j], 1/2)
 	invariant forall j int :: i <= j && j < n ==> seenSlice[j] == 0
 	for i := 0; i < n; i++ {
-		// { }
 		w.Add(1, 1, 2, PredTrue!<!>)
 		ghost if i == 0 {
 			w.Start(1, 2, PredTrue!<!>)
 		}
-		// fold locHasVal!<&seenSlice[i], s[i]!>()
 		tokens = tokens ++ seq[pred()]{ locHasVal!<&seenSlice[i], s[i]!> }
-		w.GenerateToken(tokens[i])
+		w.GenerateTokenAndDebt(tokens[i])
 		fold w.TokenById(tokens[i], i)
-		// { }
 		go worker(w, c, s[i], seenSlice, i)
 	}
 
@@ -101,19 +92,13 @@ func ParallelSum(s []int) (res int) {
 			unfold locHasVal!<&seenSlice[i],s[i]!>()
 		}
 	}
-	//assert c.m.LockInv() == AccInv!<c.sum, seenSlice!>;
+
 	c.m.Lock()
 	unfold AccInv!<c.sum, seenSlice!>()
-	res = *(c.sum) // TODO: maybe restructure the data in Accum to not have a pointer to int
+	res = *(c.sum)
 	fold AccInv!<c.sum, seenSlice!>()
 	c.m.Unlock()
-
 	sumExtensional(s, seenSlice)
-	// Main correctness criteria
-	// Goal: prove that, at this point, the value sum protected by the mutex has the sum of all elems of the array
-	//simpleSum := SimpleSum(s)
-	//assert res == simpleSum 
-
 	return res
 }
 
@@ -163,9 +148,7 @@ requires acc(accum.m.LockP(), _) && accum.m.LockInv() == AccInv!<accum.sum, seen
 requires 0 <= pos && pos < len(seenSlice)
 requires w.UnitDebt(locHasVal!<&seenSlice[pos],val!>)
 func worker(w *sync.WaitGroup, accum *Accum, val int, ghost seenSlice []int, ghost pos int) {
-	// { }
 	accum.m.Lock()
-	// { }
 	unfold AccInv!<accum.sum, seenSlice!>()
 	*(accum.sum) += val
 	update(seenSlice, pos, val)
@@ -191,8 +174,3 @@ func SimpleSum(s []int) (res int) {
 	}
 	fold sumSlice(s, res)
 }
-
-// TODO: suggestion by linard: similar example to the one above where the user defines the
-// number of chunks and a thread is created per chunk instead of per cell
-
-// TODO: Martin's example of worker threads

--- a/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
+++ b/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
@@ -20,23 +20,28 @@ type Accum struct {
 	// TODO: add ghost slices that keep track of the counted nodes
 }
 
-pred AccInv(x *int) {
-	acc(x)
+pred AccInv(x *int, seenSlice []int) {
+	acc(x) && (forall i int :: 0 <= i && i < len(seenSlice) ==> (acc(&seenSlice[i], 1/2))) && Sum(seenSlice) == *x
 }
 
 // TODO: debug this
 // requires acc(c) && acc(c.sum) && acc(c.m) && *(c.m) == sync.Mutex{}
 requires acc(c) && acc(c.sum) && acc(c.m) && c.m.state == 0 && c.m.stema == 0
-requires c.sum != nil
-ensures acc(c) && c.m.LockP() && c.m.LockInv() == (AccInv!<c.sum!>)
-func (c *Accum) Init() {
-	fold AccInv!<c.sum!>()
-	c.m.SetInv(AccInv!<c.sum!>)
+requires *c.sum == 0
+requires forall i int :: 0 <= i && i < len(seenSlice) ==> acc(&seenSlice[i], 1/2)
+requires forall i int :: 0 <= i && i < len(seenSlice) ==> seenSlice[i] == 0
+ensures acc(c) && c.m.LockP() && c.m.LockInv() == (AccInv!<c.sum, seenSlice!>)
+func (c *Accum) Init(ghost seenSlice []int) {
+	assume Sum(seenSlice) == 0
+	fold AccInv!<c.sum, seenSlice!>()
+	c.m.SetInv(AccInv!<c.sum, seenSlice!>)
 }
 
 // TODO: change names of vars and types
 // TODO: define a specific predicate for the post condition
 /* Creates a worker thread per element in the slice and concurrently computes the sum of all the elements */
+requires forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
+ensures res == old(Sum(s))
 func ParallelSum(s []int) (res int) {
 	if len(s) == 0 {
 		return 0
@@ -46,52 +51,64 @@ func ParallelSum(s []int) (res int) {
 	count@ := 0
 	m := &sync.Mutex{}
 	c := &Accum{sum: &count, m: m}
-	// { acc(c) && acc(c.sum) && acc(c.m) }
-	c.Init()
-	// { acc(c) && c.m.LockP() && c.m.LockInv() == AccInv!<c.sum!> }
+	seenSlice := make([]int, len(s))
+	c.Init(seenSlice)
 	w := &sync.WaitGroup{}
 	w.Init()
-	// {
-	//    acc(c) && c.m.LockP() &&
-	//    c.m.LockInv() == AccInv!<c.sum!> &&
-	//    w.WaitGroupP && !w.WaitMode()
-	// }
 
 	n := len(s)
 
-	invariant i >= 0
+	ghost tokens := seq[pred()]{}
+
+	invariant 0 <= i && i <= n
+	invariant len(tokens) == i
 	invariant i == 0 ==> w.WaitGroupP()
 	// Martin suggested the following line instead of the previous one, with the goal of
 	// deleting the invariant `i >= 0`. However, that is insufficient to prove the loop invariant
 	// invariant i != 0 ==> acc(w.WaitGroupP(), 1/2) && acc(w.WaitGroupStarted(), 1/2)
 	invariant i > 0 ==> acc(w.WaitGroupP(), 1/2) && acc(w.WaitGroupStarted(), 1/2)
-	invariant i >= n ==> w.Token(PredTrue!<!>)
+	invariant forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], 1/2)
+	invariant forall j int :: 0 <= j && j < i ==> tokens[j] == locHasVal!<&seenSlice[j],s[j]!>;
+	invariant forall j int :: 0 <= j && j < i ==> w.TokenById(tokens[j], j)
 	invariant !w.WaitMode()
 	invariant acc(c, _)
-	invariant acc(c.m.LockP(), _) && c.m.LockInv() == AccInv!<c.sum!>;
+	invariant acc(c.m.LockP(), _) && c.m.LockInv() == AccInv!<c.sum, seenSlice!>;
+	invariant forall j int :: i <= j && j < n ==> acc(&seenSlice[j], 1/2)
+	invariant forall j int :: i <= j && j < n ==> seenSlice[j] == 0
 	for i := 0; i < n; i++ {
 		// { }
 		w.Add(1, 1, 2, PredTrue!<!>)
 		ghost if i == 0 {
 			w.Start(1, 2, PredTrue!<!>)
 		}
-		ghost if i == n-1 {
-			fold PredTrue!<!>()
-			w.GenerateToken(PredTrue!<!>)
-		}
+		// fold locHasVal!<&seenSlice[i], s[i]!>()
+		tokens = tokens ++ seq[pred()]{ locHasVal!<&seenSlice[i], s[i]!> }
+		w.GenerateToken(tokens[i])
+		fold w.TokenById(tokens[i], i)
 		// { }
-		go worker(w, c, s[i] /*, 1, n+1*/)
+		go worker(w, c, s[i], seenSlice, i)
 	}
 
 	w.SetWaitMode(1, 2, 1, 2)
-	w.Wait(1, 1, PredTrue!<!>)
-	assert c.m.LockInv() == AccInv!<c.sum!>;
+	w.Wait(1, 1, tokens)
+	ghost {
+		invariant 0 <= i && i <= n
+		invariant forall j int :: 0 <= j && j < n ==> acc(&s[j], 1/2)
+		invariant forall j int :: 0 <= j && j < n ==> tokens[j] == locHasVal!<&seenSlice[j],s[j]!>;
+		invariant forall j int :: 0 <= j && j < n ==> (j < i ? acc(&seenSlice[j], 1/2) && seenSlice[j] == s[j] : sync.InjEval(tokens[j], j))
+		for i:=0; i < n; i++ {
+			unfold sync.InjEval(tokens[i], i)
+			unfold locHasVal!<&seenSlice[i],s[i]!>()
+		}
+	}
+	//assert c.m.LockInv() == AccInv!<c.sum, seenSlice!>;
 	c.m.Lock()
-	unfold AccInv!<c.sum!>()
+	unfold AccInv!<c.sum, seenSlice!>()
 	res = *(c.sum) // TODO: maybe restructure the data in Accum to not have a pointer to int
-	fold AccInv!<c.sum!>()
+	fold AccInv!<c.sum, seenSlice!>()
 	c.m.Unlock()
 
+	sumExtensional(s, seenSlice)
 	// Main correctness criteria
 	// Goal: prove that, at this point, the value sum protected by the mutex has the sum of all elems of the array
 	//simpleSum := SimpleSum(s)
@@ -100,17 +117,62 @@ func ParallelSum(s []int) (res int) {
 	return res
 }
 
+ghost
+requires len(a) == len(b)
+requires forall j int :: 0 <= j && j < len(a) ==> acc(&a[j], 1/2)
+requires forall j int :: 0 <= j && j < len(b) ==> acc(&b[j], 1/4) && b[j] == a[j]
+ensures old(Sum(a) - Sum(b)) == 0
+ensures forall j int :: 0 <= j && j < len(a) ==> acc(&a[j], 1/2)
+ensures forall j int :: 0 <= j && j < len(b) ==> acc(&b[j], 1/4)
+func sumExtensional(ghost a, b []int) {
+	if len(a) != 0 {
+		sumExtensional(a[:len(a)-1], b[:len(b)-1])
+	}
+}
+
+pred locHasVal(loc *int, val int) {
+	acc(loc, 1/2) && *loc == val
+}
+
+
+ghost
+requires forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], _)
+pure func Sum(ghost s []int) int {
+	return len(s) == 0? 0 : s[len(s) - 1] + Sum(s[:len(s)-1])
+}
+
+ghost
+requires forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], 1/4)
+requires acc(&s[pos], 3/4)
+requires 0 <= pos && pos < len(s)
+ensures forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], 1/4)
+ensures acc(&s[pos], 3/4)
+ensures Sum(s) == old(Sum(s)) + val
+ensures s[pos] == old(s[pos]) + val
+func update(ghost s []int, ghost pos, val int) {
+	if pos == len(s)-1 {
+		s[pos] += val
+	} else {
+		update(s[:len(s)-1], pos, val)
+	}
+}
+
 requires acc(accum, _)
-requires acc(accum.m.LockP(), _) && accum.m.LockInv() == AccInv!<accum.sum!>;
-requires w.UnitDebt(PredTrue!<!>)
-func worker(w *sync.WaitGroup, accum *Accum, val int/*, ghost dividend int, ghost divisor int*/) {
+requires acc(&seenSlice[pos], 1/2) && seenSlice[pos] == 0
+requires acc(accum.m.LockP(), _) && accum.m.LockInv() == AccInv!<accum.sum, seenSlice!>;
+requires 0 <= pos && pos < len(seenSlice)
+requires w.UnitDebt(locHasVal!<&seenSlice[pos],val!>)
+func worker(w *sync.WaitGroup, accum *Accum, val int, ghost seenSlice []int, ghost pos int) {
 	// { }
 	accum.m.Lock()
 	// { }
-	unfold AccInv!<accum.sum!>()
+	unfold AccInv!<accum.sum, seenSlice!>()
 	*(accum.sum) += val
-	fold AccInv!<accum.sum!>()
+	update(seenSlice, pos, val)
+	fold AccInv!<accum.sum, seenSlice!>()
 	accum.m.Unlock()
+	fold locHasVal!<&seenSlice[pos],val!>()
+	w.PayDebt(locHasVal!<&seenSlice[pos],val!>)
 	w.Done()
 }
 

--- a/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
+++ b/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
@@ -25,11 +25,13 @@ func (c *Accum) Init() {
 }
 
 // TODO: change names of vars and types
-// requires len(s) > 0
 /* Creates a worker thread per element in the slice and concurrently computes the sum of all the elements */
-requires s != nil
-func parallelSum(s []int) {
-	// { }
+func ParallelSum(s []int) (res int) {
+	if len(s) == 0 {
+		return 0
+	}
+
+	// { len(s) > 0 }
 	count@ := 0
 	m := &sync.Mutex{}
 	c := &Accum{sum: &count, m: m}
@@ -47,10 +49,11 @@ func parallelSum(s []int) {
 
 	invariant i >= 0
 	invariant i == 0 ==> w.WaitGroupP()
-	invariant i > 0 ==> acc(w.WaitGroupP(), 1/2) && acc(w.WaitGroupStarted(), 1/2)
 	// Martin suggested the following line instead of the previous one, with the goal of
 	// deleting the invariant `i >= 0`. However, that is insufficient to prove the loop invariant
 	// invariant i != 0 ==> acc(w.WaitGroupP(), 1/2) && acc(w.WaitGroupStarted(), 1/2)
+	invariant i > 0 ==> acc(w.WaitGroupP(), 1/2) && acc(w.WaitGroupStarted(), 1/2)
+	invariant i >= n ==> w.Token(PredTrue!<!>)
 	invariant !w.WaitMode()
 	invariant acc(c, _)
 	invariant acc(c.m.LockP(), _) && c.m.LockInv() == AccInv!<c.sum!>;
@@ -60,23 +63,36 @@ func parallelSum(s []int) {
 		ghost if i == 0 {
 			w.Start(1, 2, PredTrue!<!>)
 		}
+		ghost if i == n-1 {
+			fold PredTrue!<!>()
+			w.GenerateToken(PredTrue!<!>)
+		}
 		// { w.WaitGroupP() && !w.WaitMode() && }
 		go worker(w, c, s[i] /*, 1, n+1*/)
 	}
 
-	// w.SetWaitMode(1, 2, 1, 2) // failing!
-	/*
-	fold PredTrue!<!>()
-	w.GenerateToken(PredTrue!<!>)
+	w.SetWaitMode(1, 2, 1, 2)
+	// fold PredTrue!<!>()
+	// w.GenerateToken(PredTrue!<!>)
 	w.Wait(1, 1, PredTrue!<!>)
-	*/
+	assert c.m.LockInv() == AccInv!<c.sum!>;
+	c.m.Lock()
+	unfold AccInv!<c.sum!>()
+	// assert acc(c.sum)
 	// Goal: prove that the value sum protected by the mutex has the sum of all elems of the array
+	res = *(c.sum) // TODO: maybe restructure the data in Accum to not have a pointer to int
+	fold AccInv!<c.sum!>()
+	c.m.Unlock()
+
+	simpleSum := SimpleSum(s)
+	assert res == simpleSum
+
+	return res
 }
 
 // requires dividend > 0 && divisor > 0 // p > 0
 // requires acc(w.WaitGroupP(), dividend/divisor)
 requires acc(accum, _)
-// requires acc(accum.m, _)
 requires acc(accum.m.LockP(), _) && accum.m.LockInv() == AccInv!<accum.sum!>;
 requires w.UnitDebt(PredTrue!<!>)
 func worker(w *sync.WaitGroup, accum *Accum, val int/*, ghost dividend int, ghost divisor int*/) {
@@ -90,4 +106,16 @@ func worker(w *sync.WaitGroup, accum *Accum, val int/*, ghost dividend int, ghos
 	w.Done()
 }
 
-//pure func easySum() // used only for verification
+requires acc(s)
+ensures acc(s)
+func SimpleSum(s []int) (res int) {
+	res = 0
+	for i:=0; i<len(s); i++ {
+		res += s[i]
+	}
+}
+
+// TODO: suggestion by linard: similar example to the one above where the user defines the
+// number of chunks and a thread is created per chunk instead of per cell
+
+// TODO: Martin's example of worker threads

--- a/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
+++ b/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
@@ -5,6 +5,25 @@ package pkg
 
 import "sync"
 
+pred sumSlice(s []int, sum int) {
+	forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], _) &&
+	sumSliceIndex(s, sum, 0)
+}
+
+pred sumSliceIndex(s []int, sum int, startIndex int) {
+	forall i int :: startIndex <= i && i < len(s) ==> acc(&s[i], _) &&
+	(startIndex >= len(s) ==> sum == 0) &&
+		((startIndex < len(s)) ==> sumSliceIndex(s, sum - s[startIndex], startIndex + 1))
+}
+
+func sumSliceTest() {
+	var s []int = []int{1, 2, 3, 4} 
+	// causing
+	// Receiver of sumSliceIndex_pkg_F(s_pkg_V2, sum_pkg_V2 - (ShArrayloc((sarray(s_pkg_V2): ShArray[Ref]), sadd((soffset(s_pkg_V2): Int), startIndex_pkg_V2)): Ref).val$_Int, startIndex_pkg_V2 + 1)
+	// [mutex-and-waitgroup1.gobra@16.30--16.83]  might not be injective. (of class viper.silver.verifier.reasons$ReceiverNotInjective)
+	fold sumSliceIndex(s, 10, 0)
+}
+	
 type Accum struct {
 	sum *int
 	m *sync.Mutex
@@ -25,6 +44,7 @@ func (c *Accum) Init() {
 }
 
 // TODO: change names of vars and types
+// TODO: define a specific predicate for the post condition
 /* Creates a worker thread per element in the slice and concurrently computes the sum of all the elements */
 func ParallelSum(s []int) (res int) {
 	if len(s) == 0 {
@@ -41,7 +61,8 @@ func ParallelSum(s []int) (res int) {
 	w := &sync.WaitGroup{}
 	w.Init()
 	// {
-	//    acc(c) && c.m.LockP() && c.m.LockInv() == AccInv!<c.sum!> &&
+	//    acc(c) && c.m.LockP() &&
+	//    c.m.LockInv() == AccInv!<c.sum!> &&
 	//    w.WaitGroupP && !w.WaitMode()
 	// }
 
@@ -58,7 +79,7 @@ func ParallelSum(s []int) (res int) {
 	invariant acc(c, _)
 	invariant acc(c.m.LockP(), _) && c.m.LockInv() == AccInv!<c.sum!>;
 	for i := 0; i < n; i++ {
-		// { w.WaitGroupP() && !w.WaitMode() }
+		// { }
 		w.Add(1, 1, 2, PredTrue!<!>)
 		ghost if i == 0 {
 			w.Start(1, 2, PredTrue!<!>)
@@ -67,25 +88,23 @@ func ParallelSum(s []int) (res int) {
 			fold PredTrue!<!>()
 			w.GenerateToken(PredTrue!<!>)
 		}
-		// { w.WaitGroupP() && !w.WaitMode() && }
+		// { }
 		go worker(w, c, s[i] /*, 1, n+1*/)
 	}
 
 	w.SetWaitMode(1, 2, 1, 2)
-	// fold PredTrue!<!>()
-	// w.GenerateToken(PredTrue!<!>)
 	w.Wait(1, 1, PredTrue!<!>)
 	assert c.m.LockInv() == AccInv!<c.sum!>;
 	c.m.Lock()
 	unfold AccInv!<c.sum!>()
-	// assert acc(c.sum)
-	// Goal: prove that the value sum protected by the mutex has the sum of all elems of the array
 	res = *(c.sum) // TODO: maybe restructure the data in Accum to not have a pointer to int
 	fold AccInv!<c.sum!>()
 	c.m.Unlock()
 
-	simpleSum := SimpleSum(s)
-	assert res == simpleSum
+	// Main correctness criteria
+	// Goal: prove that, at this point, the value sum protected by the mutex has the sum of all elems of the array
+	//simpleSum := SimpleSum(s)
+	//assert res == simpleSum 
 
 	return res
 }
@@ -96,9 +115,9 @@ requires acc(accum, _)
 requires acc(accum.m.LockP(), _) && accum.m.LockInv() == AccInv!<accum.sum!>;
 requires w.UnitDebt(PredTrue!<!>)
 func worker(w *sync.WaitGroup, accum *Accum, val int/*, ghost dividend int, ghost divisor int*/) {
-	// { ? && m.LockInv() == AccInv!<accum.sum!> && acc(m.LockP(), _)}
+	// { }
 	accum.m.Lock()
-	// { ? && m.LockInv() == AccInv!<accum.sum!> && m.LockP() && m.UnlockP() && m.LockInv()() }
+	// { }
 	unfold AccInv!<accum.sum!>()
 	*(accum.sum) += val
 	fold AccInv!<accum.sum!>()
@@ -106,14 +125,15 @@ func worker(w *sync.WaitGroup, accum *Accum, val int/*, ghost dividend int, ghos
 	w.Done()
 }
 
-requires acc(s)
-ensures acc(s)
+// TODO: define a specific predicate for sum of this
+/*
 func SimpleSum(s []int) (res int) {
 	res = 0
 	for i:=0; i<len(s); i++ {
 		res += s[i]
 	}
 }
+*/
 
 // TODO: suggestion by linard: similar example to the one above where the user defines the
 // number of chunks and a thread is created per chunk instead of per cell

--- a/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
+++ b/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
@@ -6,27 +6,18 @@ package pkg
 import "sync"
 
 pred sumSlice(s []int, sum int) {
-	forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], _) &&
 	sumSliceIndex(s, sum, 0)
 }
 
 pred sumSliceIndex(s []int, sum int, startIndex int) {
-	forall i int :: startIndex <= i && i < len(s) ==> acc(&s[i], _) &&
 	(startIndex >= len(s) ==> sum == 0) &&
-		((startIndex < len(s)) ==> sumSliceIndex(s, sum - s[startIndex], startIndex + 1))
+		((startIndex < len(s)) ==> (acc(&s[startIndex], _) && sumSliceIndex(s, sum - s[startIndex], startIndex + 1)))
 }
 
-func sumSliceTest() {
-	var s []int = []int{1, 2, 3, 4} 
-	// causing
-	// Receiver of sumSliceIndex_pkg_F(s_pkg_V2, sum_pkg_V2 - (ShArrayloc((sarray(s_pkg_V2): ShArray[Ref]), sadd((soffset(s_pkg_V2): Int), startIndex_pkg_V2)): Ref).val$_Int, startIndex_pkg_V2 + 1)
-	// [mutex-and-waitgroup1.gobra@16.30--16.83]  might not be injective. (of class viper.silver.verifier.reasons$ReceiverNotInjective)
-	fold sumSliceIndex(s, 10, 0)
-}
-	
 type Accum struct {
 	sum *int
 	m *sync.Mutex
+	// TODO: add ghost slices that keep track of the counted nodes
 }
 
 pred AccInv(x *int) {
@@ -109,8 +100,6 @@ func ParallelSum(s []int) (res int) {
 	return res
 }
 
-// requires dividend > 0 && divisor > 0 // p > 0
-// requires acc(w.WaitGroupP(), dividend/divisor)
 requires acc(accum, _)
 requires acc(accum.m.LockP(), _) && accum.m.LockInv() == AccInv!<accum.sum!>;
 requires w.UnitDebt(PredTrue!<!>)
@@ -125,15 +114,21 @@ func worker(w *sync.WaitGroup, accum *Accum, val int/*, ghost dividend int, ghos
 	w.Done()
 }
 
-// TODO: define a specific predicate for sum of this
-/*
+requires forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], _)
+ensures forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], _)
+ensures sumSlice(s, res)
 func SimpleSum(s []int) (res int) {
 	res = 0
-	for i:=0; i<len(s); i++ {
-		res += s[i]
+	fold sumSliceIndex(s, 0, len(s))
+	invariant -1 <= i && i < len(s)
+	invariant forall j int :: 0 <= j && j < len(s) ==> acc(&s[j], _)
+	invariant sumSliceIndex(s, res, i+1)
+	for i:=len(s)-1; i>=0; i-- {
+		res += *(&s[i])
+		fold sumSliceIndex(s, res, i)
 	}
+	fold sumSlice(s, res)
 }
-*/
 
 // TODO: suggestion by linard: similar example to the one above where the user defines the
 // number of chunks and a thread is created per chunk instead of per cell

--- a/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
+++ b/src/test/resources/regressions/features/defunc/mutex-and-waitgroup1.gobra
@@ -5,15 +5,6 @@ package pkg
 
 import "sync"
 
-pred sumSlice(s []int, sum int) {
-	sumSliceIndex(s, sum, 0)
-}
-
-pred sumSliceIndex(s []int, sum int, startIndex int) {
-	(startIndex >= len(s) ==> sum == 0) &&
-		((startIndex < len(s)) ==> (acc(&s[startIndex], _) && sumSliceIndex(s, sum - s[startIndex], startIndex + 1)))
-}
-
 type Accum struct {
 	sum *int
 	m *sync.Mutex
@@ -157,20 +148,4 @@ func worker(w *sync.WaitGroup, accum *Accum, val int, ghost seenSlice []int, gho
 	fold locHasVal!<&seenSlice[pos],val!>()
 	w.PayDebt(locHasVal!<&seenSlice[pos],val!>)
 	w.Done()
-}
-
-requires forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], _)
-ensures forall i int :: 0 <= i && i < len(s) ==> acc(&s[i], _)
-ensures sumSlice(s, res)
-func SimpleSum(s []int) (res int) {
-	res = 0
-	fold sumSliceIndex(s, 0, len(s))
-	invariant -1 <= i && i < len(s)
-	invariant forall j int :: 0 <= j && j < len(s) ==> acc(&s[j], _)
-	invariant sumSliceIndex(s, res, i+1)
-	for i:=len(s)-1; i>=0; i-- {
-		res += *(&s[i])
-		fold sumSliceIndex(s, res, i)
-	}
-	fold sumSlice(s, res)
 }

--- a/src/test/resources/regressions/features/defunc/waitgroup-simple1.gobra
+++ b/src/test/resources/regressions/features/defunc/waitgroup-simple1.gobra
@@ -17,7 +17,7 @@ func spawnThreads(n int) {
 	// { wg.WaitGroupP() && !wg.WaitMode() && wg.UnitDebt(PredTrue!<!>) }
 	fold PredTrue!<!>()
 	// { wg.WaitGroupP() && !wg.WaitMode() && wg.UnitDebt(PredTrue!<!>) && PredTrue!<!>() }
-	wg.GenerateToken(PredTrue!<!>)
+	wg.GenerateTokenAndDebt(PredTrue!<!>)
 	// { wg.WaitGroupP() && !wg.WaitMode() && wg.UnitDebt(PredTrue!<!>) && wg.Token(PredTrue!<!>) }
 	wg.Start(1, 2, PredTrue!<!>)
 	// { acc(wg.WaitGroupP(), 1/2) && acc(wg.WaitGroupStarted(), 1/2) && !wg.WaitMode() && wg.UnitDebt(PredTrue!<!>) && wg.Token(PredTrue!<!>) }
@@ -49,7 +49,7 @@ func spawnThreads(n int) {
 		// }
 		fold PredTrue!<!>()
 		// { same as above plus PredTrue!<!>() }
-		wg.GenerateToken(PredTrue!<!>)
+		wg.GenerateTokenAndDebt(PredTrue!<!>)
 		// {
 		//   acc(wg.WaitGroupP(), 1/2) &&
 		//   acc(wg.WaitGroupStarted(), 1/2) &&
@@ -85,7 +85,7 @@ func spawnThreads(n int) {
 
 	// This example is simple and we do not need to perform any token redistribution before calling wait. This is not
 	// true in general
-	wg.Wait(1, 1, PredTrue!<!>)
+	wg.Wait(1, 1, seq[pred()]{ })
 	// {
 	//   wg.WaitGroupP() &&
 	//   PredTrue!<!>()


### PR DESCRIPTION
@MartinClochard and I finished the proof of functional correctness of `sum`. This required some changes in the WaitGroup stub to avoid injectivity-related issues in Silver (by introducing `InjEval` and `TokenById` predicates). Besides, I fixed one of the view-shifts (previously called `GenerateToken`, now called `GenerateTokenAndDebt`) to remove one unnecessary pre-condition and introduced a new viewshift (`GenerateToken`) which allows the user to generate `Tokens` without generating the corresponding Debt (this is also a particular case of the debt redistribution rule).