### PR TITLE
Small changes to the examples

### DIFF
--- a/src/test/resources/regressions/examples/dense_sparse_matrix.gobra
+++ b/src/test/resources/regressions/examples/dense_sparse_matrix.gobra
@@ -135,7 +135,7 @@ func (dm *DenseMatrix)toSparse() (sm *SparseMatrix) {
         invariant 0 <= x && x < dm.lenX() && 0 <= y && y <= dm.lenY()
         invariant forall i, j int :: (0 <= i && i < x && 0 <= j && j < dm.lenY() ==> dm.lookup(i, j) == LookupL(sm, dm.lenX(), dm.lenY(), i, j))
         invariant forall j int :: (0 <= j && j < y ==> dm.lookup(x, j) == LookupL(sm, dm.lenX(), dm.lenY(), x, j))
-        for y := 0; y < dm.lenY(); y++ {
+        for y := 0; y < lenY; y++ {
             lenX, lenY := dm.lenX(), dm.lenY()
             unfold acc(denseMatrix(dm), 1/2)
             e := &Entry{row: x, column: y, value: (dm.values)[x][y]}
@@ -147,4 +147,5 @@ func (dm *DenseMatrix)toSparse() (sm *SparseMatrix) {
         // the following assert statement is necessary to preserve the outer loop's invariants:
         assert forall i, j int :: (0 <= i && i <= x && 0 <= j && j < dm.lenY() ==> dm.lookup(i, j) == LookupL(sm, dm.lenX(), dm.lenY(), i, j))
     }
+    return
 }

--- a/src/test/resources/regressions/examples/dense_sparse_matrix.gobra
+++ b/src/test/resources/regressions/examples/dense_sparse_matrix.gobra
@@ -135,7 +135,7 @@ func (dm *DenseMatrix)toSparse() (sm *SparseMatrix) {
         invariant 0 <= x && x < dm.lenX() && 0 <= y && y <= dm.lenY()
         invariant forall i, j int :: (0 <= i && i < x && 0 <= j && j < dm.lenY() ==> dm.lookup(i, j) == LookupL(sm, dm.lenX(), dm.lenY(), i, j))
         invariant forall j int :: (0 <= j && j < y ==> dm.lookup(x, j) == LookupL(sm, dm.lenX(), dm.lenY(), x, j))
-        for y := 0; y < lenY; y++ {
+        for y := 0; y < dm.lenY(); y++ {
             lenX, lenY := dm.lenX(), dm.lenY()
             unfold acc(denseMatrix(dm), 1/2)
             e := &Entry{row: x, column: y, value: (dm.values)[x][y]}

--- a/src/test/resources/regressions/examples/impl_errors/Tree.gobra
+++ b/src/test/resources/regressions/examples/impl_errors/Tree.gobra
@@ -17,7 +17,7 @@ pred tree(self *Tree) {
 
 requires self != nil ==> tree(self)
 pure func (self *Tree) Contains(v int) bool {
-  return self != nil && (unfolding tree(self) in self.Value == v ? true : (self.Left.Contains(v) || self.Right.Contains(v)))
+  return self != nil && (unfolding tree(self) in self.Value == v || (self.Left.Contains(v) || self.Right.Contains(v)))
 }
 
 requires self != nil ==> tree(self)

--- a/src/test/resources/regressions/examples/impl_errors/dense_sparse_matrix.gobra
+++ b/src/test/resources/regressions/examples/impl_errors/dense_sparse_matrix.gobra
@@ -149,4 +149,5 @@ func (dm *DenseMatrix)toSparse() (sm *SparseMatrix) {
         // the following assert statement is necessary to preserve the outer loop's invariants:
         assert forall i, j int :: (0 <= i && i <= x && 0 <= j && j < dm.lenY() ==> dm.lookup(i, j) == LookupL(sm, dm.lenX(), dm.lenY(), i, j))
     }
+    return
 }

--- a/src/test/resources/regressions/examples/impl_errors/infinite_list.gobra
+++ b/src/test/resources/regressions/examples/impl_errors/infinite_list.gobra
@@ -56,4 +56,5 @@ func removeAllOccurrances(ptr *node, value int) (rPtr *node, removeCount int) {
     fold infList(ptr)
     rPtr = ptr
   }
+  return
 }

--- a/src/test/resources/regressions/examples/impl_errors/parallel_search_replace.gobra
+++ b/src/test/resources/regressions/examples/impl_errors/parallel_search_replace.gobra
@@ -36,7 +36,7 @@ func worker(c <- chan[]int, wg *sync.WaitGroup, x, y int) {
   invariant c.RecvGivenPerm() == PredTrue!<!>;
   invariant c.RecvGotPerm() == messagePerm!<wg,_,x,y,!>;
   invariant ok ==> messagePerm!<wg,_,x,y!>(s)
-  for s, ok := <- c; ok; s, ok := <-c {
+  for s, ok := <- c; ok; s, ok = <-c {
     unfold messagePerm!<wg,_,x,y!>(s)
     ghost s0 := toSeq(s)
     invariant 0 <= i && i <= len(s)

--- a/src/test/resources/regressions/examples/infinite_list.gobra
+++ b/src/test/resources/regressions/examples/infinite_list.gobra
@@ -54,4 +54,5 @@ func removeAllOccurrances(ptr *node, value int) (rPtr *node, removeCount int) {
     fold infList(ptr)
     rPtr = ptr
   }
+  return
 }

--- a/src/test/resources/regressions/examples/parallel_search_replace.gobra
+++ b/src/test/resources/regressions/examples/parallel_search_replace.gobra
@@ -36,7 +36,7 @@ func worker(c <- chan[]int, wg *sync.WaitGroup, x, y int) {
   invariant c.RecvGivenPerm() == PredTrue!<!>;
   invariant c.RecvGotPerm() == messagePerm!<wg,_,x,y,!>;
   invariant ok ==> messagePerm!<wg,_,x,y!>(s)
-  for s, ok := <- c; ok; s, ok := <-c {
+  for s, ok := <- c; ok; s, ok = <-c {
     unfold messagePerm!<wg,_,x,y!>(s)
     ghost s0 := toSeq(s)
     invariant 0 <= i && i <= len(s)

--- a/src/test/resources/regressions/examples/spec_errors/Tree.gobra
+++ b/src/test/resources/regressions/examples/spec_errors/Tree.gobra
@@ -17,7 +17,7 @@ pred tree(self *Tree) {
 
 requires self != nil ==> tree(self)
 pure func (self *Tree) Contains(v int) bool {
-  return self != nil && (unfolding tree(self) in self.Value == v ? true : (self.Left.Contains(v) || self.Right.Contains(v)))
+  return self != nil && (unfolding tree(self) in self.Value == v || (self.Left.Contains(v) || self.Right.Contains(v)))
 }
 
 requires self != nil ==> tree(self)

--- a/src/test/resources/regressions/examples/spec_errors/dense_sparse_matrix.gobra
+++ b/src/test/resources/regressions/examples/spec_errors/dense_sparse_matrix.gobra
@@ -149,4 +149,5 @@ func (dm *DenseMatrix)toSparse() (sm *SparseMatrix) {
         // the following assert statement is necessary to preserve the outer loop's invariants:
         assert forall i, j int :: (0 <= i && i <= x && 0 <= j && j < dm.lenY() ==> dm.lookup(i, j) == LookupL(sm, dm.lenX(), dm.lenY(), i, j))
     }
+    return
 }

--- a/src/test/resources/regressions/examples/spec_errors/infinite_list.gobra
+++ b/src/test/resources/regressions/examples/spec_errors/infinite_list.gobra
@@ -56,4 +56,5 @@ func removeAllOccurrances(ptr *node, value int) (rPtr *node, removeCount int) {
     // fold infList(ptr)
     rPtr = ptr
   }
+  return
 }

--- a/src/test/resources/regressions/examples/spec_errors/parallel_search_replace.gobra
+++ b/src/test/resources/regressions/examples/spec_errors/parallel_search_replace.gobra
@@ -38,7 +38,7 @@ func worker(c <- chan[]int, wg *sync.WaitGroup, x, y int) {
   // invariant c.RecvGotPerm() == messagePerm!<wg,_,x,y,!>;
   //:: ExpectedOutput(invariant_preservation_error:permission_error)
   invariant ok ==> messagePerm!<wg,_,x,y!>(s)
-  for s, ok := <- c; ok; s, ok := <-c {
+  for s, ok := <- c; ok; s, ok = <-c {
     unfold messagePerm!<wg,_,x,y!>(s)
     ghost s0 := toSeq(s)
     invariant 0 <= i && i <= len(s)

--- a/src/test/resources/regressions/examples/tour/Tree.gobra
+++ b/src/test/resources/regressions/examples/tour/Tree.gobra
@@ -17,7 +17,7 @@ pred tree(self *Tree) {
 
 requires self != nil ==> tree(self)
 pure func (self *Tree) Contains(v int) bool {
-  return self != nil && (unfolding tree(self) in self.Value == v ? true : (self.Left.Contains(v) || self.Right.Contains(v)))
+  return self != nil && (unfolding tree(self) in self.Value == v || (self.Left.Contains(v) || self.Right.Contains(v)))
 }
 
 requires self != nil ==> tree(self)

--- a/src/test/resources/regressions/examples/zune.gobra
+++ b/src/test/resources/regressions/examples/zune.gobra
@@ -31,6 +31,7 @@ func convertDaysBug(totalDays int) (days, year int) {
     //:: ExpectedOutput(assert_error:assertion_error)
     assert days < variant
   }
+  return
 }
 
 
@@ -54,6 +55,7 @@ func convertDaysFixed(totalDays int) (days, year int) {
 
     assert days < variant
   }
+  return
 }
 
 
@@ -81,4 +83,5 @@ func convertDaysFixedWithSomeInvariants(totalDays int) (days, year int) {
 
     assert days < variant
   }
+  return
 }


### PR DESCRIPTION
Adds missing return statements and replaces a `:=` by a `=` in `parallel_search_replace.gobra`