### PR TITLE
Removed warnings in main code

### DIFF
--- a/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
@@ -459,7 +459,6 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
     }
 
     case SequenceLit(_, typ, elems) => {
-      val typP = showType(typ)
       val exprsP = braces(space <> showIndexedExprMap(elems) <> (if (elems.nonEmpty) space else emptyDoc))
       "seq" <> brackets(showType(typ)) <+> exprsP
     }

--- a/src/main/scala/viper/gobra/ast/internal/Program.scala
+++ b/src/main/scala/viper/gobra/ast/internal/Program.scala
@@ -20,7 +20,7 @@ import viper.gobra.reporting.Source
 import viper.gobra.reporting.Source.Parser
 import viper.gobra.theory.Addressability
 import viper.gobra.translator.Names
-import viper.gobra.util.{Algorithms, TypeBounds, Violation}
+import viper.gobra.util.{TypeBounds, Violation}
 import viper.gobra.util.TypeBounds.{IntegerKind, UnboundedInteger}
 import viper.gobra.util.Violation.violation
 
@@ -244,7 +244,7 @@ sealed trait Assignee extends Node {
 }
 
 object Assignee {
-  def unapply(x: Assignee): Option[Expr] = Some(x.op)
+  def unapply(x: Assignee): Some[Expr] = Some(x.op)
   def apply(op: Expr): Assignee = op match {
     case op: AssignableVar => Var(op)
     case op: Deref => Pointer(op)
@@ -277,7 +277,7 @@ sealed trait CompositeObject extends Node {
 }
 
 object CompositeObject {
-  def unapply(arg: CompositeObject): Option[CompositeLit] = Some(arg.op)
+  def unapply(arg: CompositeObject): Some[CompositeLit] = Some(arg.op)
 
   case class Array(op : ArrayLit) extends CompositeObject
   case class Slice(op : SliceLit) extends CompositeObject
@@ -844,7 +844,7 @@ sealed abstract class BinaryIntExpr(override val operator: String) extends Binar
 }
 
 object BinaryExpr {
-  def unapply(arg: BinaryExpr): Option[(Expr, String, Expr, Type)] =
+  def unapply(arg: BinaryExpr): Some[(Expr, String, Expr, Type)] =
     Some((arg.left, arg.operator, arg.right, arg.typ))
 }
 
@@ -932,7 +932,7 @@ sealed trait BlockDeclaration extends Declaration
 sealed trait Var extends Expr with Location {
   def id: String
 
-  def unapply(arg: Var): Option[(String, Type)] =
+  def unapply(arg: Var): Some[(String, Type)] =
     Some((arg.id, arg.typ))
 }
 
@@ -952,7 +952,7 @@ sealed trait AssignableVar extends Var
 
 
 sealed trait Parameter extends BodyVar {
-  def unapply(arg: Parameter): Option[(String, Type)] =
+  def unapply(arg: Parameter): Some[(String, Type)] =
     Some((arg.id, arg.typ))
 }
 
@@ -975,7 +975,7 @@ case class BoundVar(id: String, typ: Type)(val info: Source.Parser.Info) extends
 case class LocalVar(id: String, typ: Type)(val info: Source.Parser.Info) extends BodyVar with AssignableVar with BlockDeclaration
 
 sealed trait GlobalConst extends GlobalVar {
-  def unapply(arg: GlobalConst): Option[(String, Type)] =
+  def unapply(arg: GlobalConst): Some[(String, Type)] =
     Some((arg.id, arg.typ))
 }
 

--- a/src/main/scala/viper/gobra/ast/internal/theory/Comparability.scala
+++ b/src/main/scala/viper/gobra/ast/internal/theory/Comparability.scala
@@ -41,6 +41,7 @@ object Comparability {
     case TypeHead.ArrayHD => Kind.Recursive
     case TypeHead.SliceHD => Kind.NonComparable
     case _: TypeHead.InterfaceHD => Kind.Dynamic
+    case TypeHead.ChannelHD => Kind.NonComparable
     case TypeHead.NilHD => Kind.Comparable
     case TypeHead.UnitHD => Kind.Comparable
     case TypeHead.PermHD => Kind.Comparable

--- a/src/main/scala/viper/gobra/ast/internal/theory/TypeHead.scala
+++ b/src/main/scala/viper/gobra/ast/internal/theory/TypeHead.scala
@@ -26,6 +26,7 @@ object TypeHead {
   case object ArrayHD extends TypeHead
   case object SliceHD extends TypeHead
   case class InterfaceHD(name: String) extends TypeHead
+  case object ChannelHD extends TypeHead
   case object NilHD extends TypeHead
   case object UnitHD extends TypeHead
   case object PermHD extends TypeHead
@@ -55,6 +56,7 @@ object TypeHead {
     case t: DefinedT => DefinedHD(t.name)
     case t: StructT => StructHD(t.fields.map(f => (f.name, f.ghost)))
     case t: InterfaceT => InterfaceHD(t.name)
+    case _: ChannelT => ChannelHD
     case VoidT => UnitHD
     case _: PermissionT => PermHD
     case SortT => SortHD
@@ -76,6 +78,7 @@ object TypeHead {
     case _: DefinedT => Vector.empty
     case t: StructT => t.fields.map(_.typ)
     case _: InterfaceT => Vector.empty
+    case t: ChannelT => Vector(t.elem)
     case VoidT => Vector.empty
     case _: PermissionT => Vector.empty
     case SortT => Vector.empty
@@ -133,6 +136,7 @@ object TypeHead {
     case ArrayHD => 1
     case SliceHD => 1
     case _: InterfaceHD => 0
+    case ChannelHD => 1
     case NilHD => 0
     case UnitHD => 0
     case PermHD => 0

--- a/src/main/scala/viper/gobra/ast/internal/transform/OverflowChecksTransform.scala
+++ b/src/main/scala/viper/gobra/ast/internal/transform/OverflowChecksTransform.scala
@@ -111,6 +111,9 @@ object OverflowChecksTransform extends InternalTransform {
     case m@GoMethodCall(recv, _, args) =>
       Seqn(genOverflowChecksExprs(recv +: args) :+ m)(m.info)
 
+    case m@Send(_, expr, _, _, _) =>
+      Seqn(genOverflowChecksExprs(Vector(expr)) :+ m)(m.info)
+
     case m@MakeSlice(_, _, arg1, optArg2) =>
       Seqn(genOverflowChecksExprs(arg1 +: optArg2.toVector) :+ m)(m.info)
 
@@ -121,7 +124,9 @@ object OverflowChecksTransform extends InternalTransform {
       Seqn(genOverflowChecksExprs(optArg.toVector) :+ m)(m.info)
 
     // explicitly matches remaining statements to detect non-exhaustive pattern matching if a new statement is added
-    case x@(_: Inhale | _: Exhale | _: Assert | _: Assume | _: Return | _: Fold | _: Unfold | _: SafeTypeAssertion) => x
+    case x@(_: Inhale | _: Exhale | _: Assert | _: Assume
+            | _: Return | _: Fold | _: Unfold | _: PredExprFold | _: PredExprUnfold
+            | _: SafeTypeAssertion | _: SafeReceive) => x
   }
 
   private def genOverflowChecksExprs(exprs: Vector[Expr]): Vector[Assert] =

--- a/src/main/scala/viper/gobra/ast/internal/utility/Nodes.scala
+++ b/src/main/scala/viper/gobra/ast/internal/utility/Nodes.scala
@@ -34,7 +34,7 @@ object Nodes {
       case MPredicate(recv, name, args, body) => Seq(recv, name) ++ args ++ body
       case MethodSubtypeProof(subProxy, _, superProxy, rec, args, res, b) => Seq(subProxy, superProxy, rec) ++ args ++ res ++ b
       case PureMethodSubtypeProof(subProxy, _, superProxy, rec, args, res, b) => Seq(subProxy, superProxy, rec) ++ args ++ res ++ b
-      case Field(_, _, _) => Seq()
+      case Field(_, _, _) => Seq.empty
       case s: Stmt => s match {
         case Block(decls, stmts) => decls ++ stmts
         case Seqn(stmts) => stmts
@@ -47,7 +47,7 @@ object Nodes {
         case SingleAss(left, right) => Seq(left, right)
         case FunctionCall(targets, func, args) => targets ++ Seq(func) ++ args
         case MethodCall(targets, recv, meth, args) => targets ++ Seq(recv, meth) ++ args
-        case Return() => Seq()
+        case Return() => Seq.empty
         case Assert(ass) => Seq(ass)
         case Exhale(ass) => Seq(ass)
         case Inhale(ass) => Seq(ass)
@@ -57,6 +57,12 @@ object Nodes {
         case PredExprFold(base, args, p) => Seq(base) ++ args ++ Seq(p)
         case PredExprUnfold(base, args, p) => Seq(base) ++ args ++ Seq(p)
         case SafeTypeAssertion(resTarget, successTarget, expr, _) => Seq(resTarget, successTarget, expr)
+        case GoFunctionCall(func, args) => Seq(func) ++ args
+        case GoMethodCall(recv, meth, args) => Seq(recv, meth) ++ args
+        case SafeReceive(resTarget, successTarget, channel, recvChannel, recvGivenPerm, recvGotPerm, closed) =>
+          Seq(resTarget, successTarget, channel, recvChannel, recvGivenPerm, recvGotPerm, closed)
+        case Send(channel, expr, sendChannel, sendGivenPerm, sendGotPerm) =>
+          Seq(channel, expr, sendChannel, sendGivenPerm, sendGotPerm)
       }
       case a: Assignee => Seq(a.op)
       case a: Assertion => a match {
@@ -78,7 +84,7 @@ object Nodes {
         case PureFunctionCall(func, args, _) => Seq(func) ++ args
         case PureMethodCall(recv, meth, args, _) => Seq(recv, meth) ++ args
         case Conversion(_, expr) => Seq(expr)
-        case DfltVal(_) => Seq()
+        case DfltVal(_) => Seq.empty
         case Tuple(args) => args
         case Deref(exp, _) => Seq(exp)
         case Ref(ref, _) => Seq(ref)
@@ -90,11 +96,11 @@ object Nodes {
         case IsComparableInterface(exp) => Seq(exp)
         case ToInterface(exp, _) => Seq(exp)
         case IsBehaviouralSubtype(left, right) => Seq(left, right)
-        case BoolTExpr() => Seq()
-        case IntTExpr(_) => Seq()
-        case PermTExpr() => Seq()
+        case BoolTExpr() => Seq.empty
+        case IntTExpr(_) => Seq.empty
+        case PermTExpr() => Seq.empty
         case PointerTExpr(elem) => Seq(elem)
-        case StructTExpr(_) => Seq()
+        case StructTExpr(_) => Seq.empty
         case ArrayTExpr(len, elem) => Seq(len, elem)
         case SliceTExpr(elem) => Seq(elem)
         case SequenceTExpr(elem) => Seq(elem)
@@ -102,7 +108,7 @@ object Nodes {
         case MultisetTExpr(elem) => Seq(elem)
         case OptionTExpr(elem) => Seq(elem)
         case TupleTExpr(elem) => elem
-        case DefinedTExpr(_) => Seq()
+        case DefinedTExpr(_) => Seq.empty
         case PredicateConstructor(pred, _, args) => Seq(pred) ++ args.flatten
         case IndexedExp(base, idx) => Seq(base, idx)
         case ArrayUpdate(base, left, right) => Seq(base, left, right)
@@ -117,26 +123,26 @@ object Nodes {
         case MultisetConversion(expr) => Seq(expr)
         case Length(expr) => Seq(expr)
         case Capacity(expr) => Seq(expr)
-        case OptionNone(_) => Seq()
+        case OptionNone(_) => Seq.empty
         case OptionSome(exp) => Seq(exp)
         case OptionGet(exp) => Seq(exp)
         case Negation(operand) => Seq(operand)
+        case Receive(channel, recvChannel, recvGivenPerm, recvGotPerm) => Seq(channel, recvChannel, recvGivenPerm, recvGotPerm)
         case BinaryExpr(left, _, right, _) => Seq(left, right)
-        case EqCmp(l, r) => Seq(l, r)
         case Old(op, _) => Seq(op)
         case Conditional(cond, thn, els, _) => Seq(cond, thn, els)
         case PureForall(vars, triggers, body) => vars ++ triggers ++ Seq(body)
         case Exists(vars, triggers, body) => vars ++ triggers ++ Seq(body)
         case p: Permission => p match {
-          case _: FullPerm => Seq()
-          case _: NoPerm => Seq()
+          case _: FullPerm => Seq.empty
+          case _: NoPerm => Seq.empty
           case FractionalPerm(left, right) => Seq(left, right)
-          case _: WildcardPerm => Seq()
+          case _: WildcardPerm => Seq.empty
         }
         case l: Lit => l match {
-          case IntLit(_, _) => Seq()
-          case BoolLit(_) => Seq()
-          case NilLit(_) => Seq()
+          case IntLit(_, _) => Seq.empty
+          case BoolLit(_) => Seq.empty
+          case NilLit(_) => Seq.empty
           case ArrayLit(_, _, elems) => elems.values.toSeq
           case SliceLit(_, elems) => elems.values.toSeq
           case StructLit(_, args) => args
@@ -144,18 +150,19 @@ object Nodes {
           case SetLit(_, args) => args
           case MultisetLit(_, args) => args
         }
-        case Parameter.In(_, _) => Seq()
-        case Parameter.Out(_, _) => Seq()
-        case LocalVar(_, _) => Seq()
-        case GlobalConst.Val(_, _) => Seq()
+        case Parameter.In(_, _) => Seq.empty
+        case Parameter.Out(_, _) => Seq.empty
+        case LocalVar(_, _) => Seq.empty
+        case GlobalConst.Val(_, _) => Seq.empty
+        case _: BoundVar => Seq.empty
       }
       case Trigger(exprs) => exprs
       case a: Addressable => Seq(a.op)
       case p: Proxy => p match {
-        case FunctionProxy(_) => Seq()
-        case MethodProxy(_, _) => Seq()
-        case FPredicateProxy(_) => Seq()
-        case MPredicateProxy(_, _) => Seq()
+        case FunctionProxy(_) => Seq.empty
+        case MethodProxy(_, _) => Seq.empty
+        case FPredicateProxy(_) => Seq.empty
+        case MPredicateProxy(_, _) => Seq.empty
       }
     }
 //    n match {

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -18,7 +18,7 @@ import viper.gobra.backend.{ViperBackend, ViperBackends, ViperVerifierConfig}
 import viper.gobra.GoVerifier
 import viper.gobra.frontend.PackageResolver.{FileResource, RegularImport}
 import viper.gobra.reporting.{FileWriterReporter, GobraReporter, StdIOReporter}
-import viper.gobra.util.TypeBounds
+import viper.gobra.util.{TypeBounds, Violation}
 
 
 object LoggerDefaults {
@@ -294,6 +294,7 @@ class ScallopGobraConfig(arguments: Seq[String])
         case (pkgs, files) if pkgs.nonEmpty && files.nonEmpty =>
           message(pkgs, s"specific input files and one or more package names were simultaneously provided (files: '${concatRight(files, ",")}'; package names: '${concatLeft(pkgs, ",")}')")
         case (pkgs, files) if pkgs.isEmpty && files.isEmpty => message(null, s"no input specified")
+        case c => Violation.violation(s"This case should be unreachable, but got $c")
       }
     }
 

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -15,7 +15,7 @@ import org.bitbucket.inkytonik.kiama.util.{FileSource, Filenames, IO, Positions,
 import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, message}
 import viper.gobra.ast.frontend._
 import viper.gobra.reporting.{ParsedInputMessage, ParserError, ParserErrorMessage, PreprocessedInputMessage, VerifierError}
-import viper.gobra.util.Constants
+import viper.gobra.util.{Constants, Violation}
 
 import scala.io.BufferedSource
 import scala.util.matching.Regex
@@ -91,6 +91,8 @@ object Parser {
           }
 
           Left(errors)
+
+        case c => Violation.violation(s"This case should be unreachable, but got $c")
       }
     }
 
@@ -174,6 +176,8 @@ object Parser {
         pom.positions.setStart(ns, pos)
         pom.positions.setFinish(ns, pos)
         Left(message(ns, label))
+
+      case c => Violation.violation(s"This case should be unreachable, but got $c")
     }
   }
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Addressability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Addressability.scala
@@ -83,6 +83,8 @@ trait Addressability extends BaseProperty { this: TypeInfoImpl =>
       case _: PReference => AddrMod.reference
       case _: PNegation => AddrMod.rValue
       case _: PBinaryExp[_,_] => AddrMod.rValue
+      case _: PPermission => AddrMod.rValue
+      case _: PPredConstructor => AddrMod.rValue
       case n: PUnfolding => AddrMod.unfolding(addressability(n.op))
       case _: POld => AddrMod.old
       case _: PConditional | _: PImplication | _: PForall | _: PExists => AddrMod.rValue
@@ -93,8 +95,7 @@ trait Addressability extends BaseProperty { this: TypeInfoImpl =>
            _: PSetMinus | _: PSubset => AddrMod.rValue
       case _: POptionNone | _: POptionSome | _: POptionGet => AddrMod.rValue
       case _: PSetConversion | _: PMultisetConversion | _: PSequenceConversion => AddrMod.conversionResult
-      case _: PMake => AddrMod.make
-
+      case _: PMake | _: PNew => AddrMod.make
     }
 
   def addressabilityMemberPath(base: AddrMod, path: Vector[MemberPath]): AddrMod = {

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Executability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Executability.scala
@@ -23,7 +23,7 @@ trait Executability extends BaseProperty { this: TypeInfoImpl =>
 
   // TODO: probably will be unneccessary because build int functions always have to be called
 
-  private lazy val isBuildIn: Property[PExpression] = createBinaryProperty("built-in") {
+  lazy val isBuildIn: Property[PExpression] = createBinaryProperty("built-in") {
     case _: PBuildIn => true
     case _ => false
   }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/UnderlyingType.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/UnderlyingType.scala
@@ -176,5 +176,6 @@ trait UnderlyingType { this: TypeInfoImpl =>
   lazy val isReceiverType: Property[Type] = createBinaryProperty("not a receiver type") {
     case _: DeclaredT => true
     case PointerT(t) => t.isInstanceOf[DeclaredT]
+    case _ => false
   }
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
@@ -218,6 +218,7 @@ trait IdTyping extends BaseTyping { this: TypeInfoImpl =>
         case PConstDecl(typ, right, left) => typ.map(symbType).getOrElse(getBlankAssigneeType(w, left, right))
         case _ => ???
       }
+      case _ => ???
     }
   }
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/MiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/MiscTyping.scala
@@ -103,6 +103,8 @@ trait MiscTyping extends BaseTyping { this: TypeInfoImpl =>
       }
 
       case tree.parent.pair(_: PCompositeVal, ke: PKeyedElement) => expectedMiscType(ke)
+
+      case c => Violation.violation(s"This case should be unreachable, but got $c")
     }
 
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -16,6 +16,8 @@ import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.frontend.info.implementation.typing.BaseTyping
 import viper.gobra.util.Violation.violation
 
+import scala.annotation.unused
+
 trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
 
   private[typing] def wellDefGhostExpr(expr: PGhostExpression): Messages = expr match {
@@ -268,7 +270,7 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
     * @param strong If `true`, then `isPure` tests for strong purity;
     *               otherwise for weak purity. (Is `true`` by default.)
     */
-  private def isPure(expr : PExpression)(strong : Boolean = true) : Boolean = {
+  private def isPure(expr : PExpression)(strong : Boolean) : Boolean = {
     def go(e : PExpression) = isPure(e)(strong)
 
     expr match {
@@ -352,6 +354,8 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
 
       case PIndexedExp(base, index) => Seq(base, index).forall(go)
 
+      case _: PMake | _: PNew => false
+
       // Might change as some point
       case _: PFunctionLit => false
 
@@ -362,8 +366,6 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
         case PFractionalPerm(left, right) => go(left) && go(right)
         case _ => true
       }
-
-      case PPredConstructor(_, args) => args.flatten.forall(go)
     }
   }
 
@@ -441,6 +443,7 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
     * @param trigger The trigger to be tested for validity and consistency.
     * @return True if  `trigger` is a valid and consistent trigger.
     */
+  @unused
   private def validTrigger(boundVars: Vector[PBoundVariable], trigger : PTrigger) : Messages = {
     // [validity] check whether all expressions in `trigger` are valid trigger expressions
     val (usedVars, msgs1) = combineTriggerResults(trigger.exps.map(validTriggerPattern))
@@ -459,7 +462,7 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
     * @param triggers The sequence of triggers to be tested for validity.
     * @return True if `triggers` is a valid sequence of triggers.
     */
-  private def validTriggers(vars: Vector[PBoundVariable], triggers : Vector[PTrigger]) : Messages = {
+  private def validTriggers(@unused vars: Vector[PBoundVariable], @unused triggers: Vector[PTrigger]) : Messages = {
     // TODO: As a temporary workaround, the validity checks for triggers are disabled because they are too restrictive.
     //       We should either extend the validity checks or, somehow, defer that task to Viper
     // triggers.flatMap(validTrigger(vars, _))

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostIdTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostIdTyping.scala
@@ -13,17 +13,19 @@ import viper.gobra.frontend.info.base.Type.{AssertionT, FunctionT, Type}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.util.Violation.violation
 
+import scala.annotation.unused
+
 trait GhostIdTyping { this: TypeInfoImpl =>
 
-  private[typing] def wellDefGhostRegular(entity: GhostRegular, id: PIdnNode): ValidityMessages = entity match {
+  private[typing] def wellDefGhostRegular(entity: GhostRegular, @unused id: PIdnNode): ValidityMessages = entity match {
     case _: BoundVariable => LocalMessages(noMessages)
     case predicate: Predicate => unsafeMessage(! {
       predicate.args.forall(wellDefMisc.valid)
     })
-
+    case _: BuiltInFPredicate | _: BuiltInMPredicate => LocalMessages(noMessages)
   }
 
-  private[typing] def ghostEntityType(entity: GhostRegular, id: PIdnNode): Type = entity match {
+  private[typing] def ghostEntityType(entity: GhostRegular, @unused id: PIdnNode): Type = entity match {
 
     case x: BoundVariable => typeSymbType(x.decl.typ)
     case predicate: Predicate => FunctionT(predicate.args map predicate.context.typ, AssertionT)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
@@ -57,6 +57,8 @@ trait GhostWellDef { this: TypeInfoImpl =>
       error(stmt, "ghost error: Found ghost child expression but expected none", ghostChildFound.exists(p => !p))
     }
 
+    case m: PMember => memberGhostSeparation(m)
+
     case _: PLabeledStmt
       |  _: PEmptyStmt
       |  _: PBlock

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
@@ -44,7 +44,6 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
   private val ghost_parameters: String = "ghost-parameters:"
   private val ghost_results: String = "ghost-results:"
   private val addressable_variables: String = "addressable:"
-  private val predicate_access: String = "predicate-access:"
   private val with_keyword: String = "with:"
   private val unfolding_keyword: String = "unfolding:"
 

--- a/src/main/scala/viper/gobra/reporting/BackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/BackTranslator.scala
@@ -10,6 +10,8 @@ import viper.gobra.frontend.Config
 import viper.silver.{ast => vpr}
 import viper.silver
 
+import scala.annotation.unused
+
 object BackTranslator {
 
   trait ErrorBackTranslator {
@@ -25,7 +27,7 @@ object BackTranslator {
   type ErrorTransformer = PartialFunction[silver.verifier.VerificationError, VerificationError]
   type ReasonTransformer = PartialFunction[silver.verifier.ErrorReason, VerificationErrorReason]
 
-  def backTranslate(result: BackendVerifier.Result)(config: Config): VerifierResult = result match {
+  def backTranslate(result: BackendVerifier.Result)(@unused config: Config): VerifierResult = result match {
     case BackendVerifier.Success => VerifierResult.Success
     case BackendVerifier.Failure(errors, backtrack) =>
       val errorTranslator = new DefaultErrorBackTranslator(backtrack)

--- a/src/main/scala/viper/gobra/translator/encodings/EmbeddingComponent.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/EmbeddingComponent.scala
@@ -15,7 +15,7 @@ import viper.silver.{ast => vpr}
   * Creates an embedded type E that is made up of all elements of 't' that satisfy 'p',
   * where 't' and 'p' are parametrized by an instance of P.
   */
-abstract class EmbeddingComponent[P](p: (vpr.Exp, P) => Context => vpr.Exp, t: P => Context => vpr.Type) extends Generator {
+trait EmbeddingComponent[P] extends Generator {
 
   /** Returns the embedded type E. */
   def typ(id: P)(ctx: Context): vpr.Type
@@ -30,7 +30,7 @@ abstract class EmbeddingComponent[P](p: (vpr.Exp, P) => Context => vpr.Exp, t: P
 
 object EmbeddingComponent {
 
-  class Impl[P](p: (vpr.Exp, P) => Context => vpr.Exp, t: P => Context => vpr.Type) extends EmbeddingComponent[P](p, t) {
+  class Impl[P](p: (vpr.Exp, P) => Context => vpr.Exp, t: P => Context => vpr.Type) extends EmbeddingComponent[P] {
 
     override def finalize(col: Collector): Unit = {
       generatedMember foreach col.addMember

--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
@@ -255,7 +255,7 @@ class InterfaceEncoding extends LeafTypeEncoding {
   }
 
   /** returns dynamic type of an interface expression. */
-  private def typeOfWithSubtypeFact(arg: vpr.Exp, itfT: in.InterfaceT)(pos: vpr.Position = vpr.NoPosition, info: vpr.Info = vpr.NoInfo, errT: vpr.ErrorTrafo = vpr.NoTrafos)(ctx: Context): vpr.Exp = {
+  private def typeOfWithSubtypeFact(arg: vpr.Exp, itfT: in.InterfaceT)(pos: vpr.Position, info: vpr.Info, errT: vpr.ErrorTrafo)(ctx: Context): vpr.Exp = {
     if (itfT.isEmpty) {
       typeOf(arg)(pos, info, errT)(ctx)
     } else {

--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/TypeComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/TypeComponentImpl.scala
@@ -32,6 +32,7 @@ class TypeComponentImpl extends TypeComponent {
     case PointerHD => "pointer"
     case ArrayHD => "array"
     case SliceHD => "slice"
+    case ChannelHD => "channel"
     case NilHD => "nil"
     case UnitHD => "unit"
     case PermHD => "perm"
@@ -41,6 +42,7 @@ class TypeComponentImpl extends TypeComponent {
     case MSetHD => "mset"
     case OptionHD => "option"
     case t: TupleHD => s"tuple${t.arity}"
+    case t: PredHD => s"pred${t.arity}"
 
     case t: TypeHead.DefinedHD => t.name
     case t: TypeHead.InterfaceHD => t.name

--- a/src/main/scala/viper/gobra/translator/encodings/preds/DefuncComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/preds/DefuncComponentImpl.scala
@@ -114,7 +114,7 @@ class DefuncComponentImpl extends DefuncComponent {
       typ = domainType(S)
     )(domainName = domainName(S))
   }
-  private def makeFuncApp(S: Token, id: BigInt, args: Vector[vpr.Exp])(pos: vpr.Position = vpr.NoPosition, info: vpr.Info = vpr.NoInfo, errT: vpr.ErrorTrafo = vpr.NoTrafos): vpr.DomainFuncApp = {
+  private def makeFuncApp(S: Token, id: BigInt, args: Vector[vpr.Exp])(pos: vpr.Position, info: vpr.Info, errT: vpr.ErrorTrafo): vpr.DomainFuncApp = {
     vpr.DomainFuncApp(func = makeFunc(S, id), args, Map.empty)(pos, info, errT)
   }
 

--- a/src/main/scala/viper/gobra/translator/implementations/components/SlicesImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/SlicesImpl.scala
@@ -206,7 +206,7 @@ class SlicesImpl(val arrays : Arrays) extends Slices {
   )()
 
   /** A function application of "sadd". */
-  private def add(left : vpr.Exp, right : vpr.Exp)(pos : vpr.Position = vpr.NoPosition, info : vpr.Info = vpr.NoInfo, errT : vpr.ErrorTrafo = vpr.NoTrafos) : vpr.FuncApp = {
+  private def add(left : vpr.Exp, right : vpr.Exp)(pos : vpr.Position, info : vpr.Info, errT : vpr.ErrorTrafo) : vpr.FuncApp = {
     generateDomain = true
     vpr.FuncApp(sadd_func.name, Seq(left, right))(pos, info, vpr.Int, errT)
   }

--- a/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
@@ -18,6 +18,7 @@ import viper.gobra.translator.util.PrimitiveGenerator
 import viper.gobra.util.Computation
 import viper.gobra.util.Violation.violation
 
+import scala.annotation.unused
 import scala.language.postfixOps
 
 
@@ -105,6 +106,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
   /**
     * Returns an already existing proxy for a tag or otherwise creates a new proxy and the corresponding member
     */
+  @unused
   private def getOrGenerateFunction(tag: BuiltInFunctionTag, args: Vector[in.Type])(src: Source.Parser.Info)(ctx: Context): in.FunctionProxy = {
     def create(): in.BuiltInFunction = {
       val proxy = in.FunctionProxy(freshNameForTag(tag))(src)
@@ -383,7 +385,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
     }
   }
 
-  private def translateFPredicate(x: in.BuiltInFPredicate)(ctx: Context): in.FPredicate = {
+  private def translateFPredicate(x: in.BuiltInFPredicate)(@unused ctx: Context): in.FPredicate = {
     val src = x.info
     (x.tag, x.argsT) match {
       case (PredTrueFPredTag, args) =>
@@ -403,7 +405,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
     }
   }
 
-  private def translateMPredicate(x: in.BuiltInMPredicate)(ctx: Context): in.MPredicate = {
+  private def translateMPredicate(x: in.BuiltInMPredicate)(@unused ctx: Context): in.MPredicate = {
     val src = x.info
     assert(x.receiverT.addressability == Addressability.inParameter)
     val recvParam = in.Parameter.In("c", x.receiverT)(src)

--- a/src/main/scala/viper/gobra/translator/interfaces/translator/Generator.scala
+++ b/src/main/scala/viper/gobra/translator/interfaces/translator/Generator.scala
@@ -8,12 +8,14 @@ package viper.gobra.translator.interfaces.translator
 
 import viper.gobra.translator.interfaces.{Collector, Context}
 
+import scala.annotation.unused
+
 trait Generator {
 
   /**
     * Finalizes translation. May add to collector.
     */
-  def finalize(col: Collector): Unit = {}
+  def finalize(@unused col: Collector): Unit = {}
 
   def chain[R](fs: Vector[Context => (R, Context)])(ctx: Context): (Vector[R], Context) = {
     fs.foldLeft((Vector.empty[R], ctx)){ case ((rs, c), rf) =>

--- a/src/main/scala/viper/gobra/translator/util/TypePatterns.scala
+++ b/src/main/scala/viper/gobra/translator/util/TypePatterns.scala
@@ -20,12 +20,12 @@ object TypePatterns {
 
   /** Matches every expression and splits it into the expression and its type. */
   object :: {
-    def unapply[T <: in.Expr](arg: T): Option[(T, in.Type)] = Some(arg, arg.typ)
+    def unapply[T <: in.Expr](arg: T): Some[(T, in.Type)] = Some(arg, arg.typ)
   }
 
   /** Matches every type and splits it into the type and its addressability modifier. */
   object / {
-    def unapply[T <: in.Type](arg: T): Option[(T, Addressability)] = Some(arg, arg.addressability)
+    def unapply[T <: in.Type](arg: T): Some[(T, Addressability)] = Some(arg, arg.addressability)
   }
 
   /** Matches every shared type. */

--- a/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
+++ b/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
@@ -340,7 +340,7 @@ object ViperWriter {
       w.copy(newData, codeStmt)
     }
 
-    def seqnUnits(ws: Vector[Writer[Unit]], assume: Boolean = false): Writer[vpr.Seqn] =
+    def seqnUnits(ws: Vector[Writer[Unit]]): Writer[vpr.Seqn] =
       sequence(ws.map(seqnUnit)).map(vpr.Seqn(_, Vector.empty)())
 
     def seqnUnit(w: Writer[Unit]): Writer[vpr.Seqn] = {


### PR DESCRIPTION
As the title states, the main scala files should not produce warnings anymore.
From now on, we should use `@unused` where necesarry.