### PR TITLE
Implicit Unqualified Imports

### DIFF
--- a/src/main/resources/README.md
+++ b/src/main/resources/README.md
@@ -1,6 +1,10 @@
 # Resources
 This folder contains resources that are included in the Gobra jar file.
 
+## Built-Ins
+The `.gobra` files in the `builtin` folder form a package and thus need to have the same package clause and be located in the top-level directory (i.e. subdirectories are ignored).
+Members declared in these files will be available without any import in the file being verified and can be accessed without qualifier.
+
 ## Stubs
 The `.gobra` files contained in the `stubs` folder are particularly noteworthy:
 Gobra uses them when resolving package imports.

--- a/src/main/resources/builtin/builtin.gobra
+++ b/src/main/resources/builtin/builtin.gobra
@@ -10,3 +10,10 @@ type error interface {
     // currently empty as Gobra does not yet support strings
     // Error() string
 }
+
+// The panic built-in function stops normal execution of the current
+// goroutine. Because Gobra does not support defer statements yet,
+// a panic is modeled as an unrecoverable error in the program and
+// a correct program must never call it.
+requires false
+func panic(v interface{})

--- a/src/main/resources/builtin/error.gobra
+++ b/src/main/resources/builtin/error.gobra
@@ -1,0 +1,9 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package builtin
+
+type error interface {
+    // currently empty as Gobra does not yet support strings
+    // Error() string
+}

--- a/src/main/resources/builtin/error.gobra
+++ b/src/main/resources/builtin/error.gobra
@@ -1,5 +1,8 @@
-// Any copyright is dedicated to the Public Domain.
-// http://creativecommons.org/publicdomain/zero/1.0/
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
 
 package builtin
 

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -16,7 +16,7 @@ import org.rogach.scallop.{ScallopConf, ScallopOption, listArgConverter, singleA
 import org.slf4j.LoggerFactory
 import viper.gobra.backend.{ViperBackend, ViperBackends, ViperVerifierConfig}
 import viper.gobra.GoVerifier
-import viper.gobra.frontend.PackageResolver.FileResource
+import viper.gobra.frontend.PackageResolver.{FileResource, RegularImport}
 import viper.gobra.reporting.{FileWriterReporter, GobraReporter, StdIOReporter}
 import viper.gobra.util.TypeBounds
 
@@ -305,7 +305,7 @@ class ScallopGobraConfig(arguments: Seq[String])
           case Left(_) =>
             for {
               // look for files in the current directory, i.e. use an empty importPath
-              resolvedResources <- PackageResolver.resolve("", includeDirs)
+              resolvedResources <- PackageResolver.resolve(RegularImport(""), includeDirs)
               resolvedFiles = resolvedResources.flatMap({
                 case fileResource: FileResource => Some(fileResource.file)
                 case _ => None

--- a/src/test/resources/regressions/features/errors/bar/bar.gobra
+++ b/src/test/resources/regressions/features/errors/bar/bar.gobra
@@ -1,0 +1,11 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package bar
+
+// redeclare interface error:
+type error interface {
+    // currently empty as Gobra does not yet support strings
+    // Error() string
+    Test() int
+}

--- a/src/test/resources/regressions/features/errors/error-fail1.gobra
+++ b/src/test/resources/regressions/features/errors/error-fail1.gobra
@@ -1,0 +1,12 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// not import
+
+func foo(e error) int {
+    // this does not work since the built-in error interface has not `Test` method:
+    //:: ExpectedOutput(type_error)
+    return e.Test()
+}

--- a/src/test/resources/regressions/features/errors/error-fail2.gobra
+++ b/src/test/resources/regressions/features/errors/error-fail2.gobra
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// ##(-I src/test/resources/regressions/features/errors)
+import . "bar"
+
+func foo(e error) int {
+    // this does not work since Gobra gives higher precedence to the built-in error interface than to the one
+    // declared in package bar
+    // (note that in Go, error in package bar would not be exported as it is starting with a lower case letter)
+    //:: ExpectedOutput(type_error)
+    return e.Test()
+}

--- a/src/test/resources/regressions/features/errors/error-simple1.gobra
+++ b/src/test/resources/regressions/features/errors/error-simple1.gobra
@@ -1,0 +1,23 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+func main() {
+    res, err := test()
+    if err == nil {
+        assert res == 42
+    }
+}
+
+ensures err == nil ==> res == 42
+func test() (res int, err error) {
+    if e := bar(); e != nil {
+        return -1, e
+    }
+    return 42, nil
+}
+
+func bar() error {
+    return nil
+}

--- a/src/test/resources/regressions/features/errors/error-simple2.gobra
+++ b/src/test/resources/regressions/features/errors/error-simple2.gobra
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// redeclare built-in interface error:
+type error interface {
+    Test() int
+}
+
+func foo(e error) int {
+    // this works since Go/Gobra will pick up the error interface declaration in this file
+    return e.Test()
+}

--- a/src/test/resources/regressions/features/errors/error-simple3.gobra
+++ b/src/test/resources/regressions/features/errors/error-simple3.gobra
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// ##(-I src/test/resources/regressions/features/errors)
+import b "bar"
+
+func foo(e b.error) int {
+    // this does work in Gobra since we explicitly specify that the error interface from package bar should be used:
+    // (note that this does not work in Go as error is not exported because it is written with a lower-case letter)
+    return e.Test()
+}


### PR DESCRIPTION
This PR adds the possibility to declare built-in members that will be implicitly and unqualifiedly imported in Gobra files.
For caching reasons, only a single "builtin" package is permitted. However, built-in members can be split across multiple files of said package.
In particular, the `error` interface is added as an empty interface as we do not have support for strings yet.

In addition, this PR fixes some contextual bugs in the desugarer that have lead to crashes when encountering an interface located in an imported package. @Felalolf please have a look at commit 23ddbabfda056b4d07f713e1a9f8d368794869dc.

Fixes #158