### PR TITLE
Fix issue 225

### DIFF
--- a/.github/license-check/config.json
+++ b/.github/license-check/config.json
@@ -53,7 +53,14 @@
       "project/project/**",
       "project/target/**",
       "target/**",
-      "src/main/**"
+      "src/main/**",
+      "src/test/resources/regressions/issues/windows-line-ending/**"
+    ],
+    "license": "./.github/license-check/headers/CC0.txt"
+  },
+  {
+    "include": [
+      "src/test/resources/regressions/issues/windows-line-ending/*.gobra"
     ],
     "license": "./.github/license-check/headers/CC0.txt"
   },

--- a/.github/license-check/config.json
+++ b/.github/license-check/config.json
@@ -62,7 +62,7 @@
     "include": [
       "src/test/resources/regressions/issues/windows-line-ending/*.gobra"
     ],
-    "license": "./.github/license-check/headers/CC0.txt"
+    "license": "./.github/license-check/headers/CC0-Windows.txt"
   },
   {
     "include": [

--- a/.github/license-check/headers/CC0-Windows.txt
+++ b/.github/license-check/headers/CC0-Windows.txt
@@ -1,0 +1,2 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -222,7 +222,7 @@ object Parser {
       val r = s"($finalTokenRequiringSemicolon)((?:$ignoreComments|$ignoreWhitespace)*)$$".r
       // group(1) contains the finalTokenRequiringSemicolon after which a semicolon should be inserted
       // group(2) contains the line's remainder after finalTokenRequiringSemicolon
-      r.replaceAllIn(line, m => StringEscapeUtils.escapeJava(m.group(1) ++ ";" ++ m.group(2)))
+      r.replaceAllIn(line, m => m.group(1) ++ ";" ++ m.group(2))
     }
   }
 
@@ -855,11 +855,10 @@ object Parser {
         "false" ^^^ PBoolLit(false) |
         "nil" ^^^ PNilLit() |
         regex("[0-9]+".r) ^^ (lit => PIntLit(BigInt(lit))) |
-        //runeLit |
         stringLit
 
     lazy val stringLit: Parser[PStringLit] =
-      rawStringLit | interpretedStringLit
+      (rawStringLit | interpretedStringLit) ^^ (strLit => PStringLit(StringEscapeUtils.escapeJava(strLit.lit)))
 
     lazy val rawStringLit: Parser[PStringLit] =
       // unicode characters and newlines are allowed

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -199,7 +199,7 @@ object Parser {
     }
 
     private def translate(content: String): String =
-      content.split("\n").map(translateLine).mkString("\n") ++ "\n"
+      content.split("\r\n|\n").map(translateLine).mkString("\n") ++ "\n"
 
     private def translateLine(line: String): String = {
       val identifier = """[a-zA-Z_][a-zA-Z0-9_]*"""
@@ -222,7 +222,7 @@ object Parser {
       val r = s"($finalTokenRequiringSemicolon)((?:$ignoreComments|$ignoreWhitespace)*)$$".r
       // group(1) contains the finalTokenRequiringSemicolon after which a semicolon should be inserted
       // group(2) contains the line's remainder after finalTokenRequiringSemicolon
-      r.replaceAllIn(line, m => m.group(1) ++ ";" ++ m.group(2))
+      r.replaceAllIn(line, m => StringEscapeUtils.escapeJava(m.group(1) ++ ";" ++ m.group(2)))
     }
   }
 
@@ -858,7 +858,7 @@ object Parser {
         stringLit
 
     lazy val stringLit: Parser[PStringLit] =
-      (rawStringLit | interpretedStringLit) ^^ (strLit => PStringLit(StringEscapeUtils.escapeJava(strLit.lit)))
+      rawStringLit | interpretedStringLit
 
     lazy val rawStringLit: Parser[PStringLit] =
       // unicode characters and newlines are allowed

--- a/src/test/resources/regressions/issues/000225.gobra
+++ b/src/test/resources/regressions/issues/000225.gobra
@@ -1,0 +1,4 @@
+package main
+
+ghost
+func f()

--- a/src/test/resources/regressions/issues/000225.gobra
+++ b/src/test/resources/regressions/issues/000225.gobra
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 package main
 
 ghost

--- a/src/test/resources/regressions/issues/windows-line-ending/000225.gobra
+++ b/src/test/resources/regressions/issues/windows-line-ending/000225.gobra
@@ -1,6 +1,7 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
+// This file uses the windows line endings (`\r\n`)
 package main
 
 ghost


### PR DESCRIPTION
Fixes issue #225. The parsing bug was caused by the introduction of the following line in a previous commit
```scala
r.replaceAllIn(line, m => StringEscapeUtils.escapeJava(m.group(1) ++ ";" ++ m.group(2)))
```
My understanding is that this causes `CR` characters to be escaped when they appear at the end of a line (e.g. in files created on a Windows machine).

This PR solves the issue by splitting lines on "\r\n|\n" whereas they were previously split only on "\n", which removes the occurrences of "\r\n" before parsing the contents of string literals.