### PR TITLE
Fix issues with contracts in stubs not detected in tests

### DIFF
--- a/src/main/resources/stubs/time/time.gobra
+++ b/src/main/resources/stubs/time/time.gobra
@@ -238,7 +238,6 @@ ensures forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
 func (t *Time) UnmarshalBinary(data []byte, ghost p perm) error
 
 // GobEncode implements the gob.GobEncoder interface.
-requires forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
 ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
 func (t Time) GobEncode() (res []byte, error)
 
@@ -251,7 +250,6 @@ ensures forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
 func (t *Time) GobDecode(data []byte, ghost p perm) error
 
 // MarshalJSON implements the json.Marshaler interface.
-requires forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
 ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
 func (t Time) MarshalJSON() (res []byte, error)
 
@@ -264,7 +262,6 @@ ensures forall i int :: 0 <= i && i < len(data) ==> acc(&data[i], p)
 func (t *Time) UnmarshalJSON(data []byte, ghost p perm) error
 
 // MarshalText implements the encoding.TextMarshaler interface.
-requires forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
 ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
 func (t Time) MarshalText() (res []byte, error)
 


### PR DESCRIPTION
I realized that I introduced some errors in a late commit to the `add-more-stubs` branch. More precisely, the pre-conditions of methods `GobEncode`, `MarshalJSON`, and `MarshalText` in the file `time.gobra` mention the return values. This PR fixes that.