### PR TITLE
Relative In-File Config Paths

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -111,9 +111,11 @@ class Gobra extends GoVerifier with GoIdeVerifier {
       } else {
         // our current "merge" strategy for potentially different, duplicate, or even contradicting configurations is to concatenate them:
         val args = configs.flatMap(configString => configString.split(" ")).toList
-        val inFileConfig = new ScallopGobraConfig(args, isInputOptional = true).config
+        // skip include dir checks as the include should only be parsed and is not resolved yet based on the current directory
+        val inFileConfig = new ScallopGobraConfig(args, isInputOptional = true, skipIncludeDirChecks = true).config
         // modify all relative includeDirs such that they are resolved relatively to the current file:
         val resolvedConfig = inFileConfig.copy(includeDirs = inFileConfig.includeDirs.map(
+          // it's important to convert includeDir to a string first as `path` might be a ZipPath and `includeDir` might not
           includeDir => path.getParent.resolve(includeDir.toString)))
         Some(resolvedConfig)
       }

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -111,9 +111,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
       } else {
         // our current "merge" strategy for potentially different, duplicate, or even contradicting configurations is to concatenate them:
         val args = configs.flatMap(configString => configString.split(" ")).toList
-        // input files are mandatory, therefore we take the inputFiles from the old config:
-        val fullArgs = (args :+ "-i") ++ config.inputFiles.map(_.toString)
-        val inFileConfig = new ScallopGobraConfig(fullArgs).config
+        val inFileConfig = new ScallopGobraConfig(args, isInputOptional = true).config
         // modify all relative includeDirs such that they are resolved relatively to the current file:
         val resolvedConfig = inFileConfig.copy(includeDirs = inFileConfig.includeDirs.map(
           includeDir => path.getParent.resolve(includeDir.toString)))

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -72,13 +72,13 @@ class PositionManager(val positions: Positions) extends Messaging(positions) {
   }
 
   def translate(start: Position, end: Position): SourcePosition = {
-    val filename = start.source match {
-      case FileSource(filename, _) => filename
-      case FromFileSource(filename, _) => filename
+    val path = start.source match {
+      case FileSource(filename, _) => Paths.get(filename)
+      case FromFileSource(path, _) => path
       case _ => ???
     }
     new SourcePosition(
-      Paths.get(filename),
+      path,
       LineColumnPosition(start.line, start.column),
       Some(LineColumnPosition(end.line, end.column))
     )

--- a/src/main/scala/viper/gobra/backend/BackendVerifier.scala
+++ b/src/main/scala/viper/gobra/backend/BackendVerifier.scala
@@ -49,7 +49,7 @@ object BackendVerifier {
 
     val verifier = config.backend.create(exePaths)
 
-    val programID = "_programID_" + config.inputFiles.head.getName
+    val programID = s"_programID_${config.inputFiles.head}"
 
     val verificationResult = verifier.verify(programID, config.backendConfig, BacktranslatingReporter(config.reporter, task.backtrack, config), task.program)(executor)
 

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -74,7 +74,7 @@ case class Config(
     }
 }
 
-class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = false)
+class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = false, skipIncludeDirChecks: Boolean = false)
     extends ScallopConf(arguments)
     with StrictLogging {
 
@@ -262,8 +262,10 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     } yield ()
   }
 
-  validateFilesExist(include)
-  validateFilesIsDirectory(include)
+  if (!skipIncludeDirChecks) {
+    validateFilesExist(include)
+    validateFilesIsDirectory(include)
+  }
   validateInput(input, include)
 
   verify()

--- a/src/main/scala/viper/gobra/reporting/Message.scala
+++ b/src/main/scala/viper/gobra/reporting/Message.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.reporting
 
-import java.io.File
+import java.nio.file.Path
 
 import viper.gobra.ast.frontend.PNode.PPkg
 import viper.gobra.ast.frontend.{PPackage, PProgram}
@@ -64,84 +64,84 @@ case class GobraEntityFailureMessage(verifier: String, concerning: Source.Verifi
     s"failure=${result.toString})"
 }
 
-case class PreprocessedInputMessage(input: File, preprocessedContent: () => String) extends GobraMessage {
+case class PreprocessedInputMessage(input: Path, preprocessedContent: () => String) extends GobraMessage {
   override val name: String = s"preprocessed_input_message"
 
   override def toString: String = s"preprocessed_input_message(" +
-    s"file=${input.toPath}, " +
+    s"file=${input}, " +
     s"content=${preprocessedContent()})"
 }
 
-case class ParsedInputMessage(input: File, ast: () => PProgram) extends GobraMessage {
+case class ParsedInputMessage(input: Path, ast: () => PProgram) extends GobraMessage {
   override val name: String = s"parsed_input_message"
 
   override def toString: String = s"parsed_input_message(" +
-    s"file=${input.toPath}, " +
+    s"file=${input}, " +
     s"ast=${ast().formatted})"
 }
 
-case class ParserErrorMessage(input: File, result: Vector[ParserError]) extends GobraMessage {
+case class ParserErrorMessage(input: Path, result: Vector[ParserError]) extends GobraMessage {
   override val name: String = s"parser_error_message"
 
   override def toString: String = s"parser_error_message(" +
-    s"file=${input.toPath}), " +
+    s"file=${input}), " +
     s"errors=${result.map(_.toString).mkString(",")})"
 }
 
 sealed trait TypeCheckMessage extends GobraMessage {
   override val name: String = s"type_check_message"
-  val input: File
+  val input: Path
   val ast: () => PPackage
 
   override def toString: String = s"type_check_message(" +
-    s"file=${input.toPath})"
+    s"file=${input})"
 }
 
-case class TypeCheckSuccessMessage(input: File, ast: () => PPackage, erasedGhostCode: () => String, goifiedGhostCode: () => String) extends TypeCheckMessage {
+case class TypeCheckSuccessMessage(input: Path, ast: () => PPackage, erasedGhostCode: () => String, goifiedGhostCode: () => String) extends TypeCheckMessage {
   override val name: String = s"type_check_success_message"
 
   override def toString: String = s"type_check_success_message(" +
-    s"file=${input.toPath})"
+    s"file=${input})"
 }
 
-case class TypeCheckFailureMessage(input: File, packageName: PPkg, ast: () => PPackage, result: Vector[VerifierError]) extends TypeCheckMessage {
+case class TypeCheckFailureMessage(input: Path, packageName: PPkg, ast: () => PPackage, result: Vector[VerifierError]) extends TypeCheckMessage {
   override val name: String = s"type_check_failure_message"
 
   override def toString: String = s"type_check_failure_message(" +
-    s"file=${input.toPath}, " +
+    s"file=${input}, " +
     s"package=$packageName, " +
     s"failures=${result.map(_.toString).mkString(",")})"
 }
 
-case class TypeCheckDebugMessage(input: File, ast: () => PPackage, debugTypeInfo: () => String) extends TypeCheckMessage {
+case class TypeCheckDebugMessage(input: Path, ast: () => PPackage, debugTypeInfo: () => String) extends TypeCheckMessage {
   override val name: String = s"type_check_debug_message"
 
   override def toString: String = s"type_check_debug_message(" +
-    s"file=${input.toPath}), " +
+    s"file=${input}), " +
     s"debugInfo=${debugTypeInfo()})"
 }
 
-case class DesugaredMessage(input: File, internal: () => in.Program) extends GobraMessage {
+case class DesugaredMessage(input: Path, internal: () => in.Program) extends GobraMessage {
   override val name: String = s"desugared_message"
 
   override def toString: String = s"desugared_message(" +
-    s"file=${input.toPath}, " +
+    s"file=${input}, " +
     s"internal=${internal().formatted})"
 }
 
-case class AppliedInternalTransformsMessage(input: File, internal: () => in.Program) extends GobraMessage {
+case class AppliedInternalTransformsMessage(input: Path, internal: () => in.Program) extends GobraMessage {
   override val name: String = s"transform_message"
 
   override def toString: String = s"transform_message(" +
-    s"file=${input.toPath}, " +
+    s"file=${input}, " +
     s"internal=${internal().formatted})"
 }
 
-case class GeneratedViperMessage(input: File, vprAst: () => vpr.Program, backtrack: () => BackTranslator.BackTrackInfo) extends GobraMessage {
+case class GeneratedViperMessage(input: Path, vprAst: () => vpr.Program, backtrack: () => BackTranslator.BackTrackInfo) extends GobraMessage {
   override val name: String = s"generated_viper_message"
 
   override def toString: String = s"generated_viper_message(" +
-    s"file=${input.toPath}, " +
+    s"file=${input}, " +
     s"vprFormated=$vprAstFormatted)"
 
   lazy val vprAstFormatted: String = silver.ast.pretty.FastPrettyPrinter.pretty(vprAst())

--- a/src/main/scala/viper/gobra/reporting/Reporter.scala
+++ b/src/main/scala/viper/gobra/reporting/Reporter.scala
@@ -6,8 +6,8 @@
 
 package viper.gobra.reporting
 
-import java.io.File
 import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.Path
 
 import ch.qos.logback.classic.Level
 import org.apache.commons.io.FileUtils
@@ -53,8 +53,12 @@ case class FileWriterReporter(name: String = "filewriter_reporter",
     case _ => // ignore
   }
 
-  private def write(file: File, fileExt: String, content: String): Unit = {
-    val outputFile = OutputUtil.postfixFile(file, fileExt)
-    FileUtils.writeStringToFile(outputFile, content, UTF_8)
+  private def write(input: Path, fileExt: String, content: String): Unit = {
+    val outputFile = OutputUtil.postfixFile(input, fileExt)
+    try {
+      FileUtils.writeStringToFile(outputFile.toFile, content, UTF_8)
+    } catch {
+      case _: UnsupportedOperationException => println(s"cannot write output to file $outputFile")
+    }
   }
 }

--- a/src/main/scala/viper/gobra/util/OutputUtil.scala
+++ b/src/main/scala/viper/gobra/util/OutputUtil.scala
@@ -6,14 +6,12 @@
 
 package viper.gobra.util
 
-import java.io.File
+import java.nio.file.Path
 
 
 object OutputUtil {
 
-  def postfixFile(f: File, postfix: String): File = {
-    val abolutePath = f.getAbsolutePath
-    val newFile = s"${abolutePath}.$postfix"
-    new File(newFile)
+  def postfixFile(f: Path, postfix: String): Path = {
+    f.resolveSibling(s"${f.getFileName}.$postfix")
   }
 }

--- a/src/test/resources/regressions/features/channels/channel-simple4.gobra
+++ b/src/test/resources/regressions/features/channels/channel-simple4.gobra
@@ -3,7 +3,7 @@
 
 package pkg
 
-// ##(-I src/test/resources/regressions/features/channels)
+// ##(-I ./)
 import b "bar"
 
 // "c.IsChannel()" should work across packages, i.e. the mpredicate maps to the same Viper predicate independently of

--- a/src/test/resources/regressions/features/defunc/import-preds.gobra
+++ b/src/test/resources/regressions/features/defunc/import-preds.gobra
@@ -1,7 +1,7 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-// ##(-I src/test/resources/regressions/features/defunc/includes)
+// ##(-I ./includes/)
 package pkg
 
 import "preds"

--- a/src/test/resources/regressions/features/errors/error-simple3.gobra
+++ b/src/test/resources/regressions/features/errors/error-simple3.gobra
@@ -3,7 +3,7 @@
 
 package pkg
 
-// ##(-I src/test/resources/regressions/features/errors)
+// ##(-I ./)
 import b "bar"
 
 func foo(e b.error) int {

--- a/src/test/resources/regressions/features/import/constant_import/main.gobra
+++ b/src/test/resources/regressions/features/import/constant_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/constant_import)
+// ##(-I ./)
 import b "bar"
 
 func foo() {

--- a/src/test/resources/regressions/features/import/constant_import/main2.gobra
+++ b/src/test/resources/regressions/features/import/constant_import/main2.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/constant_import)
+// ##(-I ./)
 import b "bar2"
 
 // test whether constant evaluation works across packages

--- a/src/test/resources/regressions/features/import/constant_import/main3.gobra
+++ b/src/test/resources/regressions/features/import/constant_import/main3.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/constant_import)
+// ##(-I ./)
 import . "bar3"
 
 const NewAnswer = Answer

--- a/src/test/resources/regressions/features/import/cyclic_import/main.gobra
+++ b/src/test/resources/regressions/features/import/cyclic_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/cyclic_import)
+// ##(-I ./)
 //:: ExpectedOutput(type_error)
 import f "foo" // this is a cyclic import
 

--- a/src/test/resources/regressions/features/import/error_reporting_import/main.gobra
+++ b/src/test/resources/regressions/features/import/error_reporting_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/error_reporting_import)
+// ##(-I ./)
 //:: ExpectedOutput(type_error)
 import b "bar"
 

--- a/src/test/resources/regressions/features/import/fpredicate_import/main.gobra
+++ b/src/test/resources/regressions/features/import/fpredicate_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/fpredicate_import)
+// ##(-I ./)
 import b "bar"
 
 func foo() {

--- a/src/test/resources/regressions/features/import/function_import/main.gobra
+++ b/src/test/resources/regressions/features/import/function_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/function_import)
+// ##(-I ./)
 import b "bar"
 
 func foo() {

--- a/src/test/resources/regressions/features/import/ghost_member_import/main.gobra
+++ b/src/test/resources/regressions/features/import/ghost_member_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/ghost_member_import)
+// ##(-I ./)
 import b "bar"
 
 func foo() {

--- a/src/test/resources/regressions/features/import/method_import/main.gobra
+++ b/src/test/resources/regressions/features/import/method_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/method_import)
+// ##(-I ./)
 import b "bar"
 
 func foo() {

--- a/src/test/resources/regressions/features/import/method_import/main2.gobra
+++ b/src/test/resources/regressions/features/import/method_import/main2.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/method_import)
+// ##(-I ./)
 import b "bar2"
 
 func foo() {

--- a/src/test/resources/regressions/features/import/mpredicate_import/main.gobra
+++ b/src/test/resources/regressions/features/import/mpredicate_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/mpredicate_import)
+// ##(-I ./)
 import b "bar"
 
 func foo() {

--- a/src/test/resources/regressions/features/import/multi_import/main1.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main1.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/multi_import)
+// ##(-I ./)
 // import of same package but with different qualifiers should be possible:
 import b "bar"
 import bar "bar"

--- a/src/test/resources/regressions/features/import/multi_import/main2.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main2.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/multi_import)
+// ##(-I ./)
 // import of same package with same qualifier is forbidden:
 //:: ExpectedOutput(type_error)
 import b "bar"

--- a/src/test/resources/regressions/features/import/multi_import/main3.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main3.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/multi_import)
+// ##(-I ./)
 // import of different packages but with same qualifier is forbidden:
 //:: ExpectedOutput(type_error)
 import b "bar"

--- a/src/test/resources/regressions/features/import/multi_import/main4.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main4.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/multi_import)
+// ##(-I ./)
 // unqualified import of same package is forbidden:
 import . "bar"
 import . "bar"

--- a/src/test/resources/regressions/features/import/multi_import/main5.gobra
+++ b/src/test/resources/regressions/features/import/multi_import/main5.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/multi_import)
+// ##(-I ./)
 // unqualified import of bar and foo should not work as they both define a constant with the same identifier:
 import . "bar"
 import . "foo"

--- a/src/test/resources/regressions/features/import/namespace_import/main.gobra
+++ b/src/test/resources/regressions/features/import/namespace_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/namespace_import)
+// ##(-I ./)
 import b "bar"
 
 // create a second type called Rectangle:

--- a/src/test/resources/regressions/features/import/omitted_package_name/main.gobra
+++ b/src/test/resources/regressions/features/import/omitted_package_name/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/omitted_package_name)
+// ##(-I ./)
 import "lib/foo"
 import bar "bar"
 

--- a/src/test/resources/regressions/features/import/simple_type_import/main.gobra
+++ b/src/test/resources/regressions/features/import/simple_type_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/simple_type_import)
+// ##(-I ./)
 import b "bar"
 
 func client() {

--- a/src/test/resources/regressions/features/import/struct_import/main.gobra
+++ b/src/test/resources/regressions/features/import/struct_import/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/struct_import)
+// ##(-I ./)
 import b "bar"
 
 func client() {

--- a/src/test/resources/regressions/features/import/unique_qualifiers/main1.gobra
+++ b/src/test/resources/regressions/features/import/unique_qualifiers/main1.gobra
@@ -4,7 +4,7 @@
 package main
 
 // check whether Gobra detects non-unique explicit import qualifiers
-// ##(-I src/test/resources/regressions/features/import/unique_qualifiers)
+// ##(-I ./)
 //:: ExpectedOutput(type_error)
 import not_unique "bar"
 //:: ExpectedOutput(type_error)

--- a/src/test/resources/regressions/features/import/unique_qualifiers/main2.gobra
+++ b/src/test/resources/regressions/features/import/unique_qualifiers/main2.gobra
@@ -4,7 +4,7 @@
 package main
 
 // check whether Gobra detects non-unique implicit import qualifiers
-// ##(-I src/test/resources/regressions/features/import/unique_qualifiers)
+// ##(-I ./)
 //:: ExpectedOutput(type_error)
 import "bar"
 //:: ExpectedOutput(type_error)

--- a/src/test/resources/regressions/features/import/unique_qualifiers/main3.gobra
+++ b/src/test/resources/regressions/features/import/unique_qualifiers/main3.gobra
@@ -4,7 +4,7 @@
 package main
 
 // check whether Gobra detects a mix of non-unique implicit and explicit import qualifiers
-// ##(-I src/test/resources/regressions/features/import/unique_qualifiers)
+// ##(-I ./)
 //:: ExpectedOutput(type_error)
 import bar "bar"
 //:: ExpectedOutput(type_error)

--- a/src/test/resources/regressions/features/import/unique_qualifiers/main4.gobra
+++ b/src/test/resources/regressions/features/import/unique_qualifiers/main4.gobra
@@ -4,7 +4,7 @@
 package main
 
 // check whether Gobra accepts unique qualifiers for the same package
-// ##(-I src/test/resources/regressions/features/import/unique_qualifiers)
+// ##(-I ./)
 import "bar"
 import b "bar"
 

--- a/src/test/resources/regressions/features/import/unqualified_import/functions/main1.gobra
+++ b/src/test/resources/regressions/features/import/unqualified_import/functions/main1.gobra
@@ -3,7 +3,7 @@
 
 package main1
 
-// ##(-I src/test/resources/regressions/features/import/unqualified_import/functions)
+// ##(-I ./)
 import . "bar1"
 
 func foo() {

--- a/src/test/resources/regressions/features/import/unqualified_import/functions/main2.gobra
+++ b/src/test/resources/regressions/features/import/unqualified_import/functions/main2.gobra
@@ -3,7 +3,7 @@
 
 package main2
 
-// ##(-I src/test/resources/regressions/features/import/unqualified_import/functions)
+// ##(-I ./)
 import . "bar2_1"
 import . "bar2_2"
 

--- a/src/test/resources/regressions/features/import/unqualified_import/functions/main3.gobra
+++ b/src/test/resources/regressions/features/import/unqualified_import/functions/main3.gobra
@@ -3,7 +3,7 @@
 
 package main3
 
-// ##(-I src/test/resources/regressions/features/import/unqualified_import/functions)
+// ##(-I ./)
 import . "bar3"
 
 func foo() {

--- a/src/test/resources/regressions/features/import/unqualified_import/methods/main.gobra
+++ b/src/test/resources/regressions/features/import/unqualified_import/methods/main.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/import/unqualified_import/methods)
+// ##(-I ./)
 import . "bar"
 
 func foo() {

--- a/src/test/resources/regressions/features/interfaces/counterStream.gobra
+++ b/src/test/resources/regressions/features/interfaces/counterStream.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/features/interfaces/)
+// ##(-I ./)
 
 import "counterImpl"
 

--- a/src/test/resources/regressions/issues/000124-1.gobra
+++ b/src/test/resources/regressions/issues/000124-1.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/issues/000124/)
+// ##(-I ./000124/)
 import gobra "github.com/gobra"
 
 func main() {

--- a/src/test/resources/regressions/issues/000124-2.gobra
+++ b/src/test/resources/regressions/issues/000124-2.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/issues/000124/)
+// ##(-I ./000124/)
 import "github.com/gobra"
 
 func main() {

--- a/src/test/resources/regressions/issues/000166.gobra
+++ b/src/test/resources/regressions/issues/000166.gobra
@@ -3,7 +3,7 @@
 
 package pkg
 
-// ##(-I src/test/resources/regressions/issues/000166/)
+// ##(-I ./000166/)
 
 import "bug"
 

--- a/src/test/resources/regressions/issues/000169.gobra
+++ b/src/test/resources/regressions/issues/000169.gobra
@@ -3,7 +3,7 @@
 
 package pkg
 
-// ##(-I src/test/resources/regressions/issues/000169/)
+// ##(-I ./000169/)
 
 import "pkg2"
 

--- a/src/test/resources/regressions/issues/000232.gobra
+++ b/src/test/resources/regressions/issues/000232.gobra
@@ -3,7 +3,7 @@
 
 package main
 
-// ##(-I src/test/resources/regressions/issues/000232/)
+// ##(-I ./000232/)
 
 import "bug"
 

--- a/src/test/resources/same_package/file_local_imports/import_not_avail/main1.gobra
+++ b/src/test/resources/same_package/file_local_imports/import_not_avail/main1.gobra
@@ -4,7 +4,7 @@
 package main
 
 // check whether Gobra only considers import on file level (not package level)
-// ##(-I src/test/resources/same_package/file_local_imports/import_not_avail)
+// ##(-I ./)
 import "bar"
 
 func test1() {

--- a/src/test/scala/viper/gobra/BenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/BenchmarkTests.scala
@@ -54,7 +54,7 @@ trait GobraFrontendForTesting extends Frontend {
   override def init(verifier: Verifier): Unit = () // ignore verifier argument as we reuse the Gobra / Parser / TypeChecker / etc. instances for all tests
 
   override def reset(files: Seq[Path]): Unit =
-    config = Some(Config(inputFiles = files.map(_.toFile).toVector, reporter = NoopReporter))
+    config = Some(Config(inputFiles = files.toVector, reporter = NoopReporter))
 
   def gobraResult: VerifierResult
 

--- a/src/test/scala/viper/gobra/BenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/BenchmarkTests.scala
@@ -47,6 +47,9 @@ trait BenchmarkTests extends StatisticalTestSuite {
 }
 
 trait GobraFrontendForTesting extends Frontend {
+  val z3PropertyName = "GOBRATESTS_Z3_EXE"
+  val z3Exe: Option[String] = Option(System.getProperty(z3PropertyName))
+
   protected val executor: GobraExecutionContext = new DefaultGobraExecutionContext()
   protected var config: Option[Config] = None
 
@@ -54,7 +57,7 @@ trait GobraFrontendForTesting extends Frontend {
   override def init(verifier: Verifier): Unit = () // ignore verifier argument as we reuse the Gobra / Parser / TypeChecker / etc. instances for all tests
 
   override def reset(files: Seq[Path]): Unit =
-    config = Some(Config(inputFiles = files.toVector, reporter = NoopReporter))
+    config = Some(Config(inputFiles = files.toVector, reporter = NoopReporter, z3Exe = z3Exe))
 
   def gobraResult: VerifierResult
 

--- a/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
@@ -96,7 +96,7 @@ class DetailedBenchmarkTests extends BenchmarkTests {
     private val parsing = InitialStep("parsing", () => {
       assert(config.isDefined)
       val c = config.get
-      Parser.parse(c.inputFiles.map(_.toPath))(c)
+      Parser.parse(c.inputFiles)(c)
     })
 
     private val typeChecking: NextStep[PPackage, (PPackage, TypeInfo), Vector[VerifierError]] =

--- a/src/test/scala/viper/gobra/GobraPackageTests.scala
+++ b/src/test/scala/viper/gobra/GobraPackageTests.scala
@@ -61,8 +61,8 @@ class GobraPackageTests extends GobraTests {
         val config = Config(
           logLevel = Level.INFO,
           reporter = NoopReporter,
-          inputFiles = input.files.map(_.toFile).toVector,
-          includeDirs = Vector(currentDir.toFile)
+          inputFiles = input.files.toVector,
+          includeDirs = Vector(currentDir)
         )
 
         val executor: GobraExecutionContext = new DefaultGobraExecutionContext()
@@ -101,7 +101,7 @@ class GobraPackageTests extends GobraTests {
   }
 
   private def equalConfigs(config1: Config, config2: Config): Vector[GobraTestOuput] = {
-    def equalFiles(v1: Vector[File], v2: Vector[File]): Boolean = v1.sortBy(_.toString).equals(v2.sortBy(_.toString))
+    def equalFiles(v1: Vector[Path], v2: Vector[Path]): Boolean = v1.sortBy(_.toString).equals(v2.sortBy(_.toString))
 
     val equal = (equalFiles(config1.inputFiles, config2.inputFiles)
       && equalFiles(config1.includeDirs, config2.includeDirs)

--- a/src/test/scala/viper/gobra/GobraTests.scala
+++ b/src/test/scala/viper/gobra/GobraTests.scala
@@ -46,7 +46,7 @@ class GobraTests extends AnnotationBasedTestSuite with BeforeAndAfterAll {
         val config = Config(
           logLevel = Level.INFO,
           reporter = NoopReporter,
-          inputFiles = Vector(input.file.toFile)
+          inputFiles = Vector(input.file)
         )
 
         val executor: GobraExecutionContext = new DefaultGobraExecutionContext()

--- a/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
+++ b/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
@@ -253,7 +253,7 @@ class GhostErasureUnitTests extends AnyFunSuite with Matchers with Inside {
 
       val ghostLess = new GhostLessPrinter(info).format(pkg)
       // try to parse ghostLess string:
-      val parseRes = Parser.parseProgram(StringSource(ghostLess, "Ghostless Program"), false)(config)
+      val parseRes = Parser.parseProgram(StringSource(ghostLess, "Ghostless Program"), false)
       parseRes match {
         case Right(prog) => prog
         case Left(messages) => fail(s"Parsing failed: $messages")
@@ -292,13 +292,12 @@ class GhostErasureUnitTests extends AnyFunSuite with Matchers with Inside {
     }
 
     def testProg(inputProg: String, expectedErasedProg: String): Assertion = {
-      val config = Config(Vector())
-      val inputParseAst = Parser.parseProgram(StringSource(inputProg, "Input Program"))(config)
+      val inputParseAst = Parser.parseProgram(StringSource(inputProg, "Input Program"))
       val ghostlessProg = inputParseAst match {
         case Right(prog) => ghostLessProg(prog)
         case Left(msgs) => fail(s"Parsing input program has failed with $msgs")
       }
-      val expectedParseAst = Parser.parseProgram(StringSource(expectedErasedProg, "Expected Program"))(config)
+      val expectedParseAst = Parser.parseProgram(StringSource(expectedErasedProg, "Expected Program"))
       expectedParseAst match {
         case Right(prog) => equal(ghostlessProg, prog)
         case Left(msgs) => fail(s"Parsing expected erased program has failed with $msgs")


### PR DESCRIPTION
Changes behavior of In-File IncludeDir paths to be relative to the file in which they are instead of being relative to the location at which Gobra is executed.