### PR TITLE
Fix issue 164

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -115,7 +115,7 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context)
     externallyAccessedMembers.contains(m)
   }
 
-  private lazy val variablesMap: Map[(PScope, Option[Position]), Vector[PIdnNode]] = {
+  private lazy val variablesMap: Map[(Option[Position], PScope), Vector[PIdnNode]] = {
     val ids: Vector[PIdnNode] = tree.nodes collect {
       case id: PIdnDef              => id
       case id: PIdnUnk if isDef(id) => id
@@ -125,7 +125,7 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context)
       // having the position in the key ensures that the variables of two structurally equal scopes
       // occurring in different positions are not merged in a single Vector, avoiding duplicated entries
       // in the variables of a scope
-      val scope = enclosingIdScope(f); (scope, pos(scope))
+      val scope = enclosingIdScope(f); (pos(scope), scope)
     }
   }
 
@@ -133,7 +133,7 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context)
     tree.root.positions.positions.getStart(scope)
 
   override def variables(s: PScope): Vector[PIdnNode] =
-    variablesMap.getOrElse((s, pos(s)), Vector.empty).sortWith(_.name < _.name)
+    variablesMap.getOrElse((pos(s), s), Vector.empty).sortWith(_.name < _.name)
 
   private lazy val usesMap: Map[UniqueRegular, Vector[PIdnUse]] = {
     val ids: Vector[PIdnUse] = tree.nodes collect {case id: PIdnUse if uniqueRegular(id).isDefined => id }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -123,7 +123,8 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context)
     ids.groupBy(enclosingIdScope)
   }
 
-  override def variables(s: PScope): Vector[PIdnNode] = variablesMap.getOrElse(s, Vector.empty).sortWith(_.name < _.name)
+  override def variables(s: PScope): Vector[PIdnNode] =
+    variablesMap.getOrElse(s, Vector.empty).distinct.sortWith(_.name < _.name)
 
   private lazy val usesMap: Map[UniqueRegular, Vector[PIdnUse]] = {
     val ids: Vector[PIdnUse] = tree.nodes collect {case id: PIdnUse if uniqueRegular(id).isDefined => id }

--- a/src/main/scala/viper/gobra/translator/encodings/preds/DefuncComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/preds/DefuncComponentImpl.scala
@@ -193,9 +193,6 @@ class DefuncComponentImpl extends DefuncComponent {
       // generate make and arg functions
       funcs ::= makeFunc(S, id)
 
-      // adds the default value of the predicate type
-      funcs ++= genDefaultFuncMap.get(S)
-
 //      innerArgTypes.indices foreach (idx => funcs ::= argFunc(S, id, idx))
 
 //      // generate axiom
@@ -211,6 +208,9 @@ class DefuncComponentImpl extends DefuncComponent {
 //        )(domainName = domainName(S))
 //      }
     }
+
+    // adds the default value of the predicate type
+    funcs ++= genDefaultFuncMap.get(S)
 
     vpr.Domain(
       name = domainName(S),

--- a/src/test/resources/regressions/issues/000164.gobra
+++ b/src/test/resources/regressions/issues/000164.gobra
@@ -1,0 +1,25 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+type Singleton struct {
+	x int
+}
+
+pred (s *Singleton) lessThan(bound int) {
+	acc(s) && s.x <= bound
+}
+
+requires x >= 0
+func foldSingletonLessThan(x int) {
+	s@ := Singleton{}
+	fold (&s).lessThan!<x!>()
+}
+
+func foldSingletonLessThanError(x int) {
+	s@ := Singleton{}
+	// x may be less than the value of the singleton
+	//:: ExpectedOutput(fold_error)
+	fold (&s).lessThan!<x!>()
+}


### PR DESCRIPTION
Fixes #164. The bug was triggered when local variables with the same name were declared in different functions. In that case, `variables` would return a list with repeated variables. In turn, this would lead to redeclarations of a variable in the same block, in the method `blockD` of the file `Desugar.scala`.

For reference, this is how the current implementation of `blockD` looks like
```scala
    def blockD(ctx: FunctionContext)(block: PBlock): in.Stmt = {
      val vars = info.variables(block) map localVarD(ctx)
      val ssW = sequence(block.nonEmptyStmts map (s => seqn(stmtD(ctx)(s))))
      in.Block(vars ++ ssW.decls, ssW.stmts ++ ssW.res)(meta(block))
    }
```