### PR TITLE
Channel Initialization Improvement

### DIFF
--- a/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
@@ -212,7 +212,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
     case MakeSlice(target, typeParam, lenArg, capArg) => showVar(target) <+> "=" <+> "make" <>
       parens(showType(typeParam) <> comma <+> showExprList(lenArg +: capArg.toVector))
 
-    case MakeChannel(target, typeParam, bufferSizeArg, _) => showVar(target) <+> "=" <+> "make" <>
+    case MakeChannel(target, typeParam, bufferSizeArg, _, _) => showVar(target) <+> "=" <+> "make" <>
       parens(showType(typeParam) <> opt(bufferSizeArg)(comma <+> showExpr(_)))
 
     case MakeMap(target, typeParam, initialSpaceArg) =>
@@ -561,7 +561,7 @@ class ShortPrettyPrinter extends DefaultPrettyPrinter {
     case MakeSlice(target, typeParam, lenArg, capArg) => showVar(target) <+> "=" <+> "make" <>
       parens(showType(typeParam) <> comma <+> showExprList(lenArg +: capArg.toVector))
 
-    case MakeChannel(target, typeParam, bufferSizeArg, _) => showVar(target) <+> "=" <+> "make" <>
+    case MakeChannel(target, typeParam, bufferSizeArg, _, _) => showVar(target) <+> "=" <+> "make" <>
       parens(showType(typeParam) <> opt(bufferSizeArg)(comma <+> showExpr(_)))
 
     case MakeMap(target, typeParam, initialSpaceArg) =>

--- a/src/main/scala/viper/gobra/ast/internal/Program.scala
+++ b/src/main/scala/viper/gobra/ast/internal/Program.scala
@@ -234,7 +234,7 @@ sealed trait MakeStmt extends Stmt {
 }
 
 case class MakeSlice(override val target: LocalVar, override val typeParam: SliceT, lenArg: Expr, capArg: Option[Expr])(val info: Source.Parser.Info) extends MakeStmt
-case class MakeChannel(override val target: LocalVar, override val typeParam: ChannelT, bufferSizeArg: Option[Expr], isChannel: MPredicateProxy)(val info: Source.Parser.Info) extends MakeStmt
+case class MakeChannel(override val target: LocalVar, override val typeParam: ChannelT, bufferSizeArg: Option[Expr], isChannel: MPredicateProxy, bufferSize: MethodProxy)(val info: Source.Parser.Info) extends MakeStmt
 // TODO: change type of typeParam to MapT when MapT is implemented
 case class MakeMap(override val target: LocalVar, override val typeParam: Type, initialSpaceArg: Option[Expr])(val info: Source.Parser.Info) extends MakeStmt
 

--- a/src/main/scala/viper/gobra/ast/internal/transform/OverflowChecksTransform.scala
+++ b/src/main/scala/viper/gobra/ast/internal/transform/OverflowChecksTransform.scala
@@ -114,7 +114,7 @@ object OverflowChecksTransform extends InternalTransform {
     case m@MakeSlice(_, _, arg1, optArg2) =>
       Seqn(genOverflowChecksExprs(arg1 +: optArg2.toVector) :+ m)(m.info)
 
-    case m@MakeChannel(_, _, optArg, _) =>
+    case m@MakeChannel(_, _, optArg, _, _) =>
       Seqn(genOverflowChecksExprs(optArg.toVector) :+ m)(m.info)
 
     case m@MakeMap(_, _, optArg) =>

--- a/src/main/scala/viper/gobra/ast/internal/utility/GobraStrategy.scala
+++ b/src/main/scala/viper/gobra/ast/internal/utility/GobraStrategy.scala
@@ -37,7 +37,7 @@ object GobraStrategy {
       case (_: While, Seq(cond: Expr, invs: Vector[Assertion@unchecked], body: Stmt)) => While(cond, invs, body)(meta)
       case (_: New, Seq(target: LocalVar, expr: Expr)) => New(target, expr)(meta)
       case (_: MakeSlice, Seq(target: LocalVar, typeParam: SliceT, lenArg: Expr, capArg: Option[Expr@unchecked])) => MakeSlice(target, typeParam, lenArg, capArg)(meta)
-      case (_: MakeChannel, Seq(target: LocalVar, typeParam: ChannelT, bufferSizeArg: Option[Expr@unchecked], isChannel: MPredicateProxy)) => MakeChannel(target, typeParam, bufferSizeArg, isChannel)(meta)
+      case (_: MakeChannel, Seq(target: LocalVar, typeParam: ChannelT, bufferSizeArg: Option[Expr@unchecked], isChannel: MPredicateProxy, bufferSize: MethodProxy)) => MakeChannel(target, typeParam, bufferSizeArg, isChannel, bufferSize)(meta)
       case (_: MakeMap, Seq(target: LocalVar, typeParam: Type, initialSpaceArg: Option[Expr@unchecked])) => MakeMap(target, typeParam, initialSpaceArg)(meta)
       case (_: SingleAss, Seq(l: Assignee, r: Expr)) => SingleAss(l, r)(meta)
       case (_: Assignee.Var, Seq(v: AssignableVar)) => Assignee.Var(v)

--- a/src/main/scala/viper/gobra/ast/internal/utility/Nodes.scala
+++ b/src/main/scala/viper/gobra/ast/internal/utility/Nodes.scala
@@ -40,7 +40,7 @@ object Nodes {
         case While(cond, invs, body) => Seq(cond) ++ invs ++ Seq(body)
         case New(target, typ) => Seq(target, typ)
         case MakeSlice(target, _, lenArg, capArg) => Seq(target, lenArg) ++ capArg.toSeq
-        case MakeChannel(target, _, bufferSizeArg, _) => target +: bufferSizeArg.toSeq
+        case MakeChannel(target, _, bufferSizeArg, _, _) => target +: bufferSizeArg.toSeq
         case MakeMap(target, _, initialSpaceArg) => target +: initialSpaceArg.toSeq
         case SingleAss(left, right) => Seq(left, right)
         case FunctionCall(targets, func, args) => targets ++ Seq(func) ++ args

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -1363,8 +1363,9 @@ object Desugar {
                 case s@SliceT(_) => in.MakeSlice(target, elemD(s).asInstanceOf[in.SliceT], arg0.get, arg1)(src)
                 case c@ChannelT(_, _) =>
                   val channelType = elemD(c).asInstanceOf[in.ChannelT]
-                  val isChannelProxy = mpredicateProxy(BuiltInMemberTag.IsChannelMPredTag, channelType, Vector(in.IntT(Addressability.inParameter)))(src)
-                  in.MakeChannel(target, channelType, arg0, isChannelProxy)(src)
+                  val isChannelProxy = mpredicateProxy(BuiltInMemberTag.IsChannelMPredTag, channelType, Vector())(src)
+                  val bufferSizeProxy = methodProxy(BuiltInMemberTag.BufferSizeMethodTag, channelType, Vector())(src)
+                  in.MakeChannel(target, channelType, arg0, isChannelProxy, bufferSizeProxy)(src)
                 case m@MapT(_, _) => in.MakeMap(target, elemD(m), arg0)(src)
               }
               _ <- write(make)

--- a/src/main/scala/viper/gobra/frontend/info/base/BuiltInMemberTag.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/BuiltInMemberTag.scala
@@ -179,8 +179,8 @@ object BuiltInMemberTag {
     override def typ(config: Config): AbstractType = channelReceiverType(allDirections, c => {
       // init's signature is adapted to the heavy simplifications that are in place for the initial support for channels.
       // in particular, the permission for SendGivenPerm and RecvGotPerm as well as SendGotPerm and RecvGivenPerm have
-      // to be equal. Thus, they get merge two parameters: The former pair is called `proPerm` as they describe the
-      // invariant that is exhaled at the sender's and inhaled at the receiver's side ("pro" because it "travels" in
+      // to be equal. Thus, they get merged into two parameters: The former pair is called `proPerm` as they describe
+      // the invariant that is exhaled at the sender's and inhaled at the receiver's side ("pro" because it "travels" in
       // direction of the send operation). The latter pair is merged to `contraPerm` representing the invariant that
       // "travels" in the opposite direction.
       val proPermArgType = PredT(Vector(c.elem))

--- a/src/test/resources/regressions/examples/parallel_search_replace.gobra
+++ b/src/test/resources/regressions/examples/parallel_search_replace.gobra
@@ -67,7 +67,7 @@ func SearchReplace(s []int, x, y int) {
   c := make(chan []int,4)
   var wg@ sync.WaitGroup
   ghost pr := messagePerm!<&wg,_,x,y!>;
-  c.Init(4,pr,PredTrue!<!>,PredTrue!<!>,pr)
+  c.Init(pr,PredTrue!<!>)
   wg.Init()
   ghost seqs := seq[seq[int]] {}
   ghost pseqs := seq[pred()] {}

--- a/src/test/resources/regressions/features/channels/bar/bar.gobra
+++ b/src/test/resources/regressions/features/channels/bar/bar.gobra
@@ -3,5 +3,5 @@
 
 package bar
 
-requires c.IsChannel(0)
+requires c.IsChannel() && c.BufferSize() == 0
 func useChannel(c chan<- int)

--- a/src/test/resources/regressions/features/channels/channel-fail4.gobra
+++ b/src/test/resources/regressions/features/channels/channel-fail4.gobra
@@ -22,3 +22,14 @@ func closeGhostChannel(ghost c chan int) {
     //:: ExpectedOutput(type_error)
     close(c, 1, 2, testPredicate!<0!>)
 }
+
+func initWithWrongArgType() {
+  // previously, Init took as first argument an int. If this argument is provided as a literal, type inference kicks
+  // in which crashed if the parameter type is not int. This case checks whether the type error is correctly detected
+  // and reported (i.e. without crashing Gobra)
+  c := make(chan int, 1) // make a buffered channel
+  //:: ExpectedOutput(type_error)
+  c.Init(1, testPredicate!<_!>, PredTrue!<!>, PredTrue!<!>, testPredicate!<_!>)
+  //:: ExpectedOutput(type_error)
+  c.Init(1, testPredicate!<_!>)
+}

--- a/src/test/resources/regressions/features/channels/channel-fail5.gobra
+++ b/src/test/resources/regressions/features/channels/channel-fail5.gobra
@@ -11,18 +11,12 @@ pred customTrue() {
     true
 }
 
-func initWithWrongBufferSize() {
-  c := make(chan int, 1) // make a buffered channel
-  //:: ExpectedOutput(precondition_error:permission_error)
-  c.Init(0, vIsOne!<_!>, PredTrue!<!>, PredTrue!<!>, vIsOne!<_!>)
-}
-
 func initBufferedChannelWithWrongPredicates() {
   c0 := make(chan int, 0) // make an unbuffered channel
   // if it's an unbuffered channel one can use arbitrary predicate expressions as SendGotPerm and RecvGivenPerm
-  c0.Init(0, vIsOne!<_!>, customTrue!<!>, customTrue!<!>, vIsOne!<_!>)
+  c0.Init(vIsOne!<_!>, customTrue!<!>)
   c1 := make(chan int, 1) // make a buffered channel
   // however, this is not possible if the channel is buffered:
-  //:: ExpectedOutput(precondition_error:permission_error)
-  c1.Init(0, vIsOne!<_!>, customTrue!<!>, customTrue!<!>, vIsOne!<_!>)
+  //:: ExpectedOutput(precondition_error:assertion_error)
+  c1.Init(vIsOne!<_!>, customTrue!<!>)
 }

--- a/src/test/resources/regressions/features/channels/channel-fail6.gobra
+++ b/src/test/resources/regressions/features/channels/channel-fail6.gobra
@@ -8,11 +8,24 @@ pred sendInvariant(v int) {
 }
 
 // contracts for built-in members might use other built-in members which also need to be generated (even when not mentioned in the program text)
-requires c.IsChannel(1)
+requires c.IsChannel() && c.BufferSize() == 1
 func testDependentBuiltInMembers(c chan int) {
     // PredTrue, SendChannel, RecvChannel, SendGivenPerm, SendGotPerm, RecvGivenPerm, and RecvGotPerm members have to be generated
 
     // Init cannot be called since equality of sendInvariant!<42!> and PredTrue!<!> cannot be proved
     //:: ExpectedOutput(precondition_error:assertion_error)
-    c.Init(1, sendInvariant!<_!>, sendInvariant!<42!>, sendInvariant!<42!>, sendInvariant!<_!>)
+    c.Init(sendInvariant!<_!>, sendInvariant!<42!>)
+}
+
+requires c.IsChannel() // c.BufferSize() is not specified
+func testInitWithoutBufferSize(c chan int) {
+    // as the buffer size is unknown, the second argument has to be equal to PredTrue!<!> (same situation as in the functio above)
+    //:: ExpectedOutput(precondition_error:assertion_error)
+    c.Init(sendInvariant!<_!>, sendInvariant!<42!>)
+}
+
+requires c.IsChannel() && c.BufferSize() == 0
+func testInitWithBufferSize0(c chan int) {
+    // any predicate expression can be used as second argument as it is known that the channel has buffer size 0
+    c.Init(sendInvariant!<_!>, sendInvariant!<42!>)
 }

--- a/src/test/resources/regressions/features/channels/channel-simple-buffered1.gobra
+++ b/src/test/resources/regressions/features/channels/channel-simple-buffered1.gobra
@@ -9,7 +9,7 @@ pred vIsOne(v int) {
 
 func main() {
   c := make(chan int, 1) // make a buffered channel
-  c.Init(1, vIsOne!<_!>, PredTrue!<!>, PredTrue!<!>, vIsOne!<_!>)
+  c.Init(vIsOne!<_!>, PredTrue!<!>)
   go foo(1, c)
 
   fold PredTrue!<!>()

--- a/src/test/resources/regressions/features/channels/channel-simple4.gobra
+++ b/src/test/resources/regressions/features/channels/channel-simple4.gobra
@@ -10,6 +10,7 @@ import b "bar"
 // the occurrence in packages
 func main() {
     c := make(chan int)
-    assert c.IsChannel(0)
+    assert c.IsChannel()
+    assert c.BufferSize() == 0
     b.useChannel(c)
 }

--- a/src/test/resources/regressions/features/channels/channel-simple5.gobra
+++ b/src/test/resources/regressions/features/channels/channel-simple5.gobra
@@ -9,7 +9,7 @@ pred vIsOne(v int) {
 
 func main() {
   c := make(chan int)
-  c.Init(0, vIsOne!<_!>, PredTrue!<!>, PredTrue!<!>, vIsOne!<_!>)
+  c.Init(vIsOne!<_!>, PredTrue!<!>)
   go foo(1, c)
 
   fold PredTrue!<!>()

--- a/src/test/resources/regressions/features/channels/channel-simple6.gobra
+++ b/src/test/resources/regressions/features/channels/channel-simple6.gobra
@@ -14,13 +14,13 @@ pred someLocation(p *int) {
 func main() {
   // make channel
   c := make(chan int)
-  assert c.IsChannel(0)
+  assert c.IsChannel()
+  assert c.BufferSize() == 0
 
   // set channel invariants
-  assert c.IsChannel(0)
-  assert 0 > 0 ==> PredTrue!<!> == PredTrue!<!> && PredTrue!<!> == PredTrue!<!>;
-  assert vIsOne!<_!> == vIsOne!<_!> && PredTrue!<!> == PredTrue!<!>;
-  c.Init(0, vIsOne!<_!>, PredTrue!<!>, PredTrue!<!>, vIsOne!<_!>)
+  assert c.IsChannel()
+  assert c.BufferSize() > 0 ==> PredTrue!<!> == PredTrue!<!>;
+  c.Init(vIsOne!<_!>, PredTrue!<!>)
   assert c.SendChannel() && c.RecvChannel()
   assert c.SendGivenPerm() == vIsOne!<_!> && c.SendGotPerm() == PredTrue!<!>;
   assert c.RecvGivenPerm() == PredTrue!<!> && c.RecvGotPerm() == vIsOne!<_!>;

--- a/src/test/resources/regressions/features/channels/channel-simple7.gobra
+++ b/src/test/resources/regressions/features/channels/channel-simple7.gobra
@@ -10,7 +10,7 @@ pred sendInvariant(v *int) {
 func main() {
   var c@ = make(chan *int)
   var pc *chan *int = &c
-  (*pc).Init(0, sendInvariant!<_!>, PredTrue!<!>, PredTrue!<!>, sendInvariant!<_!>)
+  (*pc).Init(sendInvariant!<_!>, PredTrue!<!>)
   go foo(pc)
 
   var x@ int = 42

--- a/src/test/resources/regressions/features/channels/channel-simple8.gobra
+++ b/src/test/resources/regressions/features/channels/channel-simple8.gobra
@@ -10,19 +10,19 @@ pred sendInvariant(v int) {
 func testIsChannelPredicateIsIndependantOfAddressability() {
   var c1@ = make(chan int)
   var c2 = make(chan int)
-  assert c1.IsChannel(0)
-  assert c2.IsChannel(0)
+  assert c1.IsChannel() && c1.BufferSize() == 0
+  assert c2.IsChannel() && c2.BufferSize() == 0
   // testCall can be called with both channels:
   testCall1(c1)
   testCall1(c2)
-  c1.Init(0, sendInvariant!<_!>, sendInvariant!<42!>, sendInvariant!<42!>, sendInvariant!<_!>)
-  c2.Init(0, sendInvariant!<_!>, sendInvariant!<42!>, sendInvariant!<42!>, sendInvariant!<_!>)
+  c1.Init(sendInvariant!<_!>, sendInvariant!<42!>)
+  c2.Init(sendInvariant!<_!>, sendInvariant!<42!>)
   testCall2(c1)
   testCall2(c2)
 }
 
-requires c.IsChannel(0)
-ensures c.IsChannel(0)
+requires c.IsChannel() && c.BufferSize() == 0
+ensures c.IsChannel() && c.BufferSize() == 0
 func testCall1(c chan int)
 
 requires c.SendChannel()


### PR DESCRIPTION
@MartinClochard proposed to remove redundant parameters from the `Init` method for channels.
In particular, the new signature is:
```
requires c.IsChannel()
requires c.BufferSize() > 0 ==> (B == pred_true{})
ensures c.SendChannel() && c.RecvChannel()
ensures c.SendGivenPerm() == A && c.SendGotPerm() == B
ensures c.RecvGivenPerm() == B && c.RecvGotPerm() == A
ghost func (c chan T).Init(A pred(T), B pred())
```

As a consequence, `IsChannel` no longer takes the buffer size as a parameter and `BufferSize` is a newly added ghost pure method:
```
requires acc(c.IsChannel(), _)
pure func (c chan T).BufferSize() (k Int)
```

@jcp19 After adapting the type-checker, I've discovered the following bug that is related to type inference for int literals:
If you have `c.Init(0, ...)` in your code and the type-checker expects the new signature, i.e. the first argument should be of type `Pred(T)`, then type inference would return `Pred(T)` as `typCtx` but this then causes a crash in `assignableWithinBounds` as that one expects a type with underlying type int.
I attempted to fix it but please double check whether you are happy with my changes (they are all in `ExprTyping.scala`)