### PR TITLE
Fix z3 path

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -52,6 +52,7 @@ case class Config(
       includeDirs = (includeDirs ++ other.includeDirs).distinct,
       reporter = reporter,
       backend = backend,
+      z3Exe = z3Exe orElse other.z3Exe,
       logLevel = if (logLevel.isGreaterOrEqual(other.logLevel)) other.logLevel else logLevel, // take minimum
       // TODO merge strategy for following properties is unclear (maybe AND or OR)
       shouldParse = shouldParse,

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -53,6 +53,7 @@ case class Config(
       reporter = reporter,
       backend = backend,
       z3Exe = z3Exe orElse other.z3Exe,
+      boogieExe = boogieExe orElse other.boogieExe,
       logLevel = if (logLevel.isGreaterOrEqual(other.logLevel)) other.logLevel else logLevel, // take minimum
       // TODO merge strategy for following properties is unclear (maybe AND or OR)
       shouldParse = shouldParse,


### PR DESCRIPTION
Currently, Gobra ignores alternative paths to `z3` passed with the `--z3Exe` flag. This happens because the method `merge` in `Config` does not explicitly state how to merge the `z3Exe` fields of two Configurations and thus, it is assigned the default value `None`. This PR fixes that. I also noticed that this happened with the `boogieExe` field and fixed it.