### PR TITLE
Add more stubs

### DIFF
--- a/src/main/resources/stubs/encoding/binary/binary.gobra
+++ b/src/main/resources/stubs/encoding/binary/binary.gobra
@@ -1,0 +1,215 @@
+package binary
+
+// A ByteOrder specifies how to convert byte sequences into
+// 16-, 32-, or 64-bit unsigned integers.
+type ByteOrder interface {
+    requires acc(&b[0], _) && acc(&b[1], _)
+	pure Uint16(b []byte) uint16
+
+    requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
+	pure Uint32(b []byte) uint32
+
+    requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
+    requires acc(&b[4], _) && acc(&b[5], _) && acc(&b[6], _) && acc(&b[7], _)
+	pure Uint64(b []byte) uint64
+
+    requires acc(&b[0]) && acc(&b[1])
+    ensures acc(&b[0]) && acc(&b[1])
+	PutUint16(b []byte, uint16)
+
+    requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+    ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+	PutUint32(b []byte, uint32)
+
+    requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+    requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+    ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+    ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+	PutUint64(b []byte, uint64)
+
+	// String() string // TODO: no support for string types
+}
+
+// Original implementation of BigEndian and LittleEndian. Changed due to lack of support
+// for global vars
+// var LittleEndian littleEndian
+// var BigEndian bigEndian
+// type littleEndian struct{}
+// type bigEndian struct{}
+
+type LittleEndian struct{}
+type BigEndian struct{}
+
+LittleEndian implements ByteOrder {
+    pure (e LittleEndian) Uint16(b []byte) uint16 {
+        return e.Uint16(b)
+    }
+
+    pure (e LittleEndian) Uint32(b []byte) uint32 {
+        return e.Uint32(b)
+    }
+
+    pure (e LittleEndian) Uint64(b []byte) uint64 {
+        return e.Uint64(b)
+    }
+
+	(e LittleEndian) PutUint16(b []byte, v uint16) {
+        e.PutUint16(b, v)
+    }
+
+	(e LittleEndian) PutUint32(b []byte, v uint32) {
+        e.PutUint32(b, v)
+    }
+
+	(e LittleEndian) PutUint64(b []byte, v uint64) {
+        e.PutUint64(b, v)
+    }
+}
+
+BigEndian implements ByteOrder {
+    pure (e BigEndian) Uint16(b []byte) uint16 {
+        return e.Uint16(b)
+    }
+
+    pure (e BigEndian) Uint32(b []byte) uint32 {
+        return e.Uint32(b)
+    }
+
+    pure (e BigEndian) Uint64(b []byte) uint64 {
+        return e.Uint64(b)
+    }
+
+	(e BigEndian) PutUint16(b []byte, v uint16) {
+        e.PutUint16(b, v)
+    }
+
+	(e BigEndian) PutUint32(b []byte, v uint32) {
+        e.PutUint32(b, v)
+    }
+
+	(e BigEndian) PutUint64(b []byte, v uint64) {
+        e.PutUint64(b, v)
+    }
+}
+
+
+requires acc(&b[0], _) && acc(&b[1], _)
+pure func (e LittleEndian) Uint16(b []byte) uint16 /*{
+	return uint16(b[0]) | uint16(b[1])<<8
+}*/
+
+
+requires acc(&b[0]) && acc(&b[1])
+ensures acc(&b[0]) && acc(&b[1])
+func (e LittleEndian) PutUint16(b []byte, v uint16) /*{
+	b[0] = byte(v)
+	b[1] = byte(v >> 8)
+}*/
+
+requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
+pure func (e LittleEndian) Uint32(b []byte) uint32 /*{
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}*/
+
+requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+func (e LittleEndian) PutUint32(b []byte, v uint32) /* {
+	b[0] = byte(v)
+	b[1] = byte(v >> 8)
+	b[2] = byte(v >> 16)
+	b[3] = byte(v >> 24)
+}*/
+
+requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
+requires acc(&b[4], _) && acc(&b[5], _) && acc(&b[6], _) && acc(&b[7], _)
+pure func (e LittleEndian) Uint64(b []byte) uint64 /*{
+	return uint64(b[0]) | uint64(b[1])<<8 | uint64(b[2])<<16 | uint64(b[3])<<24 |
+		uint64(b[4])<<32 | uint64(b[5])<<40 | uint64(b[6])<<48 | uint64(b[7])<<56
+}*/
+
+requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+func (e LittleEndian) PutUint64(b []byte, v uint64) /*{
+	b[0] = byte(v)
+	b[1] = byte(v >> 8)
+	b[2] = byte(v >> 16)
+	b[3] = byte(v >> 24)
+	b[4] = byte(v >> 32)
+	b[5] = byte(v >> 40)
+	b[6] = byte(v >> 48)
+	b[7] = byte(v >> 56)
+}*/
+
+// No support for the string type
+// func (LittleEndian) String() string { return "LittleEndian" }
+// func (LittleEndian) GoString() string { return "binary.LittleEndian" }
+
+requires acc(&b[0], _) && acc(&b[1], _)
+pure func (e BigEndian) Uint16(b []byte) uint16 /*{
+	return uint16(b[1]) | uint16(b[0])<<8
+}*/
+
+requires acc(&b[0]) && acc(&b[1])
+ensures acc(&b[0]) && acc(&b[1])
+func (e BigEndian) PutUint16(b []byte, v uint16) /*{
+	b[0] = byte(v >> 8)
+	b[1] = byte(v)
+}*/
+
+requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
+pure func (e BigEndian) Uint32(b []byte) uint32 /*{
+	return uint32(b[3]) | uint32(b[2])<<8 | uint32(b[1])<<16 | uint32(b[0])<<24
+}*/
+
+
+requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+func (e BigEndian) PutUint32(b []byte, v uint32) /*{
+	b[0] = byte(v >> 24)
+	b[1] = byte(v >> 16)
+	b[2] = byte(v >> 8)
+	b[3] = byte(v)
+}*/
+
+requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
+requires acc(&b[4], _) && acc(&b[5], _) && acc(&b[6], _) && acc(&b[7], _)
+pure func (e BigEndian) Uint64(b []byte) uint64 /*{
+	return uint64(b[7]) | uint64(b[6])<<8 | uint64(b[5])<<16 | uint64(b[4])<<24 |
+		uint64(b[3])<<32 | uint64(b[2])<<40 | uint64(b[1])<<48 | uint64(b[0])<<56
+}*/
+
+requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+func (e BigEndian) PutUint64(b []byte, v uint64) /*{
+	b[0] = byte(v >> 56)
+	b[1] = byte(v >> 48)
+	b[2] = byte(v >> 40)
+	b[3] = byte(v >> 32)
+	b[4] = byte(v >> 24)
+	b[5] = byte(v >> 16)
+	b[6] = byte(v >> 8)
+	b[7] = byte(v)
+}*/
+
+// No support for the string type
+// func (BigEndian) String() string { return "BigEndian" }
+// func (BigEndian) GoString() string { return "binary.BigEndian" }
+
+// Read reads structured binary data from r into data.
+// TODO: no support for io.Reader
+// func Read(r io.Reader, order ByteOrder, data interface{}) error
+
+// Write writes the binary representation of data into w.
+// TODO: no support for io.Write
+// func Write(w io.Writer, order ByteOrder, data interface{}) error
+
+// Size returns how many bytes Write would generate to encode the value v, which
+// must be a fixed-size value or a slice of fixed-size values, or a pointer to such data.
+// If v is neither of these, Size returns -1.
+func Size(v interface{}) int /*{
+	return dataSize(reflect.Indirect(reflect.ValueOf(v)))
+}*/

--- a/src/main/resources/stubs/encoding/binary/binary.gobra
+++ b/src/main/resources/stubs/encoding/binary/binary.gobra
@@ -1,8 +1,6 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-//
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in https://golang.org/LICENSE
 
 // Signatures for the public declarations in file
 // https://github.com/golang/go/blob/master/src/encoding/binary/binary.gobra
@@ -153,9 +151,8 @@ func (e LittleEndian) PutUint64(b []byte, v uint64) /*{
 	b[7] = byte(v >> 56)
 }*/
 
-// No support for the string type
-// func (LittleEndian) String() string { return "LittleEndian" }
-// func (LittleEndian) GoString() string { return "binary.LittleEndian" }
+func (LittleEndian) String() string { return "LittleEndian" }
+func (LittleEndian) GoString() string { return "binary.LittleEndian" }
 
 requires acc(&b[0], _) && acc(&b[1], _)
 pure func (e BigEndian) Uint16(b []byte) uint16 /*{
@@ -206,9 +203,8 @@ func (e BigEndian) PutUint64(b []byte, v uint64) /*{
 	b[7] = byte(v)
 }*/
 
-// No support for the string type
-// func (BigEndian) String() string { return "BigEndian" }
-// func (BigEndian) GoString() string { return "binary.BigEndian" }
+func (BigEndian) String() string { return "BigEndian" }
+func (BigEndian) GoString() string { return "binary.BigEndian" }
 
 // Read reads structured binary data from r into data.
 // TODO: no support for io.Reader

--- a/src/main/resources/stubs/encoding/binary/binary.gobra
+++ b/src/main/resources/stubs/encoding/binary/binary.gobra
@@ -49,6 +49,7 @@ type ByteOrder interface {
 type LittleEndian struct{}
 type BigEndian struct{}
 
+/*
 LittleEndian implements ByteOrder {
     pure (e LittleEndian) Uint16(b []byte) uint16 {
         return e.Uint16(b)
@@ -74,6 +75,7 @@ LittleEndian implements ByteOrder {
         e.PutUint64(b, v)
     }
 }
+*/
 
 BigEndian implements ByteOrder {
     pure (e BigEndian) Uint16(b []byte) uint16 {

--- a/src/main/resources/stubs/encoding/binary/binary.gobra
+++ b/src/main/resources/stubs/encoding/binary/binary.gobra
@@ -10,34 +10,34 @@ package binary
 // A ByteOrder specifies how to convert byte sequences into
 // 16-, 32-, or 64-bit unsigned integers.
 type ByteOrder interface {
-    requires acc(&b[0], _) && acc(&b[1], _)
+	requires acc(&b[0], _) && acc(&b[1], _)
 	pure Uint16(b []byte) uint16
 
-    requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
+	requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
 	pure Uint32(b []byte) uint32
 
-    requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
-    requires acc(&b[4], _) && acc(&b[5], _) && acc(&b[6], _) && acc(&b[7], _)
+	requires acc(&b[0], _) && acc(&b[1], _) && acc(&b[2], _) && acc(&b[3], _)
+	requires acc(&b[4], _) && acc(&b[5], _) && acc(&b[6], _) && acc(&b[7], _)
 	pure Uint64(b []byte) uint64
 
-    requires acc(&b[0]) && acc(&b[1])
-    ensures acc(&b[0]) && acc(&b[1])
+	requires acc(&b[0]) && acc(&b[1])
+	ensures acc(&b[0]) && acc(&b[1])
 	PutUint16(b []byte, uint16)
 
-    requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-    ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+	requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+	ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 	PutUint32(b []byte, uint32)
 
-    requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-    requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
-    ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
-    ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+	requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+	requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+	ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+	ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
 	PutUint64(b []byte, uint64)
 
 	String() string
 }
 
-// Original implementation of BigEndian and LittleEndian. Changed due to lack of support
+// (joao): Original implementation of BigEndian and LittleEndian. Changed due to lack of support
 // for global vars:
 // var LittleEndian littleEndian
 // var BigEndian bigEndian
@@ -54,55 +54,55 @@ type BigEndian struct {
 }
 
 (LittleEndian) implements ByteOrder {
-    pure (e LittleEndian) Uint16(b []byte) uint16 {
-        return e.Uint16(b)
-    }
+	pure (e LittleEndian) Uint16(b []byte) uint16 {
+		return e.Uint16(b)
+	}
 
-    pure (e LittleEndian) Uint32(b []byte) uint32 {
-        return e.Uint32(b)
-    }
+	pure (e LittleEndian) Uint32(b []byte) uint32 {
+		return e.Uint32(b)
+	}
 
-    pure (e LittleEndian) Uint64(b []byte) uint64 {
-        return e.Uint64(b)
-    }
+	pure (e LittleEndian) Uint64(b []byte) uint64 {
+		return e.Uint64(b)
+	}
 
 	(e LittleEndian) PutUint16(b []byte, v uint16) {
-        e.PutUint16(b, v)
-    }
+		e.PutUint16(b, v)
+	}
 
 	(e LittleEndian) PutUint32(b []byte, v uint32) {
-        e.PutUint32(b, v)
-    }
+		e.PutUint32(b, v)
+	}
 
 	(e LittleEndian) PutUint64(b []byte, v uint64) {
-        e.PutUint64(b, v)
-    }
+		e.PutUint64(b, v)
+	}
 }
 
 (BigEndian) implements ByteOrder {
-    pure (e BigEndian) Uint16(b []byte) uint16 {
-        return e.Uint16(b)
-    }
+	pure (e BigEndian) Uint16(b []byte) uint16 {
+		return e.Uint16(b)
+	}
 
-    pure (e BigEndian) Uint32(b []byte) uint32 {
-        return e.Uint32(b)
-    }
+	pure (e BigEndian) Uint32(b []byte) uint32 {
+		return e.Uint32(b)
+	}
 
-    pure (e BigEndian) Uint64(b []byte) uint64 {
-        return e.Uint64(b)
-    }
+	pure (e BigEndian) Uint64(b []byte) uint64 {
+		return e.Uint64(b)
+	}
 
 	(e BigEndian) PutUint16(b []byte, v uint16) {
-        e.PutUint16(b, v)
-    }
+		e.PutUint16(b, v)
+	}
 
 	(e BigEndian) PutUint32(b []byte, v uint32) {
-        e.PutUint32(b, v)
-    }
+		e.PutUint32(b, v)
+	}
 
 	(e BigEndian) PutUint64(b []byte, v uint64) {
-        e.PutUint64(b, v)
-    }
+		e.PutUint64(b, v)
+	}
 }
 
 requires acc(&b[0], _) && acc(&b[1], _)
@@ -213,7 +213,7 @@ func (e BigEndian) PutUint64(b []byte, v uint64) /*{
 ensures res == "BigEndian"
 func (b BigEndian) String() (res string) { return "BigEndian" }
 
-ensures res == "BigEndian"
+ensures res == "binary.BigEndian"
 func (b BigEndian) GoString() (res string) { return "binary.BigEndian" }
 
 // Read reads structured binary data from r into data.
@@ -227,6 +227,7 @@ func (b BigEndian) GoString() (res string) { return "binary.BigEndian" }
 // Size returns how many bytes Write would generate to encode the value v, which
 // must be a fixed-size value or a slice of fixed-size values, or a pointer to such data.
 // If v is neither of these, Size returns -1.
+// (joao) requires support for the reflect package
 func Size(v interface{}) int /*{
 	return dataSize(reflect.Indirect(reflect.ValueOf(v)))
 }*/

--- a/src/main/resources/stubs/encoding/binary/binary.gobra
+++ b/src/main/resources/stubs/encoding/binary/binary.gobra
@@ -34,11 +34,11 @@ type ByteOrder interface {
     ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
 	PutUint64(b []byte, uint64)
 
-	// String() string // TODO: no support for string types
+	String() string
 }
 
 // Original implementation of BigEndian and LittleEndian. Changed due to lack of support
-// for global vars
+// for global vars:
 // var LittleEndian littleEndian
 // var BigEndian bigEndian
 // type littleEndian struct{}
@@ -75,7 +75,8 @@ LittleEndian implements ByteOrder {
 }
 */
 
-BigEndian implements ByteOrder {
+/*
+(*BigEndian) implements ByteOrder {
     pure (e BigEndian) Uint16(b []byte) uint16 {
         return e.Uint16(b)
     }
@@ -100,6 +101,7 @@ BigEndian implements ByteOrder {
         e.PutUint64(b, v)
     }
 }
+*/
 
 
 requires acc(&b[0], _) && acc(&b[1], _)
@@ -151,8 +153,8 @@ func (e LittleEndian) PutUint64(b []byte, v uint64) /*{
 	b[7] = byte(v >> 56)
 }*/
 
-func (LittleEndian) String() string { return "LittleEndian" }
-func (LittleEndian) GoString() string { return "binary.LittleEndian" }
+func (l LittleEndian) String() string { return "LittleEndian" }
+func (l LittleEndian) GoString() string { return "binary.LittleEndian" }
 
 requires acc(&b[0], _) && acc(&b[1], _)
 pure func (e BigEndian) Uint16(b []byte) uint16 /*{
@@ -203,8 +205,8 @@ func (e BigEndian) PutUint64(b []byte, v uint64) /*{
 	b[7] = byte(v)
 }*/
 
-func (BigEndian) String() string { return "BigEndian" }
-func (BigEndian) GoString() string { return "binary.BigEndian" }
+func (b BigEndian) String() string { return "BigEndian" }
+func (b BigEndian) GoString() string { return "binary.BigEndian" }
 
 // Read reads structured binary data from r into data.
 // TODO: no support for io.Reader

--- a/src/main/resources/stubs/encoding/binary/binary.gobra
+++ b/src/main/resources/stubs/encoding/binary/binary.gobra
@@ -44,11 +44,16 @@ type ByteOrder interface {
 // type littleEndian struct{}
 // type bigEndian struct{}
 
-type LittleEndian struct{}
-type BigEndian struct{}
+type LittleEndian struct {
+	// TODO: remove field
+	x int // temporary solution to side-step problems with the encoding of interfaces with fields of finite cardinality
+}
+type BigEndian struct {
+	// TODO: remove field
+	x int // temporary solution to side-step problems with the encoding of interfaces with fields of finite cardinality
+}
 
-/*
-LittleEndian implements ByteOrder {
+(LittleEndian) implements ByteOrder {
     pure (e LittleEndian) Uint16(b []byte) uint16 {
         return e.Uint16(b)
     }
@@ -73,10 +78,8 @@ LittleEndian implements ByteOrder {
         e.PutUint64(b, v)
     }
 }
-*/
 
-/*
-(*BigEndian) implements ByteOrder {
+(BigEndian) implements ByteOrder {
     pure (e BigEndian) Uint16(b []byte) uint16 {
         return e.Uint16(b)
     }
@@ -101,8 +104,6 @@ LittleEndian implements ByteOrder {
         e.PutUint64(b, v)
     }
 }
-*/
-
 
 requires acc(&b[0], _) && acc(&b[1], _)
 pure func (e LittleEndian) Uint16(b []byte) uint16 /*{

--- a/src/main/resources/stubs/encoding/binary/binary.gobra
+++ b/src/main/resources/stubs/encoding/binary/binary.gobra
@@ -154,8 +154,11 @@ func (e LittleEndian) PutUint64(b []byte, v uint64) /*{
 	b[7] = byte(v >> 56)
 }*/
 
-func (l LittleEndian) String() string { return "LittleEndian" }
-func (l LittleEndian) GoString() string { return "binary.LittleEndian" }
+ensures res == "LittleEndian"
+func (l LittleEndian) String() (res string) { return "LittleEndian" }
+
+ensures res == "binary.LittleEndian"
+func (l LittleEndian) GoString() (res string) { return "binary.LittleEndian" }
 
 requires acc(&b[0], _) && acc(&b[1], _)
 pure func (e BigEndian) Uint16(b []byte) uint16 /*{
@@ -206,15 +209,19 @@ func (e BigEndian) PutUint64(b []byte, v uint64) /*{
 	b[7] = byte(v)
 }*/
 
-func (b BigEndian) String() string { return "BigEndian" }
-func (b BigEndian) GoString() string { return "binary.BigEndian" }
+
+ensures res == "BigEndian"
+func (b BigEndian) String() (res string) { return "BigEndian" }
+
+ensures res == "BigEndian"
+func (b BigEndian) GoString() (res string) { return "binary.BigEndian" }
 
 // Read reads structured binary data from r into data.
-// TODO: no support for io.Reader
+// TODO: add support for io.Reader
 // func Read(r io.Reader, order ByteOrder, data interface{}) error
 
 // Write writes the binary representation of data into w.
-// TODO: no support for io.Write
+// TODO: add support for io.Write
 // func Write(w io.Writer, order ByteOrder, data interface{}) error
 
 // Size returns how many bytes Write would generate to encode the value v, which

--- a/src/main/resources/stubs/encoding/binary/binary.gobra
+++ b/src/main/resources/stubs/encoding/binary/binary.gobra
@@ -1,3 +1,12 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/encoding/binary/binary.gobra
+
 package binary
 
 // A ByteOrder specifies how to convert byte sequences into

--- a/src/main/resources/stubs/net/ip.gobra
+++ b/src/main/resources/stubs/net/ip.gobra
@@ -96,9 +96,8 @@ func (ip IP) IsGlobalUnicast() bool /*{
 }*/
 
 // To4 converts the IPv4 address ip to a 4-byte representation.
-// If ip is not an IPv4 address, To4 returns nil.
 func (ip IP) To4() IP /*{
-	if len(ip) == IPv4len { // TODO: fix type error on len(ip)
+	if len(ip) == IPv4len { // (joao): type error, check issue #228
 		return ip
 	}
 	if len(ip) == IPv6len &&
@@ -111,9 +110,8 @@ func (ip IP) To4() IP /*{
 }*/
 
 // To16 converts the IP address ip to a 16-byte representation.
-// If ip is not an IP address (it is the wrong length), To16 returns nil.
 func (ip IP) To16() IP /*{
-	if len(ip) == IPv4len {
+	if len(ip) == IPv4len { // (joao): type error, check issue #228
 		return IPv4(ip[0], ip[1], ip[2], ip[3])
 	}
 	if len(ip) == IPv6len {
@@ -131,8 +129,6 @@ func (ip IP) Mask(mask IPMask) IP
 func (ip IP) String() string
 
 // MarshalText implements the encoding.TextMarshaler interface.
-// The encoding is the same as returned by String, with one exception:
-// When len(ip) is zero, it returns an empty slice.
 func (ip IP) MarshalText() ([]byte, error)
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
@@ -143,7 +139,7 @@ func (ip *IP) UnmarshalText(text []byte) error
 // An IPv4 address and that same address in IPv6 form are
 // considered to be equal.
 pure func (ip IP) Equal(x IP) bool /*{
-	if len(ip) == len(x) {
+	if len(ip) == len(x) { // (joao): type error, check issue #228
 		return bytealg.Equal(ip, x)
 	}
 	if len(ip) == IPv4len && len(x) == IPv6len {
@@ -169,9 +165,10 @@ func (n *IPNet) Network() string
 
 // String returns the CIDR notation of n like "192.0.2.0/24"
 // or "2001:db8::/48" as defined in RFC 4632 and RFC 4291.
-requires acc(n, 1/2)
-ensures acc(n, 1/2)
-func (n *IPNet) String() string
+requires p > 0
+requires acc(n, p)
+ensures acc(n, p)
+func (n *IPNet) String(ghost p perm) string
 
 // ParseIP parses s as an IP address, returning the result.
 func ParseIP(s string) IP

--- a/src/main/resources/stubs/net/ip.gobra
+++ b/src/main/resources/stubs/net/ip.gobra
@@ -13,18 +13,12 @@ const (
 	IPv6len = 16
 )
 
-// An IP is a single IP address, a slice of bytes.
-// Functions in this package accept either 4-byte (IPv4)
-// or 16-byte (IPv6) slices as input.
 type IP []byte
 
-// An IPMask is a bitmask that can be used to manipulate
-// IP addresses for IP addressing and routing.
 type IPMask []byte
 
-// An IPNet represents an IP network.
 type IPNet struct {
-	// IP   IP // TODO: embedded types not supported
+	// IP   IP // TODO: leads to a kiama cycle
 	Mask IPMask
 }
 

--- a/src/main/resources/stubs/net/ip.gobra
+++ b/src/main/resources/stubs/net/ip.gobra
@@ -40,7 +40,6 @@ func IPv4Mask(a, b, c, d byte) IPMask
 
 // CIDRMask returns an IPMask consisting of 'ones' 1 bits
 // followed by 0s up to a total length of 'bits' bits.
-// For a mask of this form, CIDRMask is the inverse of IPMask.Size.
 func CIDRMask(ones, bits int) IPMask 
 
 // Well-known IPv4 addresses
@@ -132,15 +131,12 @@ func (ip IP) To16() IP /*{
 }*/
 
 // DefaultMask returns the default IP mask for the IP address ip.
-// Only IPv4 addresses have default masks; DefaultMask returns
-// nil if ip is not a valid IPv4 address.
 func (ip IP) DefaultMask() IPMask
 
 // Mask returns the result of masking the IP address ip with mask.
 func (ip IP) Mask(mask IPMask) IP
 
-// TODO: no support for the string type
-// func (ip IP) String() string
+func (ip IP) String() string
 
 // MarshalText implements the encoding.TextMarshaler interface.
 // The encoding is the same as returned by String, with one exception:
@@ -168,18 +164,14 @@ pure func (ip IP) Equal(x IP) bool /*{
 }*/
 
 // Size returns the number of leading ones and total bits in the mask.
-// If the mask is not in the canonical form--ones followed by zeros--then
-// Size returns 0, 0.
 func (m IPMask) Size() (ones, bits int)
 
 // String returns the hexadecimal form of m, with no punctuation.
-// TODO: no support for the string type
-// func (m IPMask) String() string 
+func (m IPMask) String() string 
 
 // Contains reports whether the network includes ip.
 func (n *IPNet) Contains(ip IP) bool
 
-/* TODO: add support for the string type
 // Network returns the address's network name, "ip+net".
 func (n *IPNet) Network() string
 
@@ -190,14 +182,9 @@ ensures acc(n, 1/2)
 func (n *IPNet) String() string
 
 // ParseIP parses s as an IP address, returning the result.
-// The string s can be in IPv4 dotted decimal ("192.0.2.1"), IPv6
-// ("2001:db8::68"), or IPv4-mapped IPv6 ("::ffff:192.0.2.1") form.
-// If s is not a valid textual representation of an IP address,
-// ParseIP returns nil.
 func ParseIP(s string) IP
 
 // ParseCIDR parses s as a CIDR notation IP address and prefix length,
 // like "192.0.2.0/24" or "2001:db8::/32", as defined in
 // RFC 4632 and RFC 4291.
 func ParseCIDR(s string) (IP, *IPNet, error)
-*/

--- a/src/main/resources/stubs/net/ip.gobra
+++ b/src/main/resources/stubs/net/ip.gobra
@@ -1,0 +1,203 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/net/ip.go
+
+package net
+
+// IP address lengths (bytes).
+const (
+	IPv4len = 4
+	IPv6len = 16
+)
+
+// An IP is a single IP address, a slice of bytes.
+// Functions in this package accept either 4-byte (IPv4)
+// or 16-byte (IPv6) slices as input.
+type IP []byte
+
+// An IPMask is a bitmask that can be used to manipulate
+// IP addresses for IP addressing and routing.
+type IPMask []byte
+
+// An IPNet represents an IP network.
+type IPNet struct {
+	// IP   IP // TODO: embedded types not supported
+	Mask IPMask
+}
+
+// IPv4 returns the IP address (in 16-byte form) of the
+// IPv4 address a.b.c.d.
+func IPv4(a, b, c, d byte) IP
+
+// IPv4Mask returns the IP mask (in 4-byte form) of the
+// IPv4 mask a.b.c.d.
+func IPv4Mask(a, b, c, d byte) IPMask 
+
+// CIDRMask returns an IPMask consisting of 'ones' 1 bits
+// followed by 0s up to a total length of 'bits' bits.
+// For a mask of this form, CIDRMask is the inverse of IPMask.Size.
+func CIDRMask(ones, bits int) IPMask 
+
+// Well-known IPv4 addresses
+// TODO: add support for global vars
+/*
+var (
+	IPv4bcast     = IPv4(255, 255, 255, 255) // limited broadcast
+	IPv4allsys    = IPv4(224, 0, 0, 1)       // all systems
+	IPv4allrouter = IPv4(224, 0, 0, 2)       // all routers
+	IPv4zero      = IPv4(0, 0, 0, 0)         // all zeros
+)
+*/
+
+// Well-known IPv6 addresses
+// TODO: add support for global vars
+/*
+var (
+	IPv6zero                   = IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	IPv6unspecified            = IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	IPv6loopback               = IP{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	IPv6interfacelocalallnodes = IP{255, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	IPv6linklocalallnodes      = IP{255, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	IPv6linklocalallrouters    = IP{255, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+)
+*/
+
+// IsUnspecified reports whether ip is an unspecified address, either
+// the IPv4 address "0.0.0.0" or the IPv6 address "::".
+func (ip IP) IsUnspecified() bool /*{
+	return ip.Equal(IPv4zero) || ip.Equal(IPv6unspecified)
+}*/
+
+// IsLoopback reports whether ip is a loopback address.
+func (ip IP) IsLoopback() bool /*{
+	if ip4 := ip.To4(); ip4 != nil {
+		return ip4[0] == 127 // TODO: currently, this leads to a type error
+	}
+	return ip.Equal(IPv6loopback)
+}*/
+
+// IsMulticast reports whether ip is a multicast address.
+func (ip IP) IsMulticast() bool
+
+// IsInterfaceLocalMulticast reports whether ip is an interface-local multicast address.
+func (ip IP) IsInterfaceLocalMulticast() bool
+
+// IsLinkLocalMulticast reports whether ip is a link-local multicast address.
+func (ip IP) IsLinkLocalMulticast() bool 
+
+// IsLinkLocalUnicast reports whether ip is a link-local unicast address.
+func (ip IP) IsLinkLocalUnicast() bool 
+
+// IsGlobalUnicast reports whether ip is a global unicast
+// address.
+func (ip IP) IsGlobalUnicast() bool /*{
+	return (len(ip) == IPv4len || len(ip) == IPv6len) &&
+		!ip.Equal(IPv4bcast) &&
+		!ip.IsUnspecified() &&
+		!ip.IsLoopback() &&
+		!ip.IsMulticast() &&
+		!ip.IsLinkLocalUnicast()
+}*/
+
+// To4 converts the IPv4 address ip to a 4-byte representation.
+// If ip is not an IPv4 address, To4 returns nil.
+func (ip IP) To4() IP /*{
+	if len(ip) == IPv4len { // TODO: fix type error on len(ip)
+		return ip
+	}
+	if len(ip) == IPv6len &&
+		isZeros(ip[0:10]) &&
+		ip[10] == 255 &&
+		ip[11] == 255 {
+		return ip[12:16]
+	}
+	return nil
+}*/
+
+// To16 converts the IP address ip to a 16-byte representation.
+// If ip is not an IP address (it is the wrong length), To16 returns nil.
+func (ip IP) To16() IP /*{
+	if len(ip) == IPv4len {
+		return IPv4(ip[0], ip[1], ip[2], ip[3])
+	}
+	if len(ip) == IPv6len {
+		return ip
+	}
+	return nil
+}*/
+
+// DefaultMask returns the default IP mask for the IP address ip.
+// Only IPv4 addresses have default masks; DefaultMask returns
+// nil if ip is not a valid IPv4 address.
+func (ip IP) DefaultMask() IPMask
+
+// Mask returns the result of masking the IP address ip with mask.
+func (ip IP) Mask(mask IPMask) IP
+
+// TODO: no support for the string type
+// func (ip IP) String() string
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The encoding is the same as returned by String, with one exception:
+// When len(ip) is zero, it returns an empty slice.
+func (ip IP) MarshalText() ([]byte, error)
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// The IP address is expected in a form accepted by ParseIP.
+func (ip *IP) UnmarshalText(text []byte) error 
+
+// Equal reports whether ip and x are the same IP address.
+// An IPv4 address and that same address in IPv6 form are
+// considered to be equal.
+pure func (ip IP) Equal(x IP) bool /*{
+	if len(ip) == len(x) {
+		return bytealg.Equal(ip, x)
+	}
+	if len(ip) == IPv4len && len(x) == IPv6len {
+		return bytealg.Equal(x[0:12], v4InV6Prefix) && bytealg.Equal(ip, x[12:])
+	}
+	if len(ip) == IPv6len && len(x) == IPv4len {
+		return bytealg.Equal(ip[0:12], v4InV6Prefix) && bytealg.Equal(ip[12:], x)
+	}
+	return false
+}*/
+
+// Size returns the number of leading ones and total bits in the mask.
+// If the mask is not in the canonical form--ones followed by zeros--then
+// Size returns 0, 0.
+func (m IPMask) Size() (ones, bits int)
+
+// String returns the hexadecimal form of m, with no punctuation.
+// TODO: no support for the string type
+// func (m IPMask) String() string 
+
+// Contains reports whether the network includes ip.
+func (n *IPNet) Contains(ip IP) bool
+
+/* TODO: add support for the string type
+// Network returns the address's network name, "ip+net".
+func (n *IPNet) Network() string
+
+// String returns the CIDR notation of n like "192.0.2.0/24"
+// or "2001:db8::/48" as defined in RFC 4632 and RFC 4291.
+requires acc(n, 1/2)
+ensures acc(n, 1/2)
+func (n *IPNet) String() string
+
+// ParseIP parses s as an IP address, returning the result.
+// The string s can be in IPv4 dotted decimal ("192.0.2.1"), IPv6
+// ("2001:db8::68"), or IPv4-mapped IPv6 ("::ffff:192.0.2.1") form.
+// If s is not a valid textual representation of an IP address,
+// ParseIP returns nil.
+func ParseIP(s string) IP
+
+// ParseCIDR parses s as a CIDR notation IP address and prefix length,
+// like "192.0.2.0/24" or "2001:db8::/32", as defined in
+// RFC 4632 and RFC 4291.
+func ParseCIDR(s string) (IP, *IPNet, error)
+*/

--- a/src/main/resources/stubs/net/ip.gobra
+++ b/src/main/resources/stubs/net/ip.gobra
@@ -1,8 +1,6 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-//
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in https://golang.org/LICENSE
 
 // Signatures for the public declarations in file
 // https://github.com/golang/go/blob/master/src/net/ip.go

--- a/src/main/resources/stubs/net/ip.gobra
+++ b/src/main/resources/stubs/net/ip.gobra
@@ -129,11 +129,25 @@ func (ip IP) Mask(mask IPMask) IP
 func (ip IP) String() string
 
 // MarshalText implements the encoding.TextMarshaler interface.
-func (ip IP) MarshalText() ([]byte, error)
+ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+func (ip IP) MarshalText() (res []byte, error) /*{
+	if len(ip) == 0 {
+		return []byte(""), nil
+	}
+	if len(ip) != IPv4len && len(ip) != IPv6len {
+		return nil, &AddrError{Err: "invalid IP address", Addr: hexString(ip)}
+	}
+	return []byte(ip.String()), nil
+}*/
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 // The IP address is expected in a form accepted by ParseIP.
-func (ip *IP) UnmarshalText(text []byte) error 
+requires acc(ip)
+requires p > 0
+requires forall i int :: 0 <= i && i < len(text) ==> acc(&text[i], p)
+ensures acc(ip)
+ensures forall i int :: 0 <= i && i < len(text) ==> acc(&text[i], p)
+func (ip *IP) UnmarshalText(text []byte, ghost p perm) error 
 
 // Equal reports whether ip and x are the same IP address.
 // An IPv4 address and that same address in IPv6 form are
@@ -158,10 +172,13 @@ func (m IPMask) Size() (ones, bits int)
 func (m IPMask) String() string 
 
 // Contains reports whether the network includes ip.
-func (n *IPNet) Contains(ip IP) bool
+requires p > 0
+requires acc(n, p)
+ensures p > 0
+func (n *IPNet) Contains(ip IP, ghost p perm) bool
 
 // Network returns the address's network name, "ip+net".
-func (n *IPNet) Network() string
+func (n *IPNet) Network() string { return "ip+net" }
 
 // String returns the CIDR notation of n like "192.0.2.0/24"
 // or "2001:db8::/48" as defined in RFC 4632 and RFC 4291.
@@ -176,4 +193,5 @@ func ParseIP(s string) IP
 // ParseCIDR parses s as a CIDR notation IP address and prefix length,
 // like "192.0.2.0/24" or "2001:db8::/32", as defined in
 // RFC 4632 and RFC 4291.
-func ParseCIDR(s string) (IP, *IPNet, error)
+ensures ipnet != nil ==> acc(ipnet)
+func ParseCIDR(s string) (IP, ipnet *IPNet, error)

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -166,20 +166,24 @@ func (e *AddrError) Error() string {
 	return s
 }*/
 
-pure func (e *AddrError) Timeout() bool   { return false }
-pure func (e *AddrError) Temporary() bool { return false }
+ensures !res
+pure func (e *AddrError) Timeout() (res bool)   { return false }
+ensures !res
+pure func (e *AddrError) Temporary() (res bool) { return false }
 
 type UnknownNetworkError string
 
 func (e UnknownNetworkError) Error() string   // { return "unknown network " + string(e) }
-pure func (e UnknownNetworkError) Timeout() bool   { return false }
-pure func (e UnknownNetworkError) Temporary() bool { return false }
+ensures !res
+pure func (e UnknownNetworkError) Timeout() (res bool)   { return false }
+ensures !res
+pure func (e UnknownNetworkError) Temporary() (res bool) { return false }
 
 type InvalidAddrError string
 
 // func (e InvalidAddrError) Error() string   { return string(e) }
-func (e InvalidAddrError) Timeout() bool   { return false }
-func (e InvalidAddrError) Temporary() bool { return false }
+func (e InvalidAddrError) Timeout() (res bool)   { return false }
+func (e InvalidAddrError) Temporary() (res bool) { return false }
 
 // DNSError represents a DNS lookup error.
 type DNSError struct {
@@ -208,11 +212,13 @@ func (e *DNSError) Error(ghost p perm) string {
 
 // Timeout reports whether the DNS lookup is known to have timed out.
 requires acc(&e.IsTimeout, _)
-pure func (e *DNSError) Timeout() bool { return e.IsTimeout }
+ensures res == e.IsTimeout
+pure func (e *DNSError) Timeout() (res bool) { return e.IsTimeout }
 
 // Temporary reports whether the DNS error is known to be temporary.
 requires acc(&e.IsTimeout, _) && acc(&e.IsTemporary, _)
-pure func (e *DNSError) Temporary() bool { return e.IsTimeout || e.IsTemporary }
+ensures res == e.IsTimeout || e.IsTemporary
+pure func (e *DNSError) Temporary() (res bool) { return e.IsTimeout || e.IsTemporary }
 
 // Buffers contains zero or more runs of bytes to write.
 type Buffers [][]byte

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -13,9 +13,8 @@ import "time"
 
 // Addr represents a network end point address.
 type Addr interface {
-    // TODO: add support for string
-	// Network() string
-	// String() string
+	Network() string
+	String() string
 }
 
 // Conn is a generic stream-oriented network connection.
@@ -48,8 +47,6 @@ type Conn interface {
 	// SetWriteDeadline sets the deadline for future Write calls
 	// and any currently-blocked Write call.
 	SetWriteDeadline(t time.Time) error
-
-    ghost IsClosed() bool
 }
 
 // PacketConn is a generic packet-oriented network connection.
@@ -87,7 +84,7 @@ type Listener interface {
 	Close() error
 
 	// Addr returns the listener's network address.
-	//Addr() Addr
+	//Addr() Addr // TODO: no support for embedded types
 }
 
 // An Error represents a network error.
@@ -108,18 +105,18 @@ var (
 // package. It describes the operation, network type, and address of
 // an error.
 type OpError struct {
-    // TODO: add support for string
-	// Op string
-	// Net string
+	Op string
+	Net string
 	Source Addr
-	// Addr Addr
+	// Addr Addr // TODO: add support for embeddings
 	Err error
 }
 
 requires acc(&e.Err, _)
 pure func (e *OpError) Unwrap() error { return e.Err }
 
-// TODO: add support for string
+// requires acc(&e.Err)
+// ensures acc(&e.Err)
 // func (e *OpError) Error() string 
 
 func (e *OpError) Timeout() bool /*{
@@ -146,17 +143,17 @@ func (e *OpError) Temporary() bool /*{
 
 // A ParseError is the error type of literal network address parsers.
 type ParseError struct {
-    // TODO: add support for string
-	// Type string
-	// Text string
+	Type string
+	Text string
 }
 
+// requires acc(e)
+// ensures acc(e)
 // func (e *ParseError) Error() string
 
 type AddrError struct {
-    // TODO: add support for string
-	// Err  string
-	// Addr string
+	Err  string
+	Addr string
 }
 
 /*
@@ -171,29 +168,26 @@ func (e *AddrError) Error() string {
 	return s
 }*/
 
-func (e *AddrError) Timeout() bool   { return false }
-func (e *AddrError) Temporary() bool { return false }
+// func (e *AddrError) Timeout() bool   { return false }
+// func (e *AddrError) Temporary() bool { return false }
 
-/*
 type UnknownNetworkError string
 
-func (e UnknownNetworkError) Error() string   { return "unknown network " + string(e) }
+func (e UnknownNetworkError) Error() string   // { return "unknown network " + string(e) }
 func (e UnknownNetworkError) Timeout() bool   { return false }
 func (e UnknownNetworkError) Temporary() bool { return false }
 
 type InvalidAddrError string
 
-func (e InvalidAddrError) Error() string   { return string(e) }
+// func (e InvalidAddrError) Error() string   { return string(e) }
 func (e InvalidAddrError) Timeout() bool   { return false }
 func (e InvalidAddrError) Temporary() bool { return false }
-*/
-
 
 // DNSError represents a DNS lookup error.
 type DNSError struct {
-	// Err         string
-	// Name        string
-	// Server      string
+	Err         string
+	Name        string
+	Server      string
 	IsTimeout   bool
 	IsTemporary bool
 	IsNotFound  bool
@@ -214,14 +208,10 @@ func (e *DNSError) Error() string {
 */
 
 // Timeout reports whether the DNS lookup is known to have timed out.
-// This is not always known; a DNS lookup may fail due to a timeout
-// and return a DNSError for which Timeout returns false.
-requires acc(&e.IsTimeout, _)
-func (e *DNSError) Timeout() bool { return e.IsTimeout }
+// requires acc(&e.IsTimeout, _)
+// func (e *DNSError) Timeout() bool { return e.IsTimeout }
 
 // Temporary reports whether the DNS error is known to be temporary.
-// This is not always known; a DNS lookup may fail due to a temporary
-// error and return a DNSError for which Temporary returns false.
 requires acc(&e.IsTimeout, _) && acc(&e.IsTemporary, _)
 pure func (e *DNSError) Temporary() bool { return e.IsTimeout || e.IsTemporary }
 

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -19,10 +19,15 @@ type Addr interface {
 // Multiple goroutines may invoke methods on a Conn simultaneously.
 type Conn interface {
 	// Read reads data from the connection.
+	requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+	ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
 	Read(b []byte) (n int, err error)
 
 	// Write writes data to the connection.
-	Write(b []byte) (n int, err error)
+	requires p > 0
+	requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+	ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+	Write(b []byte, ghost p perm) (n int, err error)
 
 	// Close closes the connection.
 	// Any blocked Read or Write operations will be unblocked and return errors.
@@ -117,7 +122,10 @@ requires acc(&e.Err)
 ensures acc(&e.Err)
 func (e *OpError) Error() string 
 
-func (e *OpError) Timeout() bool /*{
+requires p > 0
+requires acc(e, p)
+ensures acc(e, p)
+func (e *OpError) Timeout(ghost p perm) bool /*{
 	if ne, ok := e.Err.(*os.SyscallError); ok {
 		t, ok := ne.Err.(timeout)
 		return ok && t.Timeout()
@@ -126,7 +134,10 @@ func (e *OpError) Timeout() bool /*{
 	return ok && t.Timeout()
 }*/
 
-func (e *OpError) Temporary() bool /*{
+requires p > 0
+requires acc(e, p)
+ensures acc(e, p)
+func (e *OpError) Temporary(ghost p perm) bool /*{
 	if e.Op == "accept" && isConnError(e.Err) {
 		return true
 	}
@@ -196,8 +207,8 @@ type DNSError struct {
 }
 
 requires p > 0
-requires acc(e, p)
-ensures acc(e, p)
+requires e != nil ==> acc(e, p)
+ensures e != nil ==> acc(e, p)
 func (e *DNSError) Error(ghost p perm) string {
 	if e == nil {
 		return "<nil>"

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -1,0 +1,275 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/net/net.go
+
+package net
+
+import "time"
+
+// Addr represents a network end point address.
+type Addr interface {
+    // TODO: add support for string
+	// Network() string
+	// String() string
+}
+
+// Conn is a generic stream-oriented network connection.
+// Multiple goroutines may invoke methods on a Conn simultaneously.
+type Conn interface {
+	// Read reads data from the connection.
+	Read(b []byte) (n int, err error)
+
+	// Write writes data to the connection.
+	Write(b []byte) (n int, err error)
+
+	// Close closes the connection.
+	// Any blocked Read or Write operations will be unblocked and return errors.
+	Close() error
+
+	// LocalAddr returns the local network address.
+	LocalAddr() Addr
+
+	// RemoteAddr returns the remote network address.
+	RemoteAddr() Addr
+
+	// SetDeadline sets the read and write deadlines associated
+	// with the connection.
+	SetDeadline(t time.Time) error
+
+	// SetReadDeadline sets the deadline for future Read calls
+	// and any currently-blocked Read call.
+	SetReadDeadline(t time.Time) error
+
+	// SetWriteDeadline sets the deadline for future Write calls
+	// and any currently-blocked Write call.
+	SetWriteDeadline(t time.Time) error
+
+    ghost IsClosed() bool
+}
+
+// PacketConn is a generic packet-oriented network connection.
+// Multiple goroutines may invoke methods on a PacketConn simultaneously.
+type PacketConn interface {
+    requires forall i int :: 0 <= i && i < len(p) ==> acc(&p[i])
+    ensures forall i int :: 0 <= i && i < len(p) ==> acc(&p[i])
+    ensures 0 <= n && n <= len(p)
+	ReadFrom(p []byte) (n int, addr Addr, err error)
+
+    // TODO: replace 1/2 by a ghost param of type Perm after introducing support for Perm
+    requires forall i int :: 0 <= i && i < len(p) ==> acc(&p[i], 1/2)
+    ensures forall i int :: 0 <= i && i < len(p) ==> acc(&p[i], 1/2)
+	WriteTo(p []byte, addr Addr) (n int, err error)
+
+	Close() error
+
+	LocalAddr() Addr
+
+	SetDeadline(t time.Time) error
+
+	SetReadDeadline(t time.Time) error
+
+	SetWriteDeadline(t time.Time) error
+}
+
+// A Listener is a generic network listener for stream-oriented protocols.
+// Multiple goroutines may invoke methods on a Listener simultaneously.
+type Listener interface {
+	// Accept waits for and returns the next connection to the listener.
+	Accept() (Conn, error)
+
+	// Close closes the listener.
+	// Any blocked Accept operations will be unblocked and return errors.
+	Close() error
+
+	// Addr returns the listener's network address.
+	//Addr() Addr
+}
+
+// An Error represents a network error.
+type Error interface {
+	// error // TODO: add support for embeddings
+	Timeout() bool   // Is the error a timeout?
+	Temporary() bool // Is the error temporary?
+}
+
+// Various errors contained in OpError.
+// TODO: introduce support for string literals and errors
+/*
+var (
+	ErrWriteToConnected = errors.New("use of WriteTo with pre-connected connection")
+)*/
+
+// OpError is the error type usually returned by functions in the net
+// package. It describes the operation, network type, and address of
+// an error.
+type OpError struct {
+    // TODO: add support for string
+	// Op string
+	// Net string
+	Source Addr
+	// Addr Addr
+	Err error
+}
+
+requires acc(&e.Err, _)
+pure func (e *OpError) Unwrap() error { return e.Err }
+
+// TODO: add support for string
+// func (e *OpError) Error() string 
+
+func (e *OpError) Timeout() bool /*{
+	if ne, ok := e.Err.(*os.SyscallError); ok {
+		t, ok := ne.Err.(timeout)
+		return ok && t.Timeout()
+	}
+	t, ok := e.Err.(timeout)
+	return ok && t.Timeout()
+}*/
+
+func (e *OpError) Temporary() bool /*{
+	if e.Op == "accept" && isConnError(e.Err) {
+		return true
+	}
+
+	if ne, ok := e.Err.(*os.SyscallError); ok {
+		t, ok := ne.Err.(temporary)
+		return ok && t.Temporary()
+	}
+	t, ok := e.Err.(temporary)
+	return ok && t.Temporary()
+}*/
+
+// A ParseError is the error type of literal network address parsers.
+type ParseError struct {
+    // TODO: add support for string
+	// Type string
+	// Text string
+}
+
+// func (e *ParseError) Error() string
+
+type AddrError struct {
+    // TODO: add support for string
+	// Err  string
+	// Addr string
+}
+
+/*
+func (e *AddrError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	s := e.Err
+	if e.Addr != "" {
+		s = "address " + e.Addr + ": " + s
+	}
+	return s
+}*/
+
+func (e *AddrError) Timeout() bool   { return false }
+func (e *AddrError) Temporary() bool { return false }
+
+/*
+type UnknownNetworkError string
+
+func (e UnknownNetworkError) Error() string   { return "unknown network " + string(e) }
+func (e UnknownNetworkError) Timeout() bool   { return false }
+func (e UnknownNetworkError) Temporary() bool { return false }
+
+type InvalidAddrError string
+
+func (e InvalidAddrError) Error() string   { return string(e) }
+func (e InvalidAddrError) Timeout() bool   { return false }
+func (e InvalidAddrError) Temporary() bool { return false }
+*/
+
+
+// DNSError represents a DNS lookup error.
+type DNSError struct {
+	// Err         string
+	// Name        string
+	// Server      string
+	IsTimeout   bool
+	IsTemporary bool
+	IsNotFound  bool
+}
+
+/*
+func (e *DNSError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	s := "lookup " + e.Name
+	if e.Server != "" {
+		s += " on " + e.Server
+	}
+	s += ": " + e.Err
+	return s
+}
+*/
+
+// Timeout reports whether the DNS lookup is known to have timed out.
+// This is not always known; a DNS lookup may fail due to a timeout
+// and return a DNSError for which Timeout returns false.
+requires acc(&e.IsTimeout, _)
+func (e *DNSError) Timeout() bool { return e.IsTimeout }
+
+// Temporary reports whether the DNS error is known to be temporary.
+// This is not always known; a DNS lookup may fail due to a temporary
+// error and return a DNSError for which Temporary returns false.
+requires acc(&e.IsTimeout, _) && acc(&e.IsTemporary, _)
+pure func (e *DNSError) Temporary() bool { return e.IsTimeout || e.IsTemporary }
+
+// Buffers contains zero or more runs of bytes to write.
+type Buffers [][]byte
+
+// TODO: add support for io.Writer
+/*
+func (v *Buffers) WriteTo(w io.Writer) (n int64, err error) {
+	if wv, ok := w.(buffersWriter); ok {
+		return wv.writeBuffers(v)
+	}
+	for _, b := range *v {
+		nb, err := w.Write(b)
+		n += int64(nb)
+		if err != nil {
+			v.consume(n)
+			return n, err
+		}
+	}
+	v.consume(n)
+	return n, nil
+}
+*/
+
+/*
+func (v *Buffers) Read(p []byte) (n int, err error) {
+	for len(p) > 0 && len(*v) > 0 {
+		n0 := copy(p, (*v)[0])
+		v.consume(int64(n0))
+		p = p[n0:]
+		n += n0
+	}
+	if len(*v) == 0 {
+		err = io.EOF
+	}
+	return
+}
+
+func (v *Buffers) consume(n int64) {
+	for len(*v) > 0 {
+		ln0 := int64(len((*v)[0]))
+		if ln0 > n {
+			(*v)[0] = (*v)[0][n:]
+			return
+		}
+		n -= ln0
+		*v = (*v)[1:]
+	}
+}
+*/

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -1,8 +1,6 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-//
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in https://golang.org/LICENSE
 
 // Signatures for the public declarations in file
 // https://github.com/golang/go/blob/master/src/net/net.go
@@ -52,15 +50,15 @@ type Conn interface {
 // PacketConn is a generic packet-oriented network connection.
 // Multiple goroutines may invoke methods on a PacketConn simultaneously.
 type PacketConn interface {
-    requires forall i int :: 0 <= i && i < len(p) ==> acc(&p[i])
-    ensures forall i int :: 0 <= i && i < len(p) ==> acc(&p[i])
-    ensures 0 <= n && n <= len(p)
+	requires forall i int :: 0 <= i && i < len(p) ==> acc(&p[i])
+	ensures forall i int :: 0 <= i && i < len(p) ==> acc(&p[i])
+	ensures 0 <= n && n <= len(p)
 	ReadFrom(p []byte) (n int, addr Addr, err error)
 
-    // TODO: replace 1/2 by a ghost param of type Perm after introducing support for Perm
-    requires forall i int :: 0 <= i && i < len(p) ==> acc(&p[i], 1/2)
-    ensures forall i int :: 0 <= i && i < len(p) ==> acc(&p[i], 1/2)
-	WriteTo(p []byte, addr Addr) (n int, err error)
+	requires permission > 0
+	requires forall i int :: 0 <= i && i < len(p) ==> acc(&p[i], permission)
+	ensures forall i int :: 0 <= i && i < len(p) ==> acc(&p[i], permission)
+	WriteTo(p []byte, addr Addr, ghost permission perm) (n int, err error)
 
 	Close() error
 
@@ -84,18 +82,18 @@ type Listener interface {
 	Close() error
 
 	// Addr returns the listener's network address.
-	//Addr() Addr // TODO: no support for embedded types
+	// Addr() Addr // (joao): error, check issue 229
 }
 
 // An Error represents a network error.
 type Error interface {
-	// error // TODO: add support for embeddings
+	// error // (joao) support for embeddings is buggy
 	Timeout() bool   // Is the error a timeout?
 	Temporary() bool // Is the error temporary?
 }
 
 // Various errors contained in OpError.
-// TODO: introduce support for string literals and errors
+// (joao): global variables and errors package not supported
 /*
 var (
 	ErrWriteToConnected = errors.New("use of WriteTo with pre-connected connection")
@@ -108,16 +106,16 @@ type OpError struct {
 	Op string
 	Net string
 	Source Addr
-	// Addr Addr // TODO: add support for embeddings
+	// Addr Addr // (joao): error, check issue 229
 	Err error
 }
 
 requires acc(&e.Err, _)
 pure func (e *OpError) Unwrap() error { return e.Err }
 
-// requires acc(&e.Err)
-// ensures acc(&e.Err)
-// func (e *OpError) Error() string 
+requires acc(&e.Err)
+ensures acc(&e.Err)
+func (e *OpError) Error() string 
 
 func (e *OpError) Timeout() bool /*{
 	if ne, ok := e.Err.(*os.SyscallError); ok {
@@ -147,9 +145,9 @@ type ParseError struct {
 	Text string
 }
 
-// requires acc(e)
-// ensures acc(e)
-// func (e *ParseError) Error() string
+requires acc(e)
+ensures acc(e)
+func (e *ParseError) Error() string
 
 type AddrError struct {
 	Err  string
@@ -168,14 +166,14 @@ func (e *AddrError) Error() string {
 	return s
 }*/
 
-// func (e *AddrError) Timeout() bool   { return false }
-// func (e *AddrError) Temporary() bool { return false }
+pure func (e *AddrError) Timeout() bool   { return false }
+pure func (e *AddrError) Temporary() bool { return false }
 
 type UnknownNetworkError string
 
 func (e UnknownNetworkError) Error() string   // { return "unknown network " + string(e) }
-func (e UnknownNetworkError) Timeout() bool   { return false }
-func (e UnknownNetworkError) Temporary() bool { return false }
+pure func (e UnknownNetworkError) Timeout() bool   { return false }
+pure func (e UnknownNetworkError) Temporary() bool { return false }
 
 type InvalidAddrError string
 
@@ -193,8 +191,10 @@ type DNSError struct {
 	IsNotFound  bool
 }
 
-/*
-func (e *DNSError) Error() string {
+requires p > 0
+requires acc(e, p)
+ensures acc(e, p)
+func (e *DNSError) Error(ghost p perm) string {
 	if e == nil {
 		return "<nil>"
 	}
@@ -205,11 +205,10 @@ func (e *DNSError) Error() string {
 	s += ": " + e.Err
 	return s
 }
-*/
 
 // Timeout reports whether the DNS lookup is known to have timed out.
-// requires acc(&e.IsTimeout, _)
-// func (e *DNSError) Timeout() bool { return e.IsTimeout }
+requires acc(&e.IsTimeout, _)
+pure func (e *DNSError) Timeout() bool { return e.IsTimeout }
 
 // Temporary reports whether the DNS error is known to be temporary.
 requires acc(&e.IsTimeout, _) && acc(&e.IsTemporary, _)

--- a/src/main/resources/stubs/strconv/atoi.gobra
+++ b/src/main/resources/stubs/strconv/atoi.gobra
@@ -1,0 +1,220 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package strconv
+
+// import "errors"
+
+// ErrRange indicates that a value is out of range for the target type.
+// var ErrRange = errors.New("value out of range")
+
+// ErrSyntax indicates that a value does not have the right syntax for the target type.
+// var ErrSyntax = errors.New("invalid syntax")
+
+// A NumError records a failed conversion.
+type NumError struct {
+	Func string // the failing function (ParseBool, ParseInt, ParseUint, ParseFloat, ParseComplex)
+	Num  string // the input
+	Err  error  // the reason the conversion failed (e.g. ErrRange, ErrSyntax, etc.)
+}
+
+func (e *NumError) Error() string /*{
+	return "strconv." + e.Func + ": " + "parsing " + Quote(e.Num) + ": " + e.Err.Error()
+}*/
+
+
+requires acc(e, _)
+pure func (e *NumError) Unwrap() error { return e.Err }
+
+// const intSize = 32 << (^uint(0) >> 63)
+
+// IntSize is the size in bits of an int or uint value.
+// const IntSize = intSize
+
+// ParseUint is like ParseInt but for unsigned numbers.
+func ParseUint(s string, base int, bitSize int) (uint64, error) /*{
+	const fnParseUint = "ParseUint"
+
+	if s == "" {
+		return 0, syntaxError(fnParseUint, s)
+	}
+
+	base0 := base == 0
+
+	s0 := s
+	switch {
+	case 2 <= base && base <= 36:
+		// valid base; nothing to do
+
+	case base == 0:
+		// Look for octal, hex prefix.
+		base = 10
+		if s[0] == '0' {
+			switch {
+			case len(s) >= 3 && lower(s[1]) == 'b':
+				base = 2
+				s = s[2:]
+			case len(s) >= 3 && lower(s[1]) == 'o':
+				base = 8
+				s = s[2:]
+			case len(s) >= 3 && lower(s[1]) == 'x':
+				base = 16
+				s = s[2:]
+			default:
+				base = 8
+				s = s[1:]
+			}
+		}
+
+	default:
+		return 0, baseError(fnParseUint, s0, base)
+	}
+
+	if bitSize == 0 {
+		bitSize = IntSize
+	} else if bitSize < 0 || bitSize > 64 {
+		return 0, bitSizeError(fnParseUint, s0, bitSize)
+	}
+
+	// Cutoff is the smallest number such that cutoff*base > maxUint64.
+	// Use compile-time constants for common cases.
+	var cutoff uint64
+	switch base {
+	case 10:
+		cutoff = maxUint64/10 + 1
+	case 16:
+		cutoff = maxUint64/16 + 1
+	default:
+		cutoff = maxUint64/uint64(base) + 1
+	}
+
+	maxVal := uint64(1)<<uint(bitSize) - 1
+
+	underscores := false
+	var n uint64
+	for _, c := range []byte(s) {
+		var d byte
+		switch {
+		case c == '_' && base0:
+			underscores = true
+			continue
+		case '0' <= c && c <= '9':
+			d = c - '0'
+		case 'a' <= lower(c) && lower(c) <= 'z':
+			d = lower(c) - 'a' + 10
+		default:
+			return 0, syntaxError(fnParseUint, s0)
+		}
+
+		if d >= byte(base) {
+			return 0, syntaxError(fnParseUint, s0)
+		}
+
+		if n >= cutoff {
+			// n*base overflows
+			return maxVal, rangeError(fnParseUint, s0)
+		}
+		n *= uint64(base)
+
+		n1 := n + uint64(d)
+		if n1 < n || n1 > maxVal {
+			// n+v overflows
+			return maxVal, rangeError(fnParseUint, s0)
+		}
+		n = n1
+	}
+
+	if underscores && !underscoreOK(s0) {
+		return 0, syntaxError(fnParseUint, s0)
+	}
+
+	return n, nil
+}
+*/
+
+// ParseInt interprets a string s in the given base (0, 2 to 36) and
+// bit size (0 to 64) and returns the corresponding value i.
+func ParseInt(s string, base int, bitSize int) (i int64, err error) /*{
+	const fnParseInt = "ParseInt"
+
+	if s == "" {
+		return 0, syntaxError(fnParseInt, s)
+	}
+
+	// Pick off leading sign.
+	s0 := s
+	neg := false
+	if s[0] == '+' {
+		s = s[1:]
+	} else if s[0] == '-' {
+		neg = true
+		s = s[1:]
+	}
+
+	// Convert unsigned and check range.
+	var un uint64
+	un, err = ParseUint(s, base, bitSize)
+	if err != nil && err.(*NumError).Err != ErrRange {
+		err.(*NumError).Func = fnParseInt
+		err.(*NumError).Num = s0
+		return 0, err
+	}
+
+	if bitSize == 0 {
+		bitSize = IntSize
+	}
+
+	cutoff := uint64(1 << uint(bitSize-1))
+	if !neg && un >= cutoff {
+		return int64(cutoff - 1), rangeError(fnParseInt, s0)
+	}
+	if neg && un > cutoff {
+		return -int64(cutoff), rangeError(fnParseInt, s0)
+	}
+	n := int64(un)
+	if neg {
+		n = -n
+	}
+	return n, nil
+}
+*/
+
+// Atoi is equivalent to ParseInt(s, 10, 0), converted to type int.
+func Atoi(s string) (int, error) /*{
+	const fnAtoi = "Atoi"
+
+	sLen := len(s)
+	if intSize == 32 && (0 < sLen && sLen < 10) ||
+		intSize == 64 && (0 < sLen && sLen < 19) {
+		// Fast path for small integers that fit int type.
+		s0 := s
+		if s[0] == '-' || s[0] == '+' {
+			s = s[1:]
+			if len(s) < 1 {
+				return 0, &NumError{fnAtoi, s0, ErrSyntax}
+			}
+		}
+
+		n := 0
+		for _, ch := range []byte(s) {
+			ch -= '0'
+			if ch > 9 {
+				return 0, &NumError{fnAtoi, s0, ErrSyntax}
+			}
+			n = n*10 + int(ch)
+		}
+		if s0[0] == '-' {
+			n = -n
+		}
+		return n, nil
+	}
+
+	// Slow path for invalid, big, or underscored integers.
+	i64, err := ParseInt(s, 10, 0)
+	if nerr, ok := err.(*NumError); ok {
+		nerr.Func = fnAtoi
+	}
+	return int(i64), err
+}
+*/

--- a/src/main/resources/stubs/strconv/atoi.gobra
+++ b/src/main/resources/stubs/strconv/atoi.gobra
@@ -1,16 +1,19 @@
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in https://golang.org/LICENSE
+
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/strconv/atoi.go
 
 package strconv
 
-// import "errors"
+// import "errors" //(joao) stub errors package still not implemented
 
 // ErrRange indicates that a value is out of range for the target type.
-// var ErrRange = errors.New("value out of range")
+// var ErrRange = errors.New("value out of range") // (joao): no support for global vars and for the errors package
 
 // ErrSyntax indicates that a value does not have the right syntax for the target type.
-// var ErrSyntax = errors.New("invalid syntax")
+// var ErrSyntax = errors.New("invalid syntax") // (joao): no support for global vars and for the errors package
 
 // A NumError records a failed conversion.
 type NumError struct {
@@ -33,188 +36,11 @@ pure func (e *NumError) Unwrap() error { return e.Err }
 // const IntSize = intSize
 
 // ParseUint is like ParseInt but for unsigned numbers.
-func ParseUint(s string, base int, bitSize int) (uint64, error) /*{
-	const fnParseUint = "ParseUint"
-
-	if s == "" {
-		return 0, syntaxError(fnParseUint, s)
-	}
-
-	base0 := base == 0
-
-	s0 := s
-	switch {
-	case 2 <= base && base <= 36:
-		// valid base; nothing to do
-
-	case base == 0:
-		// Look for octal, hex prefix.
-		base = 10
-		if s[0] == '0' {
-			switch {
-			case len(s) >= 3 && lower(s[1]) == 'b':
-				base = 2
-				s = s[2:]
-			case len(s) >= 3 && lower(s[1]) == 'o':
-				base = 8
-				s = s[2:]
-			case len(s) >= 3 && lower(s[1]) == 'x':
-				base = 16
-				s = s[2:]
-			default:
-				base = 8
-				s = s[1:]
-			}
-		}
-
-	default:
-		return 0, baseError(fnParseUint, s0, base)
-	}
-
-	if bitSize == 0 {
-		bitSize = IntSize
-	} else if bitSize < 0 || bitSize > 64 {
-		return 0, bitSizeError(fnParseUint, s0, bitSize)
-	}
-
-	// Cutoff is the smallest number such that cutoff*base > maxUint64.
-	// Use compile-time constants for common cases.
-	var cutoff uint64
-	switch base {
-	case 10:
-		cutoff = maxUint64/10 + 1
-	case 16:
-		cutoff = maxUint64/16 + 1
-	default:
-		cutoff = maxUint64/uint64(base) + 1
-	}
-
-	maxVal := uint64(1)<<uint(bitSize) - 1
-
-	underscores := false
-	var n uint64
-	for _, c := range []byte(s) {
-		var d byte
-		switch {
-		case c == '_' && base0:
-			underscores = true
-			continue
-		case '0' <= c && c <= '9':
-			d = c - '0'
-		case 'a' <= lower(c) && lower(c) <= 'z':
-			d = lower(c) - 'a' + 10
-		default:
-			return 0, syntaxError(fnParseUint, s0)
-		}
-
-		if d >= byte(base) {
-			return 0, syntaxError(fnParseUint, s0)
-		}
-
-		if n >= cutoff {
-			// n*base overflows
-			return maxVal, rangeError(fnParseUint, s0)
-		}
-		n *= uint64(base)
-
-		n1 := n + uint64(d)
-		if n1 < n || n1 > maxVal {
-			// n+v overflows
-			return maxVal, rangeError(fnParseUint, s0)
-		}
-		n = n1
-	}
-
-	if underscores && !underscoreOK(s0) {
-		return 0, syntaxError(fnParseUint, s0)
-	}
-
-	return n, nil
-}
-*/
+func ParseUint(s string, base int, bitSize int) (uint64, error)
 
 // ParseInt interprets a string s in the given base (0, 2 to 36) and
 // bit size (0 to 64) and returns the corresponding value i.
-func ParseInt(s string, base int, bitSize int) (i int64, err error) /*{
-	const fnParseInt = "ParseInt"
-
-	if s == "" {
-		return 0, syntaxError(fnParseInt, s)
-	}
-
-	// Pick off leading sign.
-	s0 := s
-	neg := false
-	if s[0] == '+' {
-		s = s[1:]
-	} else if s[0] == '-' {
-		neg = true
-		s = s[1:]
-	}
-
-	// Convert unsigned and check range.
-	var un uint64
-	un, err = ParseUint(s, base, bitSize)
-	if err != nil && err.(*NumError).Err != ErrRange {
-		err.(*NumError).Func = fnParseInt
-		err.(*NumError).Num = s0
-		return 0, err
-	}
-
-	if bitSize == 0 {
-		bitSize = IntSize
-	}
-
-	cutoff := uint64(1 << uint(bitSize-1))
-	if !neg && un >= cutoff {
-		return int64(cutoff - 1), rangeError(fnParseInt, s0)
-	}
-	if neg && un > cutoff {
-		return -int64(cutoff), rangeError(fnParseInt, s0)
-	}
-	n := int64(un)
-	if neg {
-		n = -n
-	}
-	return n, nil
-}
-*/
+func ParseInt(s string, base int, bitSize int) (i int64, err error) 
 
 // Atoi is equivalent to ParseInt(s, 10, 0), converted to type int.
-func Atoi(s string) (int, error) /*{
-	const fnAtoi = "Atoi"
-
-	sLen := len(s)
-	if intSize == 32 && (0 < sLen && sLen < 10) ||
-		intSize == 64 && (0 < sLen && sLen < 19) {
-		// Fast path for small integers that fit int type.
-		s0 := s
-		if s[0] == '-' || s[0] == '+' {
-			s = s[1:]
-			if len(s) < 1 {
-				return 0, &NumError{fnAtoi, s0, ErrSyntax}
-			}
-		}
-
-		n := 0
-		for _, ch := range []byte(s) {
-			ch -= '0'
-			if ch > 9 {
-				return 0, &NumError{fnAtoi, s0, ErrSyntax}
-			}
-			n = n*10 + int(ch)
-		}
-		if s0[0] == '-' {
-			n = -n
-		}
-		return n, nil
-	}
-
-	// Slow path for invalid, big, or underscored integers.
-	i64, err := ParseInt(s, 10, 0)
-	if nerr, ok := err.(*NumError); ok {
-		nerr.Func = fnAtoi
-	}
-	return int(i64), err
-}
-*/
+func Atoi(s string) (int, error) 

--- a/src/main/resources/stubs/strconv/atoi.gobra
+++ b/src/main/resources/stubs/strconv/atoi.gobra
@@ -22,7 +22,10 @@ type NumError struct {
 	Err  error  // the reason the conversion failed (e.g. ErrRange, ErrSyntax, etc.)
 }
 
-func (e *NumError) Error() string /*{
+requires p > 0
+requires acc(e, p)
+ensures acc(e, p)
+func (e *NumError) Error(ghost p perm) string /*{
 	return "strconv." + e.Func + ": " + "parsing " + Quote(e.Num) + ": " + e.Err.Error()
 }*/
 

--- a/src/main/resources/stubs/strings/strings.gobra
+++ b/src/main/resources/stubs/strings/strings.gobra
@@ -103,19 +103,23 @@ func LastIndexByte(s string, c byte) int /*{
 
 // SplitN slices s into substrings separated by sep and returns a slice of
 // the substrings between those separators.
-func SplitN(s, sep string, n int) []string
+ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+func SplitN(s, sep string, n int) (res []string)
 
 // SplitAfterN slices s into substrings after each instance of sep and
 // returns a slice of those substrings.
-func SplitAfterN(s, sep string, n int) []string
+ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+func SplitAfterN(s, sep string, n int) (res []string)
 
 // Split slices s into all substrings separated by sep and returns a slice of
 // the substrings between those separators.
-func Split(s, sep string) []string //{ return genSplit(s, sep, 0, -1) }
+ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+func Split(s, sep string) (res []string) //{ return genSplit(s, sep, 0, -1) }
 
 // SplitAfter slices s into all substrings after each instance of sep and
 // returns a slice of those substrings.
-func SplitAfter(s, sep string) []string /*{
+ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+func SplitAfter(s, sep string) (res []string) /*{
 	return genSplit(s, sep, len(sep), -1)
 }*/
 
@@ -124,7 +128,8 @@ func SplitAfter(s, sep string) []string /*{
 // Fields splits the string s around each instance of one or more consecutive white space
 // characters, as defined by unicode.IsSpace, returning a slice of substrings of s or an
 // empty slice if s contains only white space.
-func Fields(s string) []string
+ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+func Fields(s string) (res []string)
 
 // FieldsFunc splits the string s at each run of Unicode code points c satisfying f(c)
 // and returns an array of slices of s. If all code points in s satisfy f(c) or the

--- a/src/main/resources/stubs/strings/strings.gobra
+++ b/src/main/resources/stubs/strings/strings.gobra
@@ -1,0 +1,1054 @@
+// TODO: change license
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package strings implements simple functions to manipulate UTF-8 encoded strings.
+//
+// For information about UTF-8 strings in Go, see https://blog.golang.org/strings.
+package strings
+
+import (
+	//"internal/bytealg"
+	// "unicode"
+	// "unicode/utf8"
+)
+
+// Count counts the number of non-overlapping instances of substr in s.
+// If substr is an empty string, Count returns 1 + the number of Unicode code points in s.
+func Count(s, substr string) int /*{
+	// special case
+	if len(substr) == 0 {
+		return utf8.RuneCountInString(s) + 1
+	}
+	if len(substr) == 1 {
+		return bytealg.CountString(s, substr[0])
+	}
+	n := 0
+	for {
+		i := Index(s, substr)
+		if i == -1 {
+			return n
+		}
+		n++
+		s = s[i+len(substr):]
+	}
+}*/
+
+// Contains reports whether substr is within s.
+func Contains(s, substr string) bool {
+	return Index(s, substr) >= 0
+}
+
+// ContainsAny reports whether any Unicode code points in chars are within s.
+func ContainsAny(s, chars string) bool {
+	return IndexAny(s, chars) >= 0
+}
+
+// ContainsRune reports whether the Unicode code point r is within s.
+func ContainsRune(s string, r rune) bool {
+	return IndexRune(s, r) >= 0
+}
+
+// LastIndex returns the index of the last instance of substr in s, or -1 if substr is not present in s.
+func LastIndex(s, substr string) int /*{
+	n := len(substr)
+	switch {
+	case n == 0:
+		return len(s)
+	case n == 1:
+		return LastIndexByte(s, substr[0])
+	case n == len(s):
+		if substr == s {
+			return 0
+		}
+		return -1
+	case n > len(s):
+		return -1
+	}
+	// Rabin-Karp search from the end of the string
+	hashss, pow := bytealg.HashStrRev(substr)
+	last := len(s) - n
+	var h uint32
+	for i := len(s) - 1; i >= last; i-- {
+		h = h*bytealg.PrimeRK + uint32(s[i])
+	}
+	if h == hashss && s[last:] == substr {
+		return last
+	}
+	for i := last - 1; i >= 0; i-- {
+		h *= bytealg.PrimeRK
+		h += uint32(s[i])
+		h -= pow * uint32(s[i+n])
+		if h == hashss && s[i:i+n] == substr {
+			return i
+		}
+	}
+	return -1
+}
+*/
+
+// IndexByte returns the index of the first instance of c in s, or -1 if c is not present in s.
+func IndexByte(s string, c byte) int /*{
+	return bytealg.IndexByteString(s, c)
+}
+*/
+
+// IndexRune returns the index of the first instance of the Unicode code point
+// r, or -1 if rune is not present in s.
+// If r is utf8.RuneError, it returns the first instance of any
+// invalid UTF-8 byte sequence.
+func IndexRune(s string, r rune) int /*{
+	switch {
+	case 0 <= r && r < utf8.RuneSelf:
+		return IndexByte(s, byte(r))
+	case r == utf8.RuneError:
+		for i, r := range s {
+			if r == utf8.RuneError {
+				return i
+			}
+		}
+		return -1
+	case !utf8.ValidRune(r):
+		return -1
+	default:
+		return Index(s, string(r))
+	}
+}
+*/
+
+// IndexAny returns the index of the first instance of any Unicode code point
+// from chars in s, or -1 if no Unicode code point from chars is present in s.
+func IndexAny(s, chars string) int /*{
+	if chars == "" {
+		// Avoid scanning all of s.
+		return -1
+	}
+	if len(chars) == 1 {
+		// Avoid scanning all of s.
+		r := rune(chars[0])
+		if r >= utf8.RuneSelf {
+			r = utf8.RuneError
+		}
+		return IndexRune(s, r)
+	}
+	if len(s) > 8 {
+		if as, isASCII := makeASCIISet(chars); isASCII {
+			for i := 0; i < len(s); i++ {
+				if as.contains(s[i]) {
+					return i
+				}
+			}
+			return -1
+		}
+	}
+	for i, c := range s {
+		if IndexRune(chars, c) >= 0 {
+			return i
+		}
+	}
+	return -1
+}
+*/
+
+// LastIndexAny returns the index of the last instance of any Unicode code
+// point from chars in s, or -1 if no Unicode code point from chars is
+// present in s.
+func LastIndexAny(s, chars string) int /*{
+	if chars == "" {
+		// Avoid scanning all of s.
+		return -1
+	}
+	if len(s) == 1 {
+		rc := rune(s[0])
+		if rc >= utf8.RuneSelf {
+			rc = utf8.RuneError
+		}
+		if IndexRune(chars, rc) >= 0 {
+			return 0
+		}
+		return -1
+	}
+	if len(s) > 8 {
+		if as, isASCII := makeASCIISet(chars); isASCII {
+			for i := len(s) - 1; i >= 0; i-- {
+				if as.contains(s[i]) {
+					return i
+				}
+			}
+			return -1
+		}
+	}
+	if len(chars) == 1 {
+		rc := rune(chars[0])
+		if rc >= utf8.RuneSelf {
+			rc = utf8.RuneError
+		}
+		for i := len(s); i > 0; {
+			r, size := utf8.DecodeLastRuneInString(s[:i])
+			i -= size
+			if rc == r {
+				return i
+			}
+		}
+		return -1
+	}
+	for i := len(s); i > 0; {
+		r, size := utf8.DecodeLastRuneInString(s[:i])
+		i -= size
+		if IndexRune(chars, r) >= 0 {
+			return i
+		}
+	}
+	return -1
+}
+*/
+
+// LastIndexByte returns the index of the last instance of c in s, or -1 if c is not present in s.
+func LastIndexByte(s string, c byte) int /*{
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+*/
+
+// Generic split: splits after each instance of sep,
+// including sepSave bytes of sep in the subarrays.
+func genSplit(s, sep string, sepSave, n int) []string /*{
+	if n == 0 {
+		return nil
+	}
+	if sep == "" {
+		return explode(s, n)
+	}
+	if n < 0 {
+		n = Count(s, sep) + 1
+	}
+
+	a := make([]string, n)
+	n--
+	i := 0
+	for i < n {
+		m := Index(s, sep)
+		if m < 0 {
+			break
+		}
+		a[i] = s[:m+sepSave]
+		s = s[m+len(sep):]
+		i++
+	}
+	a[i] = s
+	return a[:i+1]
+}
+*/
+
+// SplitN slices s into substrings separated by sep and returns a slice of
+// the substrings between those separators.
+//
+// The count determines the number of substrings to return:
+//   n > 0: at most n substrings; the last substring will be the unsplit remainder.
+//   n == 0: the result is nil (zero substrings)
+//   n < 0: all substrings
+//
+// Edge cases for s and sep (for example, empty strings) are handled
+// as described in the documentation for Split.
+func SplitN(s, sep string, n int) []string { return genSplit(s, sep, 0, n) }
+
+// SplitAfterN slices s into substrings after each instance of sep and
+// returns a slice of those substrings.
+//
+// The count determines the number of substrings to return:
+//   n > 0: at most n substrings; the last substring will be the unsplit remainder.
+//   n == 0: the result is nil (zero substrings)
+//   n < 0: all substrings
+//
+// Edge cases for s and sep (for example, empty strings) are handled
+// as described in the documentation for SplitAfter.
+func SplitAfterN(s, sep string, n int) []string {
+	return genSplit(s, sep, len(sep), n)
+}
+
+// Split slices s into all substrings separated by sep and returns a slice of
+// the substrings between those separators.
+//
+// If s does not contain sep and sep is not empty, Split returns a
+// slice of length 1 whose only element is s.
+//
+// If sep is empty, Split splits after each UTF-8 sequence. If both s
+// and sep are empty, Split returns an empty slice.
+//
+// It is equivalent to SplitN with a count of -1.
+func Split(s, sep string) []string //{ return genSplit(s, sep, 0, -1) }
+
+// SplitAfter slices s into all substrings after each instance of sep and
+// returns a slice of those substrings.
+//
+// If s does not contain sep and sep is not empty, SplitAfter returns
+// a slice of length 1 whose only element is s.
+//
+// If sep is empty, SplitAfter splits after each UTF-8 sequence. If
+// both s and sep are empty, SplitAfter returns an empty slice.
+//
+// It is equivalent to SplitAfterN with a count of -1.
+func SplitAfter(s, sep string) []string /*{
+	return genSplit(s, sep, len(sep), -1)
+}*/
+
+// var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
+
+// Fields splits the string s around each instance of one or more consecutive white space
+// characters, as defined by unicode.IsSpace, returning a slice of substrings of s or an
+// empty slice if s contains only white space.
+func Fields(s string) []string /*{
+	// First count the fields.
+	// This is an exact count if s is ASCII, otherwise it is an approximation.
+	n := 0
+	wasSpace := 1
+	// setBits is used to track which bits are set in the bytes of s.
+	setBits := uint8(0)
+	for i := 0; i < len(s); i++ {
+		r := s[i]
+		setBits |= r
+		isSpace := int(asciiSpace[r])
+		n += wasSpace & ^isSpace
+		wasSpace = isSpace
+	}
+
+	if setBits >= utf8.RuneSelf {
+		// Some runes in the input string are not ASCII.
+		return FieldsFunc(s, unicode.IsSpace)
+	}
+	// ASCII fast path
+	a := make([]string, n)
+	na := 0
+	fieldStart := 0
+	i := 0
+	// Skip spaces in the front of the input.
+	for i < len(s) && asciiSpace[s[i]] != 0 {
+		i++
+	}
+	fieldStart = i
+	for i < len(s) {
+		if asciiSpace[s[i]] == 0 {
+			i++
+			continue
+		}
+		a[na] = s[fieldStart:i]
+		na++
+		i++
+		// Skip spaces in between fields.
+		for i < len(s) && asciiSpace[s[i]] != 0 {
+			i++
+		}
+		fieldStart = i
+	}
+	if fieldStart < len(s) { // Last field might end at EOF.
+		a[na] = s[fieldStart:]
+	}
+	return a
+}
+*/
+
+// FieldsFunc splits the string s at each run of Unicode code points c satisfying f(c)
+// and returns an array of slices of s. If all code points in s satisfy f(c) or the
+// string is empty, an empty slice is returned.
+//
+// FieldsFunc makes no guarantees about the order in which it calls f(c)
+// and assumes that f always returns the same value for a given c.
+/*
+func FieldsFunc(s string, f func(rune) bool) []string {
+	// A span is used to record a slice of s of the form s[start:end].
+	// The start index is inclusive and the end index is exclusive.
+	type span struct {
+		start int
+		end   int
+	}
+	spans := make([]span, 0, 32)
+
+	// Find the field start and end indices.
+	// Doing this in a separate pass (rather than slicing the string s
+	// and collecting the result substrings right away) is significantly
+	// more efficient, possibly due to cache effects.
+	start := -1 // valid span start if >= 0
+	for end, rune := range s {
+		if f(rune) {
+			if start >= 0 {
+				spans = append(spans, span{start, end})
+				// Set start to a negative value.
+				// Note: using -1 here consistently and reproducibly
+				// slows down this code by a several percent on amd64.
+				start = ^start
+			}
+		} else {
+			if start < 0 {
+				start = end
+			}
+		}
+	}
+
+	// Last field might end at EOF.
+	if start >= 0 {
+		spans = append(spans, span{start, len(s)})
+	}
+
+	// Create strings from recorded field indices.
+	a := make([]string, len(spans))
+	for i, span := range spans {
+		a[i] = s[span.start:span.end]
+	}
+
+	return a
+}
+*/
+
+// Join concatenates the elements of its first argument to create a single string. The separator
+// string sep is placed between elements in the resulting string.
+func Join(elems []string, sep string) string /*{
+	switch len(elems) {
+	case 0:
+		return ""
+	case 1:
+		return elems[0]
+	}
+	n := len(sep) * (len(elems) - 1)
+	for i := 0; i < len(elems); i++ {
+		n += len(elems[i])
+	}
+
+	var b Builder
+	b.Grow(n)
+	b.WriteString(elems[0])
+	for _, s := range elems[1:] {
+		b.WriteString(sep)
+		b.WriteString(s)
+	}
+	return b.String()
+}
+*/
+
+// HasPrefix tests whether the string s begins with prefix.
+func HasPrefix(s, prefix string) bool /*{
+	return len(s) >= len(prefix) && s[0:len(prefix)] == prefix
+}*/
+
+// HasSuffix tests whether the string s ends with suffix.
+func HasSuffix(s, suffix string) bool /*{
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}
+*/
+
+// Map returns a copy of the string s with all its characters modified
+// according to the mapping function. If mapping returns a negative value, the character is
+// dropped from the string with no replacement.
+/*
+func Map(mapping func(rune) rune, s string) string {
+	// In the worst case, the string can grow when mapped, making
+	// things unpleasant. But it's so rare we barge in assuming it's
+	// fine. It could also shrink but that falls out naturally.
+
+	// The output buffer b is initialized on demand, the first
+	// time a character differs.
+	var b Builder
+
+	for i, c := range s {
+		r := mapping(c)
+		if r == c && c != utf8.RuneError {
+			continue
+		}
+
+		var width int
+		if c == utf8.RuneError {
+			c, width = utf8.DecodeRuneInString(s[i:])
+			if width != 1 && r == c {
+				continue
+			}
+		} else {
+			width = utf8.RuneLen(c)
+		}
+
+		b.Grow(len(s) + utf8.UTFMax)
+		b.WriteString(s[:i])
+		if r >= 0 {
+			b.WriteRune(r)
+		}
+
+		s = s[i+width:]
+		break
+	}
+
+	// Fast path for unchanged input
+	if b.Cap() == 0 { // didn't call b.Grow above
+		return s
+	}
+
+	for _, c := range s {
+		r := mapping(c)
+
+		if r >= 0 {
+			// common case
+			// Due to inlining, it is more performant to determine if WriteByte should be
+			// invoked rather than always call WriteRune
+			if r < utf8.RuneSelf {
+				b.WriteByte(byte(r))
+			} else {
+				// r is not a ASCII rune.
+				b.WriteRune(r)
+			}
+		}
+	}
+
+	return b.String()
+}
+*/
+
+// Repeat returns a new string consisting of count copies of the string s.
+//
+// It panics if count is negative or if
+// the result of (len(s) * count) overflows.
+func Repeat(s string, count int) string /*{
+	if count == 0 {
+		return ""
+	}
+
+	// Since we cannot return an error on overflow,
+	// we should panic if the repeat will generate
+	// an overflow.
+	// See Issue golang.org/issue/16237
+	if count < 0 {
+		panic("strings: negative Repeat count")
+	} else if len(s)*count/count != len(s) {
+		panic("strings: Repeat count causes overflow")
+	}
+
+	n := len(s) * count
+	var b Builder
+	b.Grow(n)
+	b.WriteString(s)
+	for b.Len() < n {
+		if b.Len() <= n/2 {
+			b.WriteString(b.String())
+		} else {
+			b.WriteString(b.String()[:n-b.Len()])
+			break
+		}
+	}
+	return b.String()
+}
+*/
+
+// ToUpper returns s with all Unicode letters mapped to their upper case.
+func ToUpper(s string) string /*{
+	isASCII, hasLower := true, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= utf8.RuneSelf {
+			isASCII = false
+			break
+		}
+		hasLower = hasLower || ('a' <= c && c <= 'z')
+	}
+
+	if isASCII { // optimize for ASCII-only strings.
+		if !hasLower {
+			return s
+		}
+		var b Builder
+		b.Grow(len(s))
+		for i := 0; i < len(s); i++ {
+			c := s[i]
+			if 'a' <= c && c <= 'z' {
+				c -= 'a' - 'A'
+			}
+			b.WriteByte(c)
+		}
+		return b.String()
+	}
+	return Map(unicode.ToUpper, s)
+}
+*/
+
+// ToLower returns s with all Unicode letters mapped to their lower case.
+func ToLower(s string) string /*{
+	isASCII, hasUpper := true, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= utf8.RuneSelf {
+			isASCII = false
+			break
+		}
+		hasUpper = hasUpper || ('A' <= c && c <= 'Z')
+	}
+
+	if isASCII { // optimize for ASCII-only strings.
+		if !hasUpper {
+			return s
+		}
+		var b Builder
+		b.Grow(len(s))
+		for i := 0; i < len(s); i++ {
+			c := s[i]
+			if 'A' <= c && c <= 'Z' {
+				c += 'a' - 'A'
+			}
+			b.WriteByte(c)
+		}
+		return b.String()
+	}
+	return Map(unicode.ToLower, s)
+}
+*/
+
+// ToTitle returns a copy of the string s with all Unicode letters mapped to
+// their Unicode title case.
+func ToTitle(s string) string // { return Map(unicode.ToTitle, s) }
+
+// ToUpperSpecial returns a copy of the string s with all Unicode letters mapped to their
+// upper case using the case mapping specified by c.
+/*
+func ToUpperSpecial(c unicode.SpecialCase, s string) string {
+	return Map(c.ToUpper, s)
+}
+*/
+
+// ToLowerSpecial returns a copy of the string s with all Unicode letters mapped to their
+// lower case using the case mapping specified by c.
+/*
+func ToLowerSpecial(c unicode.SpecialCase, s string) string {
+	return Map(c.ToLower, s)
+}
+*/
+
+// ToTitleSpecial returns a copy of the string s with all Unicode letters mapped to their
+// Unicode title case, giving priority to the special casing rules.
+/*
+func ToTitleSpecial(c unicode.SpecialCase, s string) string {
+	return Map(c.ToTitle, s)
+}
+*/
+
+// ToValidUTF8 returns a copy of the string s with each run of invalid UTF-8 byte sequences
+// replaced by the replacement string, which may be empty.
+func ToValidUTF8(s, replacement string) string /*{
+	var b Builder
+
+	for i, c := range s {
+		if c != utf8.RuneError {
+			continue
+		}
+
+		_, wid := utf8.DecodeRuneInString(s[i:])
+		if wid == 1 {
+			b.Grow(len(s) + len(replacement))
+			b.WriteString(s[:i])
+			s = s[i:]
+			break
+		}
+	}
+
+	// Fast path for unchanged input
+	if b.Cap() == 0 { // didn't call b.Grow above
+		return s
+	}
+
+	invalid := false // previous byte was from an invalid UTF-8 sequence
+	for i := 0; i < len(s); {
+		c := s[i]
+		if c < utf8.RuneSelf {
+			i++
+			invalid = false
+			b.WriteByte(c)
+			continue
+		}
+		_, wid := utf8.DecodeRuneInString(s[i:])
+		if wid == 1 {
+			i++
+			if !invalid {
+				invalid = true
+				b.WriteString(replacement)
+			}
+			continue
+		}
+		invalid = false
+		b.WriteString(s[i : i+wid])
+		i += wid
+	}
+
+	return b.String()
+}
+*/
+
+// isSeparator reports whether the rune could mark a word boundary.
+// TODO: update when package unicode captures more of the properties.
+func isSeparator(r rune) bool /*{
+	// ASCII alphanumerics and underscore are not separators
+	if r <= 0x7F {
+		switch {
+		case '0' <= r && r <= '9':
+			return false
+		case 'a' <= r && r <= 'z':
+			return false
+		case 'A' <= r && r <= 'Z':
+			return false
+		case r == '_':
+			return false
+		}
+		return true
+	}
+	// Letters and digits are not separators
+	if unicode.IsLetter(r) || unicode.IsDigit(r) {
+		return false
+	}
+	// Otherwise, all we can do for now is treat spaces as separators.
+	return unicode.IsSpace(r)
+}
+*/
+
+// Title returns a copy of the string s with all Unicode letters that begin words
+// mapped to their Unicode title case.
+//
+// BUG(rsc): The rule Title uses for word boundaries does not handle Unicode punctuation properly.
+func Title(s string) string /*{
+	// Use a closure here to remember state.
+	// Hackish but effective. Depends on Map scanning in order and calling
+	// the closure once per rune.
+	prev := ' '
+	return Map(
+		func(r rune) rune {
+			if isSeparator(prev) {
+				prev = r
+				return unicode.ToTitle(r)
+			}
+			prev = r
+			return r
+		},
+		s)
+}
+*/
+
+// TrimLeftFunc returns a slice of the string s with all leading
+// Unicode code points c satisfying f(c) removed.
+/*
+func TrimLeftFunc(s string, f func(rune) bool) string {
+	i := indexFunc(s, f, false)
+	if i == -1 {
+		return ""
+	}
+	return s[i:]
+}
+*/
+
+// TrimRightFunc returns a slice of the string s with all trailing
+// Unicode code points c satisfying f(c) removed.
+/*
+func TrimRightFunc(s string, f func(rune) bool) string {
+	i := lastIndexFunc(s, f, false)
+	if i >= 0 && s[i] >= utf8.RuneSelf {
+		_, wid := utf8.DecodeRuneInString(s[i:])
+		i += wid
+	} else {
+		i++
+	}
+	return s[0:i]
+}
+
+// TrimFunc returns a slice of the string s with all leading
+// and trailing Unicode code points c satisfying f(c) removed.
+func TrimFunc(s string, f func(rune) bool) string {
+	return TrimRightFunc(TrimLeftFunc(s, f), f)
+}
+
+// IndexFunc returns the index into s of the first Unicode
+// code point satisfying f(c), or -1 if none do.
+func IndexFunc(s string, f func(rune) bool) int {
+	return indexFunc(s, f, true)
+}
+
+// LastIndexFunc returns the index into s of the last
+// Unicode code point satisfying f(c), or -1 if none do.
+func LastIndexFunc(s string, f func(rune) bool) int {
+	return lastIndexFunc(s, f, true)
+}
+*/
+
+// Trim returns a slice of the string s with all leading and
+// trailing Unicode code points contained in cutset removed.
+func Trim(s, cutset string) string /*{
+	if s == "" || cutset == "" {
+		return s
+	}
+	return TrimFunc(s, makeCutsetFunc(cutset))
+}
+*/
+
+// TrimLeft returns a slice of the string s with all leading
+// Unicode code points contained in cutset removed.
+//
+// To remove a prefix, use TrimPrefix instead.
+func TrimLeft(s, cutset string) string /*{
+	if s == "" || cutset == "" {
+		return s
+	}
+	return TrimLeftFunc(s, makeCutsetFunc(cutset))
+}
+*/
+
+// TrimRight returns a slice of the string s, with all trailing
+// Unicode code points contained in cutset removed.
+//
+// To remove a suffix, use TrimSuffix instead.
+func TrimRight(s, cutset string) string /*{
+	if s == "" || cutset == "" {
+		return s
+	}
+	return TrimRightFunc(s, makeCutsetFunc(cutset))
+}
+*/
+
+// TrimSpace returns a slice of the string s, with all leading
+// and trailing white space removed, as defined by Unicode.
+func TrimSpace(s string) string /*{
+	// Fast path for ASCII: look for the first ASCII non-space byte
+	start := 0
+	for ; start < len(s); start++ {
+		c := s[start]
+		if c >= utf8.RuneSelf {
+			// If we run into a non-ASCII byte, fall back to the
+			// slower unicode-aware method on the remaining bytes
+			return TrimFunc(s[start:], unicode.IsSpace)
+		}
+		if asciiSpace[c] == 0 {
+			break
+		}
+	}
+
+	// Now look for the first ASCII non-space byte from the end
+	stop := len(s)
+	for ; stop > start; stop-- {
+		c := s[stop-1]
+		if c >= utf8.RuneSelf {
+			return TrimFunc(s[start:stop], unicode.IsSpace)
+		}
+		if asciiSpace[c] == 0 {
+			break
+		}
+	}
+
+	// At this point s[start:stop] starts and ends with an ASCII
+	// non-space bytes, so we're done. Non-ASCII cases have already
+	// been handled above.
+	return s[start:stop]
+}
+*/
+
+// TrimPrefix returns s without the provided leading prefix string.
+// If s doesn't start with prefix, s is returned unchanged.
+func TrimPrefix(s, prefix string) string /*{
+	if HasPrefix(s, prefix) {
+		return s[len(prefix):]
+	}
+	return s
+}
+*/
+
+// TrimSuffix returns s without the provided trailing suffix string.
+// If s doesn't end with suffix, s is returned unchanged.
+func TrimSuffix(s, suffix string) string /*{
+	if HasSuffix(s, suffix) {
+		return s[:len(s)-len(suffix)]
+	}
+	return s
+}
+*/
+
+// Replace returns a copy of the string s with the first n
+// non-overlapping instances of old replaced by new.
+// If old is empty, it matches at the beginning of the string
+// and after each UTF-8 sequence, yielding up to k+1 replacements
+// for a k-rune string.
+// If n < 0, there is no limit on the number of replacements.
+func Replace(s, oldS, newS string, n int) string /*{
+	if old == new || n == 0 {
+		return s // avoid allocation
+	}
+
+	// Compute number of replacements.
+	if m := Count(s, old); m == 0 {
+		return s // avoid allocation
+	} else if n < 0 || m < n {
+		n = m
+	}
+
+	// Apply replacements to buffer.
+	var b Builder
+	b.Grow(len(s) + n*(len(new)-len(old)))
+	start := 0
+	for i := 0; i < n; i++ {
+		j := start
+		if len(old) == 0 {
+			if i > 0 {
+				_, wid := utf8.DecodeRuneInString(s[start:])
+				j += wid
+			}
+		} else {
+			j += Index(s[start:], old)
+		}
+		b.WriteString(s[start:j])
+		b.WriteString(new)
+		start = j + len(old)
+	}
+	b.WriteString(s[start:])
+	return b.String()
+}
+*/
+
+// ReplaceAll returns a copy of the string s with all
+// non-overlapping instances of old replaced by new.
+// If old is empty, it matches at the beginning of the string
+// and after each UTF-8 sequence, yielding up to k+1 replacements
+// for a k-rune string.
+func ReplaceAll(s, oldS, newS string) string {
+	return Replace(s, oldS, newS, -1)
+}
+
+// EqualFold reports whether s and t, interpreted as UTF-8 strings,
+// are equal under Unicode case-folding, which is a more general
+// form of case-insensitivity.
+func EqualFold(s, t string) bool /*{
+	for s != "" && t != "" {
+		// Extract first rune from each string.
+		var sr, tr rune
+		if s[0] < utf8.RuneSelf {
+			sr, s = rune(s[0]), s[1:]
+		} else {
+			r, size := utf8.DecodeRuneInString(s)
+			sr, s = r, s[size:]
+		}
+		if t[0] < utf8.RuneSelf {
+			tr, t = rune(t[0]), t[1:]
+		} else {
+			r, size := utf8.DecodeRuneInString(t)
+			tr, t = r, t[size:]
+		}
+
+		// If they match, keep going; if not, return false.
+
+		// Easy case.
+		if tr == sr {
+			continue
+		}
+
+		// Make sr < tr to simplify what follows.
+		if tr < sr {
+			tr, sr = sr, tr
+		}
+		// Fast check for ASCII.
+		if tr < utf8.RuneSelf {
+			// ASCII only, sr/tr must be upper/lower case
+			if 'A' <= sr && sr <= 'Z' && tr == sr+'a'-'A' {
+				continue
+			}
+			return false
+		}
+
+		// General case. SimpleFold(x) returns the next equivalent rune > x
+		// or wraps around to smaller values.
+		r := unicode.SimpleFold(sr)
+		for r != sr && r < tr {
+			r = unicode.SimpleFold(r)
+		}
+		if r == tr {
+			continue
+		}
+		return false
+	}
+
+	// One string is empty. Are both?
+	return s == t
+}
+*/
+
+// Index returns the index of the first instance of substr in s, or -1 if substr is not present in s.
+func Index(s, substr string) int /*{
+	n := len(substr)
+	switch {
+	case n == 0:
+		return 0
+	case n == 1:
+		return IndexByte(s, substr[0])
+	case n == len(s):
+		if substr == s {
+			return 0
+		}
+		return -1
+	case n > len(s):
+		return -1
+	case n <= bytealg.MaxLen:
+		// Use brute force when s and substr both are small
+		if len(s) <= bytealg.MaxBruteForce {
+			return bytealg.IndexString(s, substr)
+		}
+		c0 := substr[0]
+		c1 := substr[1]
+		i := 0
+		t := len(s) - n + 1
+		fails := 0
+		for i < t {
+			if s[i] != c0 {
+				// IndexByte is faster than bytealg.IndexString, so use it as long as
+				// we're not getting lots of false positives.
+				o := IndexByte(s[i+1:t], c0)
+				if o < 0 {
+					return -1
+				}
+				i += o + 1
+			}
+			if s[i+1] == c1 && s[i:i+n] == substr {
+				return i
+			}
+			fails++
+			i++
+			// Switch to bytealg.IndexString when IndexByte produces too many false positives.
+			if fails > bytealg.Cutover(i) {
+				r := bytealg.IndexString(s[i:], substr)
+				if r >= 0 {
+					return r + i
+				}
+				return -1
+			}
+		}
+		return -1
+	}
+	c0 := substr[0]
+	c1 := substr[1]
+	i := 0
+	t := len(s) - n + 1
+	fails := 0
+	for i < t {
+		if s[i] != c0 {
+			o := IndexByte(s[i+1:t], c0)
+			if o < 0 {
+				return -1
+			}
+			i += o + 1
+		}
+		if s[i+1] == c1 && s[i:i+n] == substr {
+			return i
+		}
+		i++
+		fails++
+		if fails >= 4+i>>4 && i < t {
+			// See comment in ../bytes/bytes.go.
+			j := bytealg.IndexRabinKarp(s[i:], substr)
+			if j < 0 {
+				return -1
+			}
+			return i + j
+		}
+	}
+	return -1
+}
+*/

--- a/src/main/resources/stubs/strings/strings.gobra
+++ b/src/main/resources/stubs/strings/strings.gobra
@@ -137,13 +137,12 @@ func FieldsFunc(s string, f func(rune) bool) []string
 // Join concatenates the elements of its first argument to create a single string. The separator
 // string sep is placed between elements in the resulting string.
 
-/* // (joao) makes silver crash with error "Contract might not be well-formed"
-requires forall i int :: 0 < i && i < len(elems) ==> acc(&elems[i], _)
+requires forall i int :: 0 <= i && i < len(elems) ==> acc(&elems[i], _)
 ensures len(elems) == 0 ==> res == ""
 ensures len(elems) == 1 ==> res == elems[0]
-ensures len(elems) > 1 ==> res == elems[0] + sep + Join(elems[1:], sep)
-pure */
-func Join(elems []string, sep string) (res string) /*{
+// (joao) Leads to precondition of call might not hold (permission to elems[i] might not suffice)
+// ensures len(elems) > 1 ==> res == elems[0] + sep + Join(elems[1:], sep)
+pure func Join(elems []string, sep string) (res string) /*{
 	switch len(elems) {
 	case 0:
 		return ""

--- a/src/main/resources/stubs/strings/strings.gobra
+++ b/src/main/resources/stubs/strings/strings.gobra
@@ -1,12 +1,10 @@
-// TODO: change license
-
 // Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in https://golang.org/LICENSE
 
-// Package strings implements simple functions to manipulate UTF-8 encoded strings.
-//
-// For information about UTF-8 strings in Go, see https://blog.golang.org/strings.
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/strings/strings.go
+
 package strings
 
 import (
@@ -52,42 +50,7 @@ func ContainsRune(s string, r rune) bool {
 }
 
 // LastIndex returns the index of the last instance of substr in s, or -1 if substr is not present in s.
-func LastIndex(s, substr string) int /*{
-	n := len(substr)
-	switch {
-	case n == 0:
-		return len(s)
-	case n == 1:
-		return LastIndexByte(s, substr[0])
-	case n == len(s):
-		if substr == s {
-			return 0
-		}
-		return -1
-	case n > len(s):
-		return -1
-	}
-	// Rabin-Karp search from the end of the string
-	hashss, pow := bytealg.HashStrRev(substr)
-	last := len(s) - n
-	var h uint32
-	for i := len(s) - 1; i >= last; i-- {
-		h = h*bytealg.PrimeRK + uint32(s[i])
-	}
-	if h == hashss && s[last:] == substr {
-		return last
-	}
-	for i := last - 1; i >= 0; i-- {
-		h *= bytealg.PrimeRK
-		h += uint32(s[i])
-		h -= pow * uint32(s[i+n])
-		if h == hashss && s[i:i+n] == substr {
-			return i
-		}
-	}
-	return -1
-}
-*/
+func LastIndex(s, substr string) int
 
 // IndexByte returns the index of the first instance of c in s, or -1 if c is not present in s.
 func IndexByte(s string, c byte) int /*{
@@ -120,180 +83,38 @@ func IndexRune(s string, r rune) int /*{
 
 // IndexAny returns the index of the first instance of any Unicode code point
 // from chars in s, or -1 if no Unicode code point from chars is present in s.
-func IndexAny(s, chars string) int /*{
-	if chars == "" {
-		// Avoid scanning all of s.
-		return -1
-	}
-	if len(chars) == 1 {
-		// Avoid scanning all of s.
-		r := rune(chars[0])
-		if r >= utf8.RuneSelf {
-			r = utf8.RuneError
-		}
-		return IndexRune(s, r)
-	}
-	if len(s) > 8 {
-		if as, isASCII := makeASCIISet(chars); isASCII {
-			for i := 0; i < len(s); i++ {
-				if as.contains(s[i]) {
-					return i
-				}
-			}
-			return -1
-		}
-	}
-	for i, c := range s {
-		if IndexRune(chars, c) >= 0 {
-			return i
-		}
-	}
-	return -1
-}
-*/
+func IndexAny(s, chars string) int
 
 // LastIndexAny returns the index of the last instance of any Unicode code
 // point from chars in s, or -1 if no Unicode code point from chars is
 // present in s.
-func LastIndexAny(s, chars string) int /*{
-	if chars == "" {
-		// Avoid scanning all of s.
-		return -1
-	}
-	if len(s) == 1 {
-		rc := rune(s[0])
-		if rc >= utf8.RuneSelf {
-			rc = utf8.RuneError
-		}
-		if IndexRune(chars, rc) >= 0 {
-			return 0
-		}
-		return -1
-	}
-	if len(s) > 8 {
-		if as, isASCII := makeASCIISet(chars); isASCII {
-			for i := len(s) - 1; i >= 0; i-- {
-				if as.contains(s[i]) {
-					return i
-				}
-			}
-			return -1
-		}
-	}
-	if len(chars) == 1 {
-		rc := rune(chars[0])
-		if rc >= utf8.RuneSelf {
-			rc = utf8.RuneError
-		}
-		for i := len(s); i > 0; {
-			r, size := utf8.DecodeLastRuneInString(s[:i])
-			i -= size
-			if rc == r {
-				return i
-			}
-		}
-		return -1
-	}
-	for i := len(s); i > 0; {
-		r, size := utf8.DecodeLastRuneInString(s[:i])
-		i -= size
-		if IndexRune(chars, r) >= 0 {
-			return i
-		}
-	}
-	return -1
-}
-*/
+func LastIndexAny(s, chars string) int
 
 // LastIndexByte returns the index of the last instance of c in s, or -1 if c is not present in s.
 func LastIndexByte(s string, c byte) int /*{
 	for i := len(s) - 1; i >= 0; i-- {
-		if s[i] == c {
+		if s[i] == c { // (joao) no support for indexing a string
 			return i
 		}
 	}
 	return -1
-}
-*/
-
-// Generic split: splits after each instance of sep,
-// including sepSave bytes of sep in the subarrays.
-func genSplit(s, sep string, sepSave, n int) []string /*{
-	if n == 0 {
-		return nil
-	}
-	if sep == "" {
-		return explode(s, n)
-	}
-	if n < 0 {
-		n = Count(s, sep) + 1
-	}
-
-	a := make([]string, n)
-	n--
-	i := 0
-	for i < n {
-		m := Index(s, sep)
-		if m < 0 {
-			break
-		}
-		a[i] = s[:m+sepSave]
-		s = s[m+len(sep):]
-		i++
-	}
-	a[i] = s
-	return a[:i+1]
 }
 */
 
 // SplitN slices s into substrings separated by sep and returns a slice of
 // the substrings between those separators.
-//
-// The count determines the number of substrings to return:
-//   n > 0: at most n substrings; the last substring will be the unsplit remainder.
-//   n == 0: the result is nil (zero substrings)
-//   n < 0: all substrings
-//
-// Edge cases for s and sep (for example, empty strings) are handled
-// as described in the documentation for Split.
-func SplitN(s, sep string, n int) []string { return genSplit(s, sep, 0, n) }
+func SplitN(s, sep string, n int) []string
 
 // SplitAfterN slices s into substrings after each instance of sep and
 // returns a slice of those substrings.
-//
-// The count determines the number of substrings to return:
-//   n > 0: at most n substrings; the last substring will be the unsplit remainder.
-//   n == 0: the result is nil (zero substrings)
-//   n < 0: all substrings
-//
-// Edge cases for s and sep (for example, empty strings) are handled
-// as described in the documentation for SplitAfter.
-func SplitAfterN(s, sep string, n int) []string {
-	return genSplit(s, sep, len(sep), n)
-}
+func SplitAfterN(s, sep string, n int) []string
 
 // Split slices s into all substrings separated by sep and returns a slice of
 // the substrings between those separators.
-//
-// If s does not contain sep and sep is not empty, Split returns a
-// slice of length 1 whose only element is s.
-//
-// If sep is empty, Split splits after each UTF-8 sequence. If both s
-// and sep are empty, Split returns an empty slice.
-//
-// It is equivalent to SplitN with a count of -1.
 func Split(s, sep string) []string //{ return genSplit(s, sep, 0, -1) }
 
 // SplitAfter slices s into all substrings after each instance of sep and
 // returns a slice of those substrings.
-//
-// If s does not contain sep and sep is not empty, SplitAfter returns
-// a slice of length 1 whose only element is s.
-//
-// If sep is empty, SplitAfter splits after each UTF-8 sequence. If
-// both s and sep are empty, SplitAfter returns an empty slice.
-//
-// It is equivalent to SplitAfterN with a count of -1.
 func SplitAfter(s, sep string) []string /*{
 	return genSplit(s, sep, len(sep), -1)
 }*/
@@ -303,111 +124,26 @@ func SplitAfter(s, sep string) []string /*{
 // Fields splits the string s around each instance of one or more consecutive white space
 // characters, as defined by unicode.IsSpace, returning a slice of substrings of s or an
 // empty slice if s contains only white space.
-func Fields(s string) []string /*{
-	// First count the fields.
-	// This is an exact count if s is ASCII, otherwise it is an approximation.
-	n := 0
-	wasSpace := 1
-	// setBits is used to track which bits are set in the bytes of s.
-	setBits := uint8(0)
-	for i := 0; i < len(s); i++ {
-		r := s[i]
-		setBits |= r
-		isSpace := int(asciiSpace[r])
-		n += wasSpace & ^isSpace
-		wasSpace = isSpace
-	}
-
-	if setBits >= utf8.RuneSelf {
-		// Some runes in the input string are not ASCII.
-		return FieldsFunc(s, unicode.IsSpace)
-	}
-	// ASCII fast path
-	a := make([]string, n)
-	na := 0
-	fieldStart := 0
-	i := 0
-	// Skip spaces in the front of the input.
-	for i < len(s) && asciiSpace[s[i]] != 0 {
-		i++
-	}
-	fieldStart = i
-	for i < len(s) {
-		if asciiSpace[s[i]] == 0 {
-			i++
-			continue
-		}
-		a[na] = s[fieldStart:i]
-		na++
-		i++
-		// Skip spaces in between fields.
-		for i < len(s) && asciiSpace[s[i]] != 0 {
-			i++
-		}
-		fieldStart = i
-	}
-	if fieldStart < len(s) { // Last field might end at EOF.
-		a[na] = s[fieldStart:]
-	}
-	return a
-}
-*/
+func Fields(s string) []string
 
 // FieldsFunc splits the string s at each run of Unicode code points c satisfying f(c)
 // and returns an array of slices of s. If all code points in s satisfy f(c) or the
 // string is empty, an empty slice is returned.
-//
-// FieldsFunc makes no guarantees about the order in which it calls f(c)
-// and assumes that f always returns the same value for a given c.
+// (joao) no support for higher-order functions
 /*
-func FieldsFunc(s string, f func(rune) bool) []string {
-	// A span is used to record a slice of s of the form s[start:end].
-	// The start index is inclusive and the end index is exclusive.
-	type span struct {
-		start int
-		end   int
-	}
-	spans := make([]span, 0, 32)
-
-	// Find the field start and end indices.
-	// Doing this in a separate pass (rather than slicing the string s
-	// and collecting the result substrings right away) is significantly
-	// more efficient, possibly due to cache effects.
-	start := -1 // valid span start if >= 0
-	for end, rune := range s {
-		if f(rune) {
-			if start >= 0 {
-				spans = append(spans, span{start, end})
-				// Set start to a negative value.
-				// Note: using -1 here consistently and reproducibly
-				// slows down this code by a several percent on amd64.
-				start = ^start
-			}
-		} else {
-			if start < 0 {
-				start = end
-			}
-		}
-	}
-
-	// Last field might end at EOF.
-	if start >= 0 {
-		spans = append(spans, span{start, len(s)})
-	}
-
-	// Create strings from recorded field indices.
-	a := make([]string, len(spans))
-	for i, span := range spans {
-		a[i] = s[span.start:span.end]
-	}
-
-	return a
-}
+func FieldsFunc(s string, f func(rune) bool) []string 
 */
 
 // Join concatenates the elements of its first argument to create a single string. The separator
 // string sep is placed between elements in the resulting string.
-func Join(elems []string, sep string) string /*{
+
+/* // (joao) makes silver crash with error "Contract might not be well-formed"
+requires forall i int :: 0 < i && i < len(elems) ==> acc(&elems[i], _)
+ensures len(elems) == 0 ==> res == ""
+ensures len(elems) == 1 ==> res == elems[0]
+ensures len(elems) > 1 ==> res == elems[0] + sep + Join(elems[1:], sep)
+pure */
+func Join(elems []string, sep string) (res string) /*{
 	switch len(elems) {
 	case 0:
 		return ""
@@ -431,11 +167,13 @@ func Join(elems []string, sep string) string /*{
 */
 
 // HasPrefix tests whether the string s begins with prefix.
+// (joao) no support for slicing a string
 func HasPrefix(s, prefix string) bool /*{
 	return len(s) >= len(prefix) && s[0:len(prefix)] == prefix
 }*/
 
 // HasSuffix tests whether the string s ends with suffix.
+// (joao) no support for slicing a string
 func HasSuffix(s, suffix string) bool /*{
 	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
 }
@@ -444,72 +182,18 @@ func HasSuffix(s, suffix string) bool /*{
 // Map returns a copy of the string s with all its characters modified
 // according to the mapping function. If mapping returns a negative value, the character is
 // dropped from the string with no replacement.
+// (joao) no support for higher-order functions
 /*
-func Map(mapping func(rune) rune, s string) string {
-	// In the worst case, the string can grow when mapped, making
-	// things unpleasant. But it's so rare we barge in assuming it's
-	// fine. It could also shrink but that falls out naturally.
-
-	// The output buffer b is initialized on demand, the first
-	// time a character differs.
-	var b Builder
-
-	for i, c := range s {
-		r := mapping(c)
-		if r == c && c != utf8.RuneError {
-			continue
-		}
-
-		var width int
-		if c == utf8.RuneError {
-			c, width = utf8.DecodeRuneInString(s[i:])
-			if width != 1 && r == c {
-				continue
-			}
-		} else {
-			width = utf8.RuneLen(c)
-		}
-
-		b.Grow(len(s) + utf8.UTFMax)
-		b.WriteString(s[:i])
-		if r >= 0 {
-			b.WriteRune(r)
-		}
-
-		s = s[i+width:]
-		break
-	}
-
-	// Fast path for unchanged input
-	if b.Cap() == 0 { // didn't call b.Grow above
-		return s
-	}
-
-	for _, c := range s {
-		r := mapping(c)
-
-		if r >= 0 {
-			// common case
-			// Due to inlining, it is more performant to determine if WriteByte should be
-			// invoked rather than always call WriteRune
-			if r < utf8.RuneSelf {
-				b.WriteByte(byte(r))
-			} else {
-				// r is not a ASCII rune.
-				b.WriteRune(r)
-			}
-		}
-	}
-
-	return b.String()
-}
+func Map(mapping func(rune) rune, s string) string 
 */
 
 // Repeat returns a new string consisting of count copies of the string s.
 //
 // It panics if count is negative or if
 // the result of (len(s) * count) overflows.
-func Repeat(s string, count int) string /*{
+requires count >= 0
+ensures res == (count == 0? "" : s + Repeat(s, count - 1))
+pure func Repeat(s string, count int) (res string) /*{
 	if count == 0 {
 		return ""
 	}
@@ -541,66 +225,10 @@ func Repeat(s string, count int) string /*{
 */
 
 // ToUpper returns s with all Unicode letters mapped to their upper case.
-func ToUpper(s string) string /*{
-	isASCII, hasLower := true, false
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c >= utf8.RuneSelf {
-			isASCII = false
-			break
-		}
-		hasLower = hasLower || ('a' <= c && c <= 'z')
-	}
-
-	if isASCII { // optimize for ASCII-only strings.
-		if !hasLower {
-			return s
-		}
-		var b Builder
-		b.Grow(len(s))
-		for i := 0; i < len(s); i++ {
-			c := s[i]
-			if 'a' <= c && c <= 'z' {
-				c -= 'a' - 'A'
-			}
-			b.WriteByte(c)
-		}
-		return b.String()
-	}
-	return Map(unicode.ToUpper, s)
-}
-*/
+func ToUpper(s string) string
 
 // ToLower returns s with all Unicode letters mapped to their lower case.
-func ToLower(s string) string /*{
-	isASCII, hasUpper := true, false
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c >= utf8.RuneSelf {
-			isASCII = false
-			break
-		}
-		hasUpper = hasUpper || ('A' <= c && c <= 'Z')
-	}
-
-	if isASCII { // optimize for ASCII-only strings.
-		if !hasUpper {
-			return s
-		}
-		var b Builder
-		b.Grow(len(s))
-		for i := 0; i < len(s); i++ {
-			c := s[i]
-			if 'A' <= c && c <= 'Z' {
-				c += 'a' - 'A'
-			}
-			b.WriteByte(c)
-		}
-		return b.String()
-	}
-	return Map(unicode.ToLower, s)
-}
-*/
+func ToLower(s string) string
 
 // ToTitle returns a copy of the string s with all Unicode letters mapped to
 // their Unicode title case.
@@ -608,6 +236,7 @@ func ToTitle(s string) string // { return Map(unicode.ToTitle, s) }
 
 // ToUpperSpecial returns a copy of the string s with all Unicode letters mapped to their
 // upper case using the case mapping specified by c.
+// (joao) No support for the unicode package yet
 /*
 func ToUpperSpecial(c unicode.SpecialCase, s string) string {
 	return Map(c.ToUpper, s)
@@ -616,6 +245,7 @@ func ToUpperSpecial(c unicode.SpecialCase, s string) string {
 
 // ToLowerSpecial returns a copy of the string s with all Unicode letters mapped to their
 // lower case using the case mapping specified by c.
+// (joao) No support for the unicode package yet
 /*
 func ToLowerSpecial(c unicode.SpecialCase, s string) string {
 	return Map(c.ToLower, s)
@@ -624,6 +254,7 @@ func ToLowerSpecial(c unicode.SpecialCase, s string) string {
 
 // ToTitleSpecial returns a copy of the string s with all Unicode letters mapped to their
 // Unicode title case, giving priority to the special casing rules.
+// (joao) No support for the unicode package yet
 /*
 func ToTitleSpecial(c unicode.SpecialCase, s string) string {
 	return Map(c.ToTitle, s)
@@ -632,57 +263,9 @@ func ToTitleSpecial(c unicode.SpecialCase, s string) string {
 
 // ToValidUTF8 returns a copy of the string s with each run of invalid UTF-8 byte sequences
 // replaced by the replacement string, which may be empty.
-func ToValidUTF8(s, replacement string) string /*{
-	var b Builder
-
-	for i, c := range s {
-		if c != utf8.RuneError {
-			continue
-		}
-
-		_, wid := utf8.DecodeRuneInString(s[i:])
-		if wid == 1 {
-			b.Grow(len(s) + len(replacement))
-			b.WriteString(s[:i])
-			s = s[i:]
-			break
-		}
-	}
-
-	// Fast path for unchanged input
-	if b.Cap() == 0 { // didn't call b.Grow above
-		return s
-	}
-
-	invalid := false // previous byte was from an invalid UTF-8 sequence
-	for i := 0; i < len(s); {
-		c := s[i]
-		if c < utf8.RuneSelf {
-			i++
-			invalid = false
-			b.WriteByte(c)
-			continue
-		}
-		_, wid := utf8.DecodeRuneInString(s[i:])
-		if wid == 1 {
-			i++
-			if !invalid {
-				invalid = true
-				b.WriteString(replacement)
-			}
-			continue
-		}
-		invalid = false
-		b.WriteString(s[i : i+wid])
-		i += wid
-	}
-
-	return b.String()
-}
-*/
+func ToValidUTF8(s, replacement string) string
 
 // isSeparator reports whether the rune could mark a word boundary.
-// TODO: update when package unicode captures more of the properties.
 func isSeparator(r rune) bool /*{
 	// ASCII alphanumerics and underscore are not separators
 	if r <= 0x7F {
@@ -709,28 +292,11 @@ func isSeparator(r rune) bool /*{
 
 // Title returns a copy of the string s with all Unicode letters that begin words
 // mapped to their Unicode title case.
-//
-// BUG(rsc): The rule Title uses for word boundaries does not handle Unicode punctuation properly.
-func Title(s string) string /*{
-	// Use a closure here to remember state.
-	// Hackish but effective. Depends on Map scanning in order and calling
-	// the closure once per rune.
-	prev := ' '
-	return Map(
-		func(r rune) rune {
-			if isSeparator(prev) {
-				prev = r
-				return unicode.ToTitle(r)
-			}
-			prev = r
-			return r
-		},
-		s)
-}
-*/
+func Title(s string) string 
 
 // TrimLeftFunc returns a slice of the string s with all leading
 // Unicode code points c satisfying f(c) removed.
+// (joao) no support for higher-order functions
 /*
 func TrimLeftFunc(s string, f func(rune) bool) string {
 	i := indexFunc(s, f, false)
@@ -743,6 +309,7 @@ func TrimLeftFunc(s string, f func(rune) bool) string {
 
 // TrimRightFunc returns a slice of the string s with all trailing
 // Unicode code points c satisfying f(c) removed.
+// (joao) no support for higher-order functions
 /*
 func TrimRightFunc(s string, f func(rune) bool) string {
 	i := lastIndexFunc(s, f, false)
@@ -758,18 +325,21 @@ func TrimRightFunc(s string, f func(rune) bool) string {
 // TrimFunc returns a slice of the string s with all leading
 // and trailing Unicode code points c satisfying f(c) removed.
 func TrimFunc(s string, f func(rune) bool) string {
+	// (joao) no support for higher-order functions
 	return TrimRightFunc(TrimLeftFunc(s, f), f)
 }
 
 // IndexFunc returns the index into s of the first Unicode
 // code point satisfying f(c), or -1 if none do.
 func IndexFunc(s string, f func(rune) bool) int {
+	// (joao) no support for higher-order functions
 	return indexFunc(s, f, true)
 }
 
 // LastIndexFunc returns the index into s of the last
 // Unicode code point satisfying f(c), or -1 if none do.
 func LastIndexFunc(s string, f func(rune) bool) int {
+	// (joao) no support for higher-order functions
 	return lastIndexFunc(s, f, true)
 }
 */
@@ -810,39 +380,7 @@ func TrimRight(s, cutset string) string /*{
 
 // TrimSpace returns a slice of the string s, with all leading
 // and trailing white space removed, as defined by Unicode.
-func TrimSpace(s string) string /*{
-	// Fast path for ASCII: look for the first ASCII non-space byte
-	start := 0
-	for ; start < len(s); start++ {
-		c := s[start]
-		if c >= utf8.RuneSelf {
-			// If we run into a non-ASCII byte, fall back to the
-			// slower unicode-aware method on the remaining bytes
-			return TrimFunc(s[start:], unicode.IsSpace)
-		}
-		if asciiSpace[c] == 0 {
-			break
-		}
-	}
-
-	// Now look for the first ASCII non-space byte from the end
-	stop := len(s)
-	for ; stop > start; stop-- {
-		c := s[stop-1]
-		if c >= utf8.RuneSelf {
-			return TrimFunc(s[start:stop], unicode.IsSpace)
-		}
-		if asciiSpace[c] == 0 {
-			break
-		}
-	}
-
-	// At this point s[start:stop] starts and ends with an ASCII
-	// non-space bytes, so we're done. Non-ASCII cases have already
-	// been handled above.
-	return s[start:stop]
-}
-*/
+func TrimSpace(s string) string
 
 // TrimPrefix returns s without the provided leading prefix string.
 // If s doesn't start with prefix, s is returned unchanged.
@@ -858,58 +396,17 @@ func TrimPrefix(s, prefix string) string /*{
 // If s doesn't end with suffix, s is returned unchanged.
 func TrimSuffix(s, suffix string) string /*{
 	if HasSuffix(s, suffix) {
-		return s[:len(s)-len(suffix)]
+		return s[:len(s)-len(suffix)] // (joao): slicing a string is still unsupported
 	}
 	return s
-}
-*/
+}*/
 
 // Replace returns a copy of the string s with the first n
 // non-overlapping instances of old replaced by new.
-// If old is empty, it matches at the beginning of the string
-// and after each UTF-8 sequence, yielding up to k+1 replacements
-// for a k-rune string.
-// If n < 0, there is no limit on the number of replacements.
-func Replace(s, oldS, newS string, n int) string /*{
-	if old == new || n == 0 {
-		return s // avoid allocation
-	}
-
-	// Compute number of replacements.
-	if m := Count(s, old); m == 0 {
-		return s // avoid allocation
-	} else if n < 0 || m < n {
-		n = m
-	}
-
-	// Apply replacements to buffer.
-	var b Builder
-	b.Grow(len(s) + n*(len(new)-len(old)))
-	start := 0
-	for i := 0; i < n; i++ {
-		j := start
-		if len(old) == 0 {
-			if i > 0 {
-				_, wid := utf8.DecodeRuneInString(s[start:])
-				j += wid
-			}
-		} else {
-			j += Index(s[start:], old)
-		}
-		b.WriteString(s[start:j])
-		b.WriteString(new)
-		start = j + len(old)
-	}
-	b.WriteString(s[start:])
-	return b.String()
-}
-*/
+func Replace(s, oldS, newS string, n int) string 
 
 // ReplaceAll returns a copy of the string s with all
 // non-overlapping instances of old replaced by new.
-// If old is empty, it matches at the beginning of the string
-// and after each UTF-8 sequence, yielding up to k+1 replacements
-// for a k-rune string.
 func ReplaceAll(s, oldS, newS string) string {
 	return Replace(s, oldS, newS, -1)
 }
@@ -917,138 +414,7 @@ func ReplaceAll(s, oldS, newS string) string {
 // EqualFold reports whether s and t, interpreted as UTF-8 strings,
 // are equal under Unicode case-folding, which is a more general
 // form of case-insensitivity.
-func EqualFold(s, t string) bool /*{
-	for s != "" && t != "" {
-		// Extract first rune from each string.
-		var sr, tr rune
-		if s[0] < utf8.RuneSelf {
-			sr, s = rune(s[0]), s[1:]
-		} else {
-			r, size := utf8.DecodeRuneInString(s)
-			sr, s = r, s[size:]
-		}
-		if t[0] < utf8.RuneSelf {
-			tr, t = rune(t[0]), t[1:]
-		} else {
-			r, size := utf8.DecodeRuneInString(t)
-			tr, t = r, t[size:]
-		}
-
-		// If they match, keep going; if not, return false.
-
-		// Easy case.
-		if tr == sr {
-			continue
-		}
-
-		// Make sr < tr to simplify what follows.
-		if tr < sr {
-			tr, sr = sr, tr
-		}
-		// Fast check for ASCII.
-		if tr < utf8.RuneSelf {
-			// ASCII only, sr/tr must be upper/lower case
-			if 'A' <= sr && sr <= 'Z' && tr == sr+'a'-'A' {
-				continue
-			}
-			return false
-		}
-
-		// General case. SimpleFold(x) returns the next equivalent rune > x
-		// or wraps around to smaller values.
-		r := unicode.SimpleFold(sr)
-		for r != sr && r < tr {
-			r = unicode.SimpleFold(r)
-		}
-		if r == tr {
-			continue
-		}
-		return false
-	}
-
-	// One string is empty. Are both?
-	return s == t
-}
-*/
+func EqualFold(s, t string) bool
 
 // Index returns the index of the first instance of substr in s, or -1 if substr is not present in s.
-func Index(s, substr string) int /*{
-	n := len(substr)
-	switch {
-	case n == 0:
-		return 0
-	case n == 1:
-		return IndexByte(s, substr[0])
-	case n == len(s):
-		if substr == s {
-			return 0
-		}
-		return -1
-	case n > len(s):
-		return -1
-	case n <= bytealg.MaxLen:
-		// Use brute force when s and substr both are small
-		if len(s) <= bytealg.MaxBruteForce {
-			return bytealg.IndexString(s, substr)
-		}
-		c0 := substr[0]
-		c1 := substr[1]
-		i := 0
-		t := len(s) - n + 1
-		fails := 0
-		for i < t {
-			if s[i] != c0 {
-				// IndexByte is faster than bytealg.IndexString, so use it as long as
-				// we're not getting lots of false positives.
-				o := IndexByte(s[i+1:t], c0)
-				if o < 0 {
-					return -1
-				}
-				i += o + 1
-			}
-			if s[i+1] == c1 && s[i:i+n] == substr {
-				return i
-			}
-			fails++
-			i++
-			// Switch to bytealg.IndexString when IndexByte produces too many false positives.
-			if fails > bytealg.Cutover(i) {
-				r := bytealg.IndexString(s[i:], substr)
-				if r >= 0 {
-					return r + i
-				}
-				return -1
-			}
-		}
-		return -1
-	}
-	c0 := substr[0]
-	c1 := substr[1]
-	i := 0
-	t := len(s) - n + 1
-	fails := 0
-	for i < t {
-		if s[i] != c0 {
-			o := IndexByte(s[i+1:t], c0)
-			if o < 0 {
-				return -1
-			}
-			i += o + 1
-		}
-		if s[i+1] == c1 && s[i:i+n] == substr {
-			return i
-		}
-		i++
-		fails++
-		if fails >= 4+i>>4 && i < t {
-			// See comment in ../bytes/bytes.go.
-			j := bytealg.IndexRabinKarp(s[i:], substr)
-			if j < 0 {
-				return -1
-			}
-			return i + j
-		}
-	}
-	return -1
-}
-*/
+func Index(s, substr string) int

--- a/src/main/resources/stubs/time/time.gobra
+++ b/src/main/resources/stubs/time/time.gobra
@@ -41,7 +41,19 @@ const (
 )
 
 // String returns the English name of the month ("January", "February", ...).
-func (m Month) String() string
+ensures m == January ==> res == "January"
+ensures m == February ==> res == "February"
+ensures m == March ==> res == "March"
+ensures m == April ==> res == "April"
+ensures m == May ==> res == "May"
+ensures m == June ==> res == "June"
+ensures m == July ==> res == "July"
+ensures m == August ==> res == "August"
+ensures m == September ==> res == "September"
+ensures m == October ==> res == "October"
+ensures m == November ==> res == "November"
+ensures m == December ==> res == "December"
+func (m Month) String() (res string)
 
 // A Weekday specifies a day of the week (Sunday = 0, ...).
 type Weekday int
@@ -58,8 +70,15 @@ const (
 )
 
 // String returns the English name of the day ("Sunday", "Monday", ...).
-func (d Weekday) String() string 
 
+ensures d == Sunday ==> res == "Sunday"
+ensures d == Monday ==> res == "Monday"
+ensures d == Tuesday ==> res == "Tuesday"
+ensures d == Wednesday ==> res == "Wednesday"
+ensures d == Thursday ==> res == "Thursday"
+ensures d == Friday ==> res == "Friday"
+ensures d == Saturday ==> res == "Saturday"
+func (d Weekday) String() (res string)
 
 // IsZero reports whether t represents the zero time instant,
 // January 1, year 1, 00:00:00 UTC.

--- a/src/main/resources/stubs/time/time.gobra
+++ b/src/main/resources/stubs/time/time.gobra
@@ -205,7 +205,8 @@ func (t Time) Local() Time /*{
 // In returns a copy of t representing the same time instant, but
 // with the copy's location information set to loc for display
 // purposes.
-requires loc != nil
+requires acc(loc)
+ensures acc(loc)
 func (t Time) In(loc *Location) Time
 
 // Location returns the time zone information associated with t.
@@ -229,25 +230,51 @@ func (t Time) UnixNano() int64
 func (t Time) MarshalBinary() ([]byte, error) 
 
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
-func (t *Time) UnmarshalBinary(data []byte) error
+requires acc(t)
+requires p > 0
+requires forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
+ensures acc(t)
+ensures forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
+func (t *Time) UnmarshalBinary(data []byte, ghost p perm) error
 
 // GobEncode implements the gob.GobEncoder interface.
-func (t Time) GobEncode() ([]byte, error)
+requires forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+func (t Time) GobEncode() (res []byte, error)
 
 // GobDecode implements the gob.GobDecoder interface.
-func (t *Time) GobDecode(data []byte) error
+requires acc(t)
+requires p > 0
+requires forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
+ensures acc(t)
+ensures forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
+func (t *Time) GobDecode(data []byte, ghost p perm) error
 
 // MarshalJSON implements the json.Marshaler interface.
-func (t Time) MarshalJSON() ([]byte, error)
+requires forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+func (t Time) MarshalJSON() (res []byte, error)
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-func (t *Time) UnmarshalJSON(data []byte) error
+requires acc(t)
+requires p > 0
+requires forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
+ensures acc(t)
+ensures forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
+func (t *Time) UnmarshalJSON(data []byte, ghost p perm) error
 
 // MarshalText implements the encoding.TextMarshaler interface.
-func (t Time) MarshalText() ([]byte, error)
+requires forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+func (t Time) MarshalText() (res []byte, error)
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
-func (t *Time) UnmarshalText(data []byte) error
+requires acc(t)
+requires p > 0
+requires forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
+ensures acc(t)
+ensures forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
+func (t *Time) UnmarshalText(data []byte, ghost p perm) error
 
 // Unix returns the local Time corresponding to the given Unix time,
 // sec seconds and nsec nanoseconds since January 1, 1970 UTC.
@@ -255,9 +282,10 @@ func Unix(sec int64, nsec int64) Time
 
 // Date returns the Time corresponding to yyyy-mm-dd hh:mm:ss + nsec nanoseconds
 // in the appropriate zone for that time in the given location.
-requires acc(loc, 1/2) // TODO: add param p of type Perm and require it to be greater than 0
-ensures acc(loc, 1/2)
-func Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location) Time
+requires p > 0
+requires acc(loc, p)
+ensures acc(loc, p)
+func Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location, ghost p perm) Time
 
 // Truncate returns the result of rounding t down to a multiple of d (since the zero time).
 func (t Time) Truncate(d Duration) Time

--- a/src/main/resources/stubs/time/time.gobra
+++ b/src/main/resources/stubs/time/time.gobra
@@ -43,7 +43,7 @@ const (
 )
 
 // String returns the English name of the month ("January", "February", ...).
-// func (m Month) String() string // (joao) string type not supported
+func (m Month) String() string
 
 // A Weekday specifies a day of the week (Sunday = 0, ...).
 type Weekday int
@@ -60,7 +60,7 @@ const (
 )
 
 // String returns the English name of the day ("Sunday", "Monday", ...).
-// func (d Weekday) String() string 
+func (d Weekday) String() string 
 
 
 // IsZero reports whether t represents the zero time instant,
@@ -124,7 +124,7 @@ const (
 )
 
 // String returns a string representing the duration in the form "72h3m0.5s".
-// func (d Duration) String() string
+func (d Duration) String() string
 
 // Nanoseconds returns the duration as an integer nanosecond count.
 func (d Duration) Nanoseconds() int64 { return int64(d) }
@@ -198,7 +198,7 @@ func (t Time) Location() (res *Location)
 
 // Zone computes the time zone in effect at time t, returning the abbreviated
 // name of the zone (such as "CET") and its offset in seconds east of UTC.
-// func (t Time) Zone() (name string, offset int) 
+func (t Time) Zone() (name string, offset int) 
 
 // Unix returns t as a Unix time, the number of seconds elapsed
 // since January 1, 1970 UTC.

--- a/src/main/resources/stubs/time/time.gobra
+++ b/src/main/resources/stubs/time/time.gobra
@@ -1,7 +1,12 @@
-// Signatures for the declarations in file
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+// Signatures for the public declarations in file
 // https://github.com/golang/go/blob/master/src/time/time.go
 
-// (joao) check licenses
 package time
 
 type Time struct {
@@ -17,10 +22,6 @@ pure func (t Time) After(u Time) bool
 pure func (t Time) Before(u Time) bool
 
 // Equal reports whether t and u represent the same time instant.
-// Two times can be equal even if they are in different locations.
-// For example, 6:00 +0200 and 4:00 UTC are Equal.
-// See the documentation on the Time type for the pitfalls of using == with
-// Time values; most code should use Equal instead.
 func (t Time) Equal(u Time) bool
 
 // A Month specifies a month of the year (January = 1, ...).
@@ -109,21 +110,10 @@ ensures 1 <= res && res <= 365
 func (t Time) YearDay() (res int)
 
 // A Duration represents the elapsed time between two instants
-// as an int64 nanosecond count. The representation limits the
-// largest representable duration to approximately 290 years.
+// as a nanosecond count.
 type Duration int64
 
-// Common durations. There is no definition for units of Day or larger
-// to avoid confusion across daylight savings time zone transitions.
-//
-// To count the number of units in a Duration, divide:
-//	second := time.Second
-//	fmt.Print(int64(second/time.Millisecond)) // prints 1000
-//
-// To convert an integer number of units to a Duration, multiply:
-//	seconds := 10
-//	fmt.Print(time.Duration(seconds)*time.Second) // prints 10s
-//
+// Common durations
 const (
 	Nanosecond  Duration = 1
 	Microsecond          = 1000 * Nanosecond
@@ -134,10 +124,6 @@ const (
 )
 
 // String returns a string representing the duration in the form "72h3m0.5s".
-// Leading zero units are omitted. As a special case, durations less than one
-// second format use a smaller unit (milli-, micro-, or nanoseconds) to ensure
-// that the leading digit is non-zero. The zero duration formats as 0s.
-
 // func (d Duration) String() string
 
 // Nanoseconds returns the duration as an integer nanosecond count.
@@ -149,36 +135,15 @@ func (d Duration) Microseconds() int64 { return int64(d) / 1000 }
 // Milliseconds returns the duration as an integer millisecond count.
 func (d Duration) Milliseconds() int64 { return int64(d) / 1000000 }
 
-// These methods return float64 because the dominant
-// use case is for printing a floating point number like 1.5s, and
-// a truncation to integer would make them not useful in those cases.
-// Splitting the integer and fraction ourselves guarantees that
-// converting the returned float64 to an integer rounds the same
-// way that a pure integer conversion would have, even in cases
-// where, say, float64(d.Nanoseconds())/1e9 would have rounded
-// differently.
-
 // Seconds returns the duration as a floating point number of seconds.
 /* (joao) no support for float
-func (d Duration) Seconds() float64 {
-	sec := d / Second
-	nsec := d % Second
-	return float64(sec) + float64(nsec)/1e9
-}
+func (d Duration) Seconds() float64
 
 // Minutes returns the duration as a floating point number of minutes.
-func (d Duration) Minutes() float64 {
-	min := d / Minute
-	nsec := d % Minute
-	return float64(min) + float64(nsec)/(60*1e9)
-}
+func (d Duration) Minutes() float64
 
 // Hours returns the duration as a floating point number of hours.
-func (d Duration) Hours() float64 {
-	hour := d / Hour
-	nsec := d % Hour
-	return float64(hour) + float64(nsec)/(60*60*1e9)
-}
+func (d Duration) Hours() float64
 */
 
 // Truncate returns the result of rounding d toward zero to a multiple of m.
@@ -188,20 +153,12 @@ ensures m > 0 ==> res == d - d%m // leads to violation in the desugarer
 pure func (d Duration) Truncate(m Duration) (res Duration)
 
 // Round returns the result of rounding d to the nearest multiple of m.
-// The rounding behavior for halfway values is to round away from zero.
-// If the result exceeds the maximum (or minimum)
-// value that can be stored in a Duration,
-// Round returns the maximum (or minimum) duration.
-// If m <= 0, Round returns d unchanged.
 pure func (d Duration) Round(m Duration) Duration
 
 // Add returns the time t+d.
 func (t Time) Add(d Duration) Time
 
-// Sub returns the duration t-u. If the result exceeds the maximum (or minimum)
-// value that can be stored in a Duration, the maximum (or minimum) duration
-// will be returned.
-// To compute t-d for a duration d, use t.Add(-d).
+// Sub returns the duration t-u.
 func (t Time) Sub(u Time) Duration
 
 // Since returns the time elapsed since t.
@@ -214,26 +171,7 @@ func Until(t Time) Duration
 
 // AddDate returns the time corresponding to adding the
 // given number of years, months, and days to t.
-// For example, AddDate(-1, 2, 3) applied to January 1, 2011
-// returns March 4, 2010.
-//
-// AddDate normalizes its result in the same way that Date does,
-// so, for example, adding one month to October 31 yields
-// December 1, the normalized form for November 31.
-func (t Time) AddDate(years int, months int, days int) Time /*{
-	year, month, day := t.Date()
-	hour, min, sec := t.Clock()
-	return Date(year+years, month+Month(months), day+days, hour, min, sec, int(t.nsec()), t.Location())
-}
-*/
-
-// Monotonic times are reported as offsets from startNano.
-// We initialize startNano to runtimeNano() - 1 so that on systems where
-// monotonic time resolution is fairly low (e.g. Windows 2008
-// which appears to have a default resolution of 15ms),
-// we avoid ever reporting a monotonic time of 0.
-// (Callers may want to use 0 as "time not set".)
-// var startNano int64 = runtimeNano() - 1 // TODO: global vars
+func (t Time) AddDate(years int, months int, days int) Time
 
 // Now returns the current local time.
 func Now() Time
@@ -250,8 +188,6 @@ func (t Time) Local() Time /*{
 // In returns a copy of t representing the same time instant, but
 // with the copy's location information set to loc for display
 // purposes.
-//
-// In panics if loc is nil.
 requires loc != nil
 func (t Time) In(loc *Location) Time
 
@@ -265,91 +201,49 @@ func (t Time) Location() (res *Location)
 // func (t Time) Zone() (name string, offset int) 
 
 // Unix returns t as a Unix time, the number of seconds elapsed
-// since January 1, 1970 UTC. The result does not depend on the
-// location associated with t.
-// Unix-like operating systems often record time as a 32-bit
-// count of seconds, but since the method here returns a 64-bit
-// value it is valid for billions of years into the past or future.
+// since January 1, 1970 UTC.
 func (t Time) Unix() int64
 
 // UnixNano returns t as a Unix time, the number of nanoseconds elapsed
-// since January 1, 1970 UTC. The result is undefined if the Unix time
-// in nanoseconds cannot be represented by an int64 (a date before the year
-// 1678 or after 2262). Note that this means the result of calling UnixNano
-// on the zero Time is undefined. The result does not depend on the
-// location associated with t.
+// since January 1, 1970 UTC.
 func (t Time) UnixNano() int64
 
 // MarshalBinary implements the encoding.BinaryMarshaler interface.
-//func (t Time) MarshalBinary() ([]byte, error) 
+func (t Time) MarshalBinary() ([]byte, error) 
 
 // UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
-//func (t *Time) UnmarshalBinary(data []byte) error
+func (t *Time) UnmarshalBinary(data []byte) error
 
 // GobEncode implements the gob.GobEncoder interface.
-// func (t Time) GobEncode() ([]byte, error)
+func (t Time) GobEncode() ([]byte, error)
 
 // GobDecode implements the gob.GobDecoder interface.
-// func (t *Time) GobDecode(data []byte) error
+func (t *Time) GobDecode(data []byte) error
 
 // MarshalJSON implements the json.Marshaler interface.
-// The time is a quoted string in RFC 3339 format, with sub-second precision added if present.
-// func (t Time) MarshalJSON() ([]byte, error)
+func (t Time) MarshalJSON() ([]byte, error)
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-// The time is expected to be a quoted string in RFC 3339 format.
-// func (t *Time) UnmarshalJSON(data []byte) error
+func (t *Time) UnmarshalJSON(data []byte) error
 
 // MarshalText implements the encoding.TextMarshaler interface.
-// The time is formatted in RFC 3339 format, with sub-second precision added if present.
-// func (t Time) MarshalText() ([]byte, error)
+func (t Time) MarshalText() ([]byte, error)
 
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
-// The time is expected to be in RFC 3339 format.
-// func (t *Time) UnmarshalText(data []byte) error
+func (t *Time) UnmarshalText(data []byte) error
 
 // Unix returns the local Time corresponding to the given Unix time,
 // sec seconds and nsec nanoseconds since January 1, 1970 UTC.
-// It is valid to pass nsec outside the range [0, 999999999].
-// Not all sec values have a corresponding time value. One such
-// value is 1<<63-1 (the largest int64 value).
 func Unix(sec int64, nsec int64) Time
 
-// Date returns the Time corresponding to
-//	yyyy-mm-dd hh:mm:ss + nsec nanoseconds
+// Date returns the Time corresponding to yyyy-mm-dd hh:mm:ss + nsec nanoseconds
 // in the appropriate zone for that time in the given location.
-//
-// The month, day, hour, min, sec, and nsec values may be outside
-// their usual ranges and will be normalized during the conversion.
-// For example, October 32 converts to November 1.
-//
-// A daylight savings time transition skips or repeats times.
-// For example, in the United States, March 13, 2011 2:15am never occurred,
-// while November 6, 2011 1:15am occurred twice. In such cases, the
-// choice of time zone, and therefore the time, is not well-defined.
-// Date returns a time that is correct in one of the two zones involved
-// in the transition, but it does not guarantee which.
-//
-// Date panics if loc is nil.
-requires acc(loc, 1/2) // can be changed to any value p > 0, but requires a ghost param of type Perm
+requires acc(loc, 1/2) // TODO: add param p of type Perm and require it to be greater than 0
 ensures acc(loc, 1/2)
 func Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location) Time
 
 // Truncate returns the result of rounding t down to a multiple of d (since the zero time).
-// If d <= 0, Truncate returns t stripped of any monotonic clock reading but otherwise unchanged.
-//
-// Truncate operates on the time as an absolute duration since the
-// zero time; it does not operate on the presentation form of the
-// time. Thus, Truncate(Hour) may return a time with a non-zero
-// minute, depending on the time's Location.
 func (t Time) Truncate(d Duration) Time
 
 // Round returns the result of rounding t to the nearest multiple of d (since the zero time).
-// The rounding behavior for halfway values is to round up.
-// If d <= 0, Round returns t stripped of any monotonic clock reading but otherwise unchanged.
-//
-// Round operates on the time as an absolute duration since the
-// zero time; it does not operate on the presentation form of the
-// time. Thus, Round(Hour) may return a time with a non-zero
-// minute, depending on the time's Location.
 func (t Time) Round(d Duration) Time

--- a/src/main/resources/stubs/time/time.gobra
+++ b/src/main/resources/stubs/time/time.gobra
@@ -1,0 +1,355 @@
+// Signatures for the declarations in file
+// https://github.com/golang/go/blob/master/src/time/time.go
+
+// (joao) check licenses
+package time
+
+type Time struct {
+	wall uint64
+	ext  int64
+	loc *Location
+}
+
+// After reports whether the time instant t is after u.
+pure func (t Time) After(u Time) bool
+
+// Before reports whether the time instant t is before u.
+pure func (t Time) Before(u Time) bool
+
+// Equal reports whether t and u represent the same time instant.
+// Two times can be equal even if they are in different locations.
+// For example, 6:00 +0200 and 4:00 UTC are Equal.
+// See the documentation on the Time type for the pitfalls of using == with
+// Time values; most code should use Equal instead.
+func (t Time) Equal(u Time) bool
+
+// A Month specifies a month of the year (January = 1, ...).
+type Month int
+
+const (
+	January Month = 1
+	February Month = 2
+	March Month = 3
+	April Month = 4
+	May Month = 5
+	June Month = 6
+	July Month = 7
+	August Month = 8
+	September Month = 9
+	October Month = 10
+	November Month = 11
+	December Month = 12
+)
+
+// String returns the English name of the month ("January", "February", ...).
+// func (m Month) String() string // (joao) string type not supported
+
+// A Weekday specifies a day of the week (Sunday = 0, ...).
+type Weekday int
+
+const (
+	// (joao) this used to be defined in terms of iota
+	Sunday Weekday = 0
+	Monday Weekday = 1
+	Tuesday Weekday = 2
+	Wednesday Weekday = 3
+	Thursday Weekday = 4
+	Friday Weekday = 5
+	Saturday Weekday = 6
+)
+
+// String returns the English name of the day ("Sunday", "Monday", ...).
+// func (d Weekday) String() string 
+
+
+// IsZero reports whether t represents the zero time instant,
+// January 1, year 1, 00:00:00 UTC.
+pure func (t Time) IsZero() bool
+
+// Date returns the year, month, and day in which t occurs.
+func (t Time) Date() (year int, month Month, day int)
+
+// Year returns the year in which t occurs.
+func (t Time) Year() int
+
+// Month returns the month of the year specified by t.
+func (t Time) Month() Month
+
+// Day returns the day of the month specified by t.
+func (t Time) Day() int
+
+// Weekday returns the day of the week specified by t.
+func (t Time) Weekday() Weekday
+
+func (t Time) ISOWeek() (year, week int)
+
+// Clock returns the hour, minute, and second within the day specified by t.
+func (t Time) Clock() (hour, min, sec int)
+
+// Hour returns the hour within the day specified by t, in the range [0, 23].
+ensures 0 <= res && res <= 23
+pure func (t Time) Hour() (res int)
+
+// Minute returns the minute offset within the hour specified by t, in the range [0, 59].
+ensures 0 <= res && res <= 59
+pure func (t Time) Minute() (res int)
+
+// Second returns the second offset within the minute specified by t, in the range [0, 59].
+ensures 0 <= res && res <= 59
+pure func (t Time) Second() (res int)
+
+// Nanosecond returns the nanosecond offset within the second specified by t,
+// in the range [0, 999999999].
+ensures 0 <= res && res <= 999999999
+pure func (t Time) Nanosecond() (res int)
+
+// YearDay returns the day of the year specified by t, in the range [1,365] for non-leap years,
+// and [1,366] in leap years.
+ensures 1 <= res && res <= 365
+func (t Time) YearDay() (res int)
+
+// A Duration represents the elapsed time between two instants
+// as an int64 nanosecond count. The representation limits the
+// largest representable duration to approximately 290 years.
+type Duration int64
+
+// Common durations. There is no definition for units of Day or larger
+// to avoid confusion across daylight savings time zone transitions.
+//
+// To count the number of units in a Duration, divide:
+//	second := time.Second
+//	fmt.Print(int64(second/time.Millisecond)) // prints 1000
+//
+// To convert an integer number of units to a Duration, multiply:
+//	seconds := 10
+//	fmt.Print(time.Duration(seconds)*time.Second) // prints 10s
+//
+const (
+	Nanosecond  Duration = 1
+	Microsecond          = 1000 * Nanosecond
+	Millisecond          = 1000 * Microsecond
+	Second               = 1000 * Millisecond
+	Minute               = 60 * Second
+	Hour                 = 60 * Minute
+)
+
+// String returns a string representing the duration in the form "72h3m0.5s".
+// Leading zero units are omitted. As a special case, durations less than one
+// second format use a smaller unit (milli-, micro-, or nanoseconds) to ensure
+// that the leading digit is non-zero. The zero duration formats as 0s.
+
+// func (d Duration) String() string
+
+// Nanoseconds returns the duration as an integer nanosecond count.
+func (d Duration) Nanoseconds() int64 { return int64(d) }
+
+// Microseconds returns the duration as an integer microsecond count.
+func (d Duration) Microseconds() int64 { return int64(d) / 1000 }
+
+// Milliseconds returns the duration as an integer millisecond count.
+func (d Duration) Milliseconds() int64 { return int64(d) / 1000000 }
+
+// These methods return float64 because the dominant
+// use case is for printing a floating point number like 1.5s, and
+// a truncation to integer would make them not useful in those cases.
+// Splitting the integer and fraction ourselves guarantees that
+// converting the returned float64 to an integer rounds the same
+// way that a pure integer conversion would have, even in cases
+// where, say, float64(d.Nanoseconds())/1e9 would have rounded
+// differently.
+
+// Seconds returns the duration as a floating point number of seconds.
+/* (joao) no support for float
+func (d Duration) Seconds() float64 {
+	sec := d / Second
+	nsec := d % Second
+	return float64(sec) + float64(nsec)/1e9
+}
+
+// Minutes returns the duration as a floating point number of minutes.
+func (d Duration) Minutes() float64 {
+	min := d / Minute
+	nsec := d % Minute
+	return float64(min) + float64(nsec)/(60*1e9)
+}
+
+// Hours returns the duration as a floating point number of hours.
+func (d Duration) Hours() float64 {
+	hour := d / Hour
+	nsec := d % Hour
+	return float64(hour) + float64(nsec)/(60*60*1e9)
+}
+*/
+
+// Truncate returns the result of rounding d toward zero to a multiple of m.
+// If m <= 0, Truncate returns d unchanged.
+ensures m <= 0 ==> res == d
+ensures m > 0 ==> res == d - d%m // leads to violation in the desugarer
+pure func (d Duration) Truncate(m Duration) (res Duration)
+
+// Round returns the result of rounding d to the nearest multiple of m.
+// The rounding behavior for halfway values is to round away from zero.
+// If the result exceeds the maximum (or minimum)
+// value that can be stored in a Duration,
+// Round returns the maximum (or minimum) duration.
+// If m <= 0, Round returns d unchanged.
+pure func (d Duration) Round(m Duration) Duration
+
+// Add returns the time t+d.
+func (t Time) Add(d Duration) Time
+
+// Sub returns the duration t-u. If the result exceeds the maximum (or minimum)
+// value that can be stored in a Duration, the maximum (or minimum) duration
+// will be returned.
+// To compute t-d for a duration d, use t.Add(-d).
+func (t Time) Sub(u Time) Duration
+
+// Since returns the time elapsed since t.
+// It is shorthand for time.Now().Sub(t).
+func Since(t Time) Duration
+
+// Until returns the duration until t.
+// It is shorthand for t.Sub(time.Now()).
+func Until(t Time) Duration
+
+// AddDate returns the time corresponding to adding the
+// given number of years, months, and days to t.
+// For example, AddDate(-1, 2, 3) applied to January 1, 2011
+// returns March 4, 2010.
+//
+// AddDate normalizes its result in the same way that Date does,
+// so, for example, adding one month to October 31 yields
+// December 1, the normalized form for November 31.
+func (t Time) AddDate(years int, months int, days int) Time /*{
+	year, month, day := t.Date()
+	hour, min, sec := t.Clock()
+	return Date(year+years, month+Month(months), day+days, hour, min, sec, int(t.nsec()), t.Location())
+}
+*/
+
+// Monotonic times are reported as offsets from startNano.
+// We initialize startNano to runtimeNano() - 1 so that on systems where
+// monotonic time resolution is fairly low (e.g. Windows 2008
+// which appears to have a default resolution of 15ms),
+// we avoid ever reporting a monotonic time of 0.
+// (Callers may want to use 0 as "time not set".)
+// var startNano int64 = runtimeNano() - 1 // TODO: global vars
+
+// Now returns the current local time.
+func Now() Time
+
+// UTC returns t with the location set to UTC.
+func (t Time) UTC() Time
+
+// Local returns t with the location set to local time.
+func (t Time) Local() Time /*{
+	t.setLoc(Local)
+	return t
+}*/
+
+// In returns a copy of t representing the same time instant, but
+// with the copy's location information set to loc for display
+// purposes.
+//
+// In panics if loc is nil.
+requires loc != nil
+func (t Time) In(loc *Location) Time
+
+// Location returns the time zone information associated with t.
+// ensures t.loc == nil ==> res == UTC // UTC is currently commented because it is a global var
+ensures t.loc != nil ==> res == t.loc
+func (t Time) Location() (res *Location)
+
+// Zone computes the time zone in effect at time t, returning the abbreviated
+// name of the zone (such as "CET") and its offset in seconds east of UTC.
+// func (t Time) Zone() (name string, offset int) 
+
+// Unix returns t as a Unix time, the number of seconds elapsed
+// since January 1, 1970 UTC. The result does not depend on the
+// location associated with t.
+// Unix-like operating systems often record time as a 32-bit
+// count of seconds, but since the method here returns a 64-bit
+// value it is valid for billions of years into the past or future.
+func (t Time) Unix() int64
+
+// UnixNano returns t as a Unix time, the number of nanoseconds elapsed
+// since January 1, 1970 UTC. The result is undefined if the Unix time
+// in nanoseconds cannot be represented by an int64 (a date before the year
+// 1678 or after 2262). Note that this means the result of calling UnixNano
+// on the zero Time is undefined. The result does not depend on the
+// location associated with t.
+func (t Time) UnixNano() int64
+
+// MarshalBinary implements the encoding.BinaryMarshaler interface.
+//func (t Time) MarshalBinary() ([]byte, error) 
+
+// UnmarshalBinary implements the encoding.BinaryUnmarshaler interface.
+//func (t *Time) UnmarshalBinary(data []byte) error
+
+// GobEncode implements the gob.GobEncoder interface.
+// func (t Time) GobEncode() ([]byte, error)
+
+// GobDecode implements the gob.GobDecoder interface.
+// func (t *Time) GobDecode(data []byte) error
+
+// MarshalJSON implements the json.Marshaler interface.
+// The time is a quoted string in RFC 3339 format, with sub-second precision added if present.
+// func (t Time) MarshalJSON() ([]byte, error)
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+// The time is expected to be a quoted string in RFC 3339 format.
+// func (t *Time) UnmarshalJSON(data []byte) error
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The time is formatted in RFC 3339 format, with sub-second precision added if present.
+// func (t Time) MarshalText() ([]byte, error)
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface.
+// The time is expected to be in RFC 3339 format.
+// func (t *Time) UnmarshalText(data []byte) error
+
+// Unix returns the local Time corresponding to the given Unix time,
+// sec seconds and nsec nanoseconds since January 1, 1970 UTC.
+// It is valid to pass nsec outside the range [0, 999999999].
+// Not all sec values have a corresponding time value. One such
+// value is 1<<63-1 (the largest int64 value).
+func Unix(sec int64, nsec int64) Time
+
+// Date returns the Time corresponding to
+//	yyyy-mm-dd hh:mm:ss + nsec nanoseconds
+// in the appropriate zone for that time in the given location.
+//
+// The month, day, hour, min, sec, and nsec values may be outside
+// their usual ranges and will be normalized during the conversion.
+// For example, October 32 converts to November 1.
+//
+// A daylight savings time transition skips or repeats times.
+// For example, in the United States, March 13, 2011 2:15am never occurred,
+// while November 6, 2011 1:15am occurred twice. In such cases, the
+// choice of time zone, and therefore the time, is not well-defined.
+// Date returns a time that is correct in one of the two zones involved
+// in the transition, but it does not guarantee which.
+//
+// Date panics if loc is nil.
+requires acc(loc, 1/2) // can be changed to any value p > 0, but requires a ghost param of type Perm
+ensures acc(loc, 1/2)
+func Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location) Time
+
+// Truncate returns the result of rounding t down to a multiple of d (since the zero time).
+// If d <= 0, Truncate returns t stripped of any monotonic clock reading but otherwise unchanged.
+//
+// Truncate operates on the time as an absolute duration since the
+// zero time; it does not operate on the presentation form of the
+// time. Thus, Truncate(Hour) may return a time with a non-zero
+// minute, depending on the time's Location.
+func (t Time) Truncate(d Duration) Time
+
+// Round returns the result of rounding t to the nearest multiple of d (since the zero time).
+// The rounding behavior for halfway values is to round up.
+// If d <= 0, Round returns t stripped of any monotonic clock reading but otherwise unchanged.
+//
+// Round operates on the time as an absolute duration since the
+// zero time; it does not operate on the presentation form of the
+// time. Thus, Round(Hour) may return a time with a non-zero
+// minute, depending on the time's Location.
+func (t Time) Round(d Duration) Time

--- a/src/main/resources/stubs/time/time.gobra
+++ b/src/main/resources/stubs/time/time.gobra
@@ -1,8 +1,6 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-//
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in https://golang.org/LICENSE
 
 // Signatures for the public declarations in file
 // https://github.com/golang/go/blob/master/src/time/time.go

--- a/src/main/resources/stubs/time/zoneinfo.gobra
+++ b/src/main/resources/stubs/time/zoneinfo.gobra
@@ -1,15 +1,13 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/time/zoneinfo.go
 
 package time
-
-/*
-import (
-	// "errors"
-	// "sync"
-	// "syscall"
-)*/
 
 type Location struct {
 	// name string // TODO
@@ -35,23 +33,7 @@ type zoneTrans struct {
 
 // No support for global variables
 // var UTC *Location = &utcLoc
-//var utcLoc = Location{name: "UTC"}
 // var Local *Location = &localLoc
-// var localLoc Location
-// var localOnce sync.Once // TODO: no support for once
-
-// TODO: nees support for sync.Once; 
-// TODO: get is a reserved keyword
-//func (l *Location) get() *Location
-/*{
-	if l == nil {
-		return &utcLoc
-	}
-	if l == &localLoc {
-		localOnce.Do(initLocal)
-	}
-	return l
-}*/
 
 // TODO: Transitively requires synchronization through the call to get
 // pure func (l *Location) String() string {
@@ -72,39 +54,5 @@ func FixedZone(name string, offset int) *Location {
 }
 */
 
-/*
-func LoadLocation(name string) (*Location, error) {
-	if name == "" || name == "UTC" {
-		return UTC, nil
-	}
-	if name == "Local" {
-		return Local, nil
-	}
-	if containsDotDot(name) || name[0] == '/' || name[0] == '\\' {
-		// No valid IANA Time Zone name contains a single dot,
-		// much less dot dot. Likewise, none begin with a slash.
-		return nil, errLocation
-	}
-	zoneinfoOnce.Do(func() {
-		env, _ := syscall.Getenv("ZONEINFO")
-		zoneinfo = &env
-	})
-	var firstErr error
-	if *zoneinfo != "" {
-		if zoneData, err := loadTzinfoFromDirOrZip(*zoneinfo, name); err == nil {
-			if z, err := LoadLocationFromTZData(name, zoneData); err == nil {
-				return z, nil
-			}
-			firstErr = err
-		} else if err != syscall.ENOENT {
-			firstErr = err
-		}
-	}
-	if z, err := loadLocation(name, zoneSources); err == nil {
-		return z, nil
-	} else if firstErr == nil {
-		firstErr = err
-	}
-	return nil, firstErr
-}
-*/
+// No support for strings
+// func LoadLocation(name string) (*Location, error) 

--- a/src/main/resources/stubs/time/zoneinfo.gobra
+++ b/src/main/resources/stubs/time/zoneinfo.gobra
@@ -1,0 +1,110 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package time
+
+/*
+import (
+	// "errors"
+	// "sync"
+	// "syscall"
+)*/
+
+type Location struct {
+	// name string // TODO
+	// zone []zone // Leads to cycle in kiama
+	tx   []zoneTrans
+	// extend string // TODO
+	cacheStart int64
+	cacheEnd   int64
+	cacheZone  *zone
+}
+
+type zone struct {
+	// name   string // TODO
+	offset int
+	isDST  bool
+}
+
+type zoneTrans struct {
+	when         int64
+	index        uint8
+	isstd, isutc bool
+}
+
+// No support for global variables
+// var UTC *Location = &utcLoc
+//var utcLoc = Location{name: "UTC"}
+// var Local *Location = &localLoc
+// var localLoc Location
+// var localOnce sync.Once // TODO: no support for once
+
+// TODO: nees support for sync.Once; 
+// TODO: get is a reserved keyword
+//func (l *Location) get() *Location
+/*{
+	if l == nil {
+		return &utcLoc
+	}
+	if l == &localLoc {
+		localOnce.Do(initLocal)
+	}
+	return l
+}*/
+
+// TODO: Transitively requires synchronization through the call to get
+// pure func (l *Location) String() string {
+// 	return l.get().name
+//}
+
+/*
+func FixedZone(name string, offset int) *Location {
+	l := &Location{
+		name:       name,
+		zone:       []zone{{name, offset, false}},
+		tx:         []zoneTrans{{alpha, 0, false, false}},
+		cacheStart: alpha,
+		cacheEnd:   omega,
+	}
+	l.cacheZone = &l.zone[0]
+	return l
+}
+*/
+
+/*
+func LoadLocation(name string) (*Location, error) {
+	if name == "" || name == "UTC" {
+		return UTC, nil
+	}
+	if name == "Local" {
+		return Local, nil
+	}
+	if containsDotDot(name) || name[0] == '/' || name[0] == '\\' {
+		// No valid IANA Time Zone name contains a single dot,
+		// much less dot dot. Likewise, none begin with a slash.
+		return nil, errLocation
+	}
+	zoneinfoOnce.Do(func() {
+		env, _ := syscall.Getenv("ZONEINFO")
+		zoneinfo = &env
+	})
+	var firstErr error
+	if *zoneinfo != "" {
+		if zoneData, err := loadTzinfoFromDirOrZip(*zoneinfo, name); err == nil {
+			if z, err := LoadLocationFromTZData(name, zoneData); err == nil {
+				return z, nil
+			}
+			firstErr = err
+		} else if err != syscall.ENOENT {
+			firstErr = err
+		}
+	}
+	if z, err := loadLocation(name, zoneSources); err == nil {
+		return z, nil
+	} else if firstErr == nil {
+		firstErr = err
+	}
+	return nil, firstErr
+}
+*/

--- a/src/main/resources/stubs/time/zoneinfo.gobra
+++ b/src/main/resources/stubs/time/zoneinfo.gobra
@@ -9,7 +9,7 @@ package time
 
 type Location struct {
 	name string
-	// zone []zone // TODO: Leads to cycle in kiama
+	// zone []zone // (joao) Leads to cycle in kiama
 	tx   []zoneTrans
 	extend string
 	cacheStart int64
@@ -38,7 +38,8 @@ type zoneTrans struct {
 // 	return l.get().name
 //}
 
-func FixedZone(name string, offset int) *Location /*{
+ensures acc(res)
+func FixedZone(name string, offset int) (res *Location) /*{
 	l := &Location{
 		name:       name,
 		zone:       []zone{{name, offset, false}},

--- a/src/main/resources/stubs/time/zoneinfo.gobra
+++ b/src/main/resources/stubs/time/zoneinfo.gobra
@@ -10,17 +10,17 @@
 package time
 
 type Location struct {
-	// name string // TODO
-	// zone []zone // Leads to cycle in kiama
+	// name string
+	// zone []zone // TODO: Leads to cycle in kiama
 	tx   []zoneTrans
-	// extend string // TODO
+	extend string
 	cacheStart int64
 	cacheEnd   int64
 	cacheZone  *zone
 }
 
 type zone struct {
-	// name   string // TODO
+	name   string
 	offset int
 	isDST  bool
 }

--- a/src/main/resources/stubs/time/zoneinfo.gobra
+++ b/src/main/resources/stubs/time/zoneinfo.gobra
@@ -1,8 +1,6 @@
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at http://mozilla.org/MPL/2.0/.
-//
-// Copyright (c) 2011-2020 ETH Zurich.
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in https://golang.org/LICENSE
 
 // Signatures for the public declarations in file
 // https://github.com/golang/go/blob/master/src/time/zoneinfo.go
@@ -10,7 +8,7 @@
 package time
 
 type Location struct {
-	// name string
+	name string
 	// zone []zone // TODO: Leads to cycle in kiama
 	tx   []zoneTrans
 	extend string
@@ -35,13 +33,12 @@ type zoneTrans struct {
 // var UTC *Location = &utcLoc
 // var Local *Location = &localLoc
 
-// TODO: Transitively requires synchronization through the call to get
+// TODO: Transitively requires synchronization through the call to get, uses Once in the actual code
 // pure func (l *Location) String() string {
 // 	return l.get().name
 //}
 
-/*
-func FixedZone(name string, offset int) *Location {
+func FixedZone(name string, offset int) *Location /*{
 	l := &Location{
 		name:       name,
 		zone:       []zone{{name, offset, false}},
@@ -49,10 +46,8 @@ func FixedZone(name string, offset int) *Location {
 		cacheStart: alpha,
 		cacheEnd:   omega,
 	}
-	l.cacheZone = &l.zone[0]
+	l.cacheZone = (&l.zone)[0]
 	return l
-}
-*/
+}*/
 
-// No support for strings
-// func LoadLocation(name string) (*Location, error) 
+func LoadLocation(name string) (*Location, error) 

--- a/src/main/scala/viper/gobra/ast/internal/Program.scala
+++ b/src/main/scala/viper/gobra/ast/internal/Program.scala
@@ -837,7 +837,7 @@ sealed abstract class BinaryIntExpr(override val operator: String) extends Binar
     // translation to the internal language.
     case (x, IntT(_, UnboundedInteger)) if x.isInstanceOf[DefinedT] => x.withAddressability(Addressability.Exclusive)
     case (IntT(_, UnboundedInteger), y) if y.isInstanceOf[DefinedT] => y.withAddressability(Addressability.Exclusive)
-
+    case (x, y) if x.equalsWithoutMod(y) => x.withAddressability(Addressability.Exclusive)
     case (l, r) => violation(s"cannot merge types $l and $r")
 
   }

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -342,7 +342,7 @@ object Desugar {
           case in.BoolT(Addressability.Exclusive) =>
             val constValue = sc.context.boolConstantEvaluation(sc.exp)
             in.BoolLit(constValue.get)(src)
-          case in.IntT(Addressability.Exclusive, _) =>
+          case x if underlyingType(x).isInstanceOf[in.IntT] && x.addressability == Addressability.Exclusive =>
             val constValue = sc.context.intConstantEvaluation(sc.exp)
             in.IntLit(constValue.get)(src)
           case _ => ???

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -338,16 +338,19 @@ object Desugar {
       case sc@st.SingleConstant(_, id, _, _, _, _) =>
         val src = meta(id)
         val gVar = globalConstD(sc)(src)
-        val intLit: in.Lit = gVar.typ match {
+        val lit: in.Lit = gVar.typ match {
           case in.BoolT(Addressability.Exclusive) =>
             val constValue = sc.context.boolConstantEvaluation(sc.exp)
             in.BoolLit(constValue.get)(src)
+          case in.StringT(Addressability.Exclusive) =>
+            val constValue = sc.context.stringConstantEvaluation(sc.exp)
+            in.StringLit(constValue.get)(src)
           case x if underlyingType(x).isInstanceOf[in.IntT] && x.addressability == Addressability.Exclusive =>
             val constValue = sc.context.intConstantEvaluation(sc.exp)
             in.IntLit(constValue.get)(src)
           case _ => ???
         }
-        Vector(in.GlobalConstDecl(gVar, intLit)(src))
+        Vector(in.GlobalConstDecl(gVar, lit)(src))
 
       // Constants defined with the blank identifier can be safely ignored as they
       // must be computable statically (and thus do not have side effects) and

--- a/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
+++ b/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
@@ -66,6 +66,8 @@ trait ExternalTypeInfo {
 
   def intConstantEvaluation(expr: PExpression): Option[BigInt]
 
+  def stringConstantEvaluation(expr: PExpression): Option[String]
+
   def keyElementIndices(elems : Vector[PKeyedElement]) : Vector[BigInt]
 
   def getTypeInfo: TypeInfo

--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -168,5 +168,7 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context)
 
   override def intConstantEvaluation(expr: PExpression): Option[BigInt] = intConstantEval(expr)
 
+  override def stringConstantEvaluation(expr: PExpression): Option[String] = stringConstantEval(expr)
+
   override def getTypeInfo: TypeInfo = this
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Assignability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Assignability.scala
@@ -93,6 +93,7 @@ trait Assignability extends BaseProperty { this: TypeInfoImpl =>
     case (t, op) => s"type error: got $t, but expected type compatible with $op"
   } {
     case (Single(IntT(_)), PAddOp() | PSubOp() | PMulOp() | PDivOp() | PModOp()) => true
+    case (Single(StringT), PAddOp()) => true
     case _ => false
   }
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
@@ -96,4 +96,17 @@ trait ConstantEvaluation { this: TypeInfoImpl =>
 
       case _ => None
     }
+
+  lazy val stringConstantEval: PExpression => Option[String] = {
+    attr[PExpression, Option[String]] {
+      case PStringLit(lit) => Some(lit)
+
+      case PAdd(l,r) => for {
+        lStr <- stringConstantEval(l)
+        rStr <- stringConstantEval(r)
+      } yield lStr + rStr
+
+      case _ => None
+    }
+  }
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Convertibility.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Convertibility.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.frontend.info.implementation.property
 
-import viper.gobra.frontend.info.base.Type.{DeclaredT, IntT, PointerT, Single, Type}
+import viper.gobra.frontend.info.base.Type.{DeclaredT, IntT, PointerT, Single, SliceT, StringT, Type}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 
 trait Convertibility extends BaseProperty { this: TypeInfoImpl =>
@@ -19,6 +19,7 @@ trait Convertibility extends BaseProperty { this: TypeInfoImpl =>
     case (Single(lst), Single(rst)) => (lst, rst) match {
       case (left, right) if assignableTo(left, right) => true
       case (IntT(_), IntT(_)) => true
+      case (SliceT(IntT(config.typeBounds.Byte)), StringT) => true
       case (left, right) => (underlyingType(left), underlyingType(right)) match {
         case (l, r) if identicalTypes(l, r) => true
         case (IntT(_), IntT(_)) => true

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Convertibility.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Convertibility.scala
@@ -21,6 +21,7 @@ trait Convertibility extends BaseProperty { this: TypeInfoImpl =>
       case (IntT(_), IntT(_)) => true
       case (left, right) => (underlyingType(left), underlyingType(right)) match {
         case (l, r) if identicalTypes(l, r) => true
+        case (IntT(_), IntT(_)) => true
         case (PointerT(l), PointerT(r)) if identicalTypes(underlyingType(l), underlyingType(r)) &&
           !(left.isInstanceOf[DeclaredT] && right.isInstanceOf[DeclaredT]) => true
         case _ => false

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -736,6 +736,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
   private[typing] def wellDefIfConstExpr(expr: PExpression): Messages = typ(expr) match {
     case BooleanT => error(expr, s"expected constant boolean expression", boolConstantEval(expr).isEmpty)
     case typ if underlyingType(typ).isInstanceOf[IntT] => error(expr, s"expected constant int expression", intConstantEval(expr).isEmpty)
+    case StringT => error(expr, s"expected constant string expression", stringConstantEval(expr).isEmpty)
     case _ => error(expr, s"expected a constant expression")
   }
 }

--- a/src/test/resources/regressions/features/stubs/stubs-fail0.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs-fail0.gobra
@@ -4,6 +4,6 @@
 package main
 
 import (
-    //:: ExpectedOutput(type_error)
+    //:: ExpectedOutput(parser_error)
     "nopackagewhatsoever"
 )

--- a/src/test/resources/regressions/features/stubs/stubs-fail0.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs-fail0.gobra
@@ -1,0 +1,9 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+import (
+    //:: ExpectedOutput(type_error)
+    "nopackagewhatsoever"
+)

--- a/src/test/resources/regressions/features/stubs/stubs-fail1.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs-fail1.gobra
@@ -1,0 +1,10 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+import "net"
+
+// Should fail, package net does not contain member DoesNotExist
+//:: ExpectedOutput(type_error)
+func closePacketConn(conn net.DoesNotExist) error

--- a/src/test/resources/regressions/features/stubs/stubs0.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs0.gobra
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+import (
+    "encoding/binary"
+    "net"
+    "strconv"
+    "strings"
+    "sync"
+    "time"
+)

--- a/src/test/resources/regressions/features/stubs/stubs0.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs0.gobra
@@ -3,11 +3,51 @@
 
 package main
 
+// All packages are found
 import (
-    "encoding/binary"
-    "net"
-    "strconv"
-    "strings"
-    "sync"
-    "time"
+	"encoding/binary"
+	"net"
+	"strconv"
+	"strings"
+	"time"
 )
+
+// Checks that files from package "encoding/binary" are correctly parsed
+func testEncodingBinary(e binary.LittleEndian) {
+	s := make([]byte, 2)
+	e.PutUint16(s, uint16(0))
+	assert e.String() == "LittleEndian"
+}
+
+// Checks that files from package "net" are correctly parsed
+// 1: file net/ip.gobra
+func testNet1(ip net.IP) {
+	s, e := ip.MarshalText() 
+}
+
+// 2: file net/net.gobra
+requires acc(opErr)
+func testNet2(opErr *net.OpError) error {
+	return opErr.Unwrap()
+}
+
+// Checks that files from package "strconv" are correctly parsed
+func testStrconv() {
+	i, _ := strconv.ParseUint("10", 10, 64)
+}
+
+// Checks that files from package "strings" are correctly parsed
+func testStrings(s string) bool {
+	return strings.HasPrefix(s, "test")
+}
+
+// Checks that files from package "time" are correctly parsed
+// 1: file time/time.gobra
+func testTime1(d time.Weekday) {
+	assert d == time.Wednesday ==> d.String() == "Wednesday"
+}
+
+// 2: file time/zoneinfo.gobra
+func testTime2(name string) (res *time.Location) {
+	return time.FixedZone(name, 0)
+}

--- a/src/test/resources/regressions/features/stubs/stubs1.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs1.gobra
@@ -1,0 +1,12 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+import "net"
+
+func ipLen(ip net.IP) int
+
+func closePacketConn(conn net.PacketConn) error {
+    return conn.Close()
+}

--- a/src/test/resources/regressions/features/stubs/stubs1.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs1.gobra
@@ -10,3 +10,11 @@ func ipLen(ip net.IP) int
 func closePacketConn(conn net.PacketConn) error {
     return conn.Close()
 }
+
+func addrErrorTimeout(ae * net.AddrError) {
+    assert !ae.Timeout()
+}
+
+func addrErrorTimeoutInterface(ae net.Error) {
+    assert !ae.Timeout()
+}

--- a/src/test/resources/regressions/features/stubs/stubs1.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs1.gobra
@@ -11,10 +11,11 @@ func closePacketConn(conn net.PacketConn) error {
     return conn.Close()
 }
 
-func addrErrorTimeout(ae * net.AddrError) {
+func addrErrorTimeout(ae * net.AddrError) bool {
     assert !ae.Timeout()
+    return ae.Timeout()
 }
 
-func addrErrorTimeoutInterface(ae net.Error) {
-    assert !ae.Timeout()
+func addrErrorTimeoutInterface(ae net.Error) bool {
+    return ae.Timeout()
 }


### PR DESCRIPTION
This PR adds stubs for some files in packages `encoding/binary`, `net`, `strconv`, `strings` and `time`. The definitions in these files are required for verifying the SCION dataplane.

When deciding what to include in the stubs, I tried to follow these guidelines:
- I opted to include the headers for every exported member in the files, even if those members are severely under-specified. Sometimes, this was not possible (e.g. higher order functions are omitted/commented because there is no support for the function type). 
- I included the definition of non-exported packages in cases where they are useful to verify parts of the implementation of other exported members
- I included the full uncommented body of members whenever they could be fully verified. If they could not for some "small reason", I would still include the commented body and an annotation starting with `(joao)` stating the reason why it fails.
- Most often, I include comments from the original code to serve as documentation but I made them shorter. For a full description, one should look at the original sources.