### PR TITLE
Implement preserves keyword

### DIFF
--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -770,6 +770,7 @@ sealed trait PSpecification extends PGhostNode
 
 case class PFunctionSpec(
                       pres: Vector[PExpression],
+                      preserves: Vector[PExpression],
                       posts: Vector[PExpression],
                       isPure: Boolean = false,
                       ) extends PSpecification

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -108,13 +108,15 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
 
   def showPure: Doc = "pure" <> line
   def showPre(pre: PExpression): Doc = "requires" <+> showExpr(pre)
+  def showPreserves(preserves: PExpression): Doc = "preserves" <+> showExpr(preserves)
   def showPost(post: PExpression): Doc = "ensures" <+> showExpr(post)
   def showInv(inv: PExpression): Doc = "invariant" <+> showExpr(inv)
 
   def showSpec(spec: PSpecification): Doc = spec match {
-    case PFunctionSpec(pres, posts, isPure) =>
+    case PFunctionSpec(pres, preserves, posts, isPure) =>
       (if (isPure) showPure else emptyDoc) <>
       hcat(pres map (showPre(_) <> line)) <>
+        hcat(preserves map (showPreserves(_) <> line)) <>
         hcat(posts map (showPost(_) <> line))
 
     case PLoopSpec(inv) =>

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -461,8 +461,8 @@ object Desugar {
       }
 
       // translate pre- and postconditions
-      val pres = decl.spec.pres map preconditionD(specCtx)
-      val posts = decl.spec.posts map postconditionD(specCtx)
+      val pres = (decl.spec.pres ++ decl.spec.preserves) map preconditionD(specCtx)
+      val posts = (decl.spec.preserves ++ decl.spec.posts) map postconditionD(specCtx)
 
       // p1' := p1; ... ; pn' := pn
       val argInits = argsWithSubs.flatMap{
@@ -610,8 +610,8 @@ object Desugar {
       }
 
       // translate pre- and postconditions
-      val pres = decl.spec.pres map preconditionD(specCtx)
-      val posts = decl.spec.posts map postconditionD(specCtx)
+      val pres = (decl.spec.pres ++ decl.spec.preserves) map preconditionD(specCtx)
+      val posts = (decl.spec.preserves ++ decl.spec.posts) map postconditionD(specCtx)
 
       // s' := s
       val recvInits = (recvWithSubs match {
@@ -700,8 +700,8 @@ object Desugar {
       }
 
       // translate pre- and postconditions
-      val pres = decl.spec.pres map preconditionD(ctx)
-      val posts = decl.spec.posts map postconditionD(ctx)
+      val pres = (decl.spec.pres ++ decl.spec.preserves) map preconditionD(ctx)
+      val posts = (decl.spec.preserves ++ decl.spec.posts) map postconditionD(ctx)
 
       val bodyOpt = decl.body.map {
         case (_, b: PBlock) =>
@@ -2106,8 +2106,8 @@ object Desugar {
           val returnsWithSubs = m.result.outs.zipWithIndex map { case (p,i) => outParameterD(p,i,xInfo) }
           val (returns, _) = returnsWithSubs.unzip
           val specCtx = new FunctionContext(_ => _ => in.Seqn(Vector.empty)(src)) // dummy assign
-          val pres = m.spec.pres map preconditionD(specCtx)
-          val posts = m.spec.posts map postconditionD(specCtx)
+          val pres = (m.spec.pres ++ m.spec.preserves) map preconditionD(specCtx)
+          val posts = (m.spec.preserves ++ m.spec.posts) map postconditionD(specCtx)
 
           val mem = if (m.spec.isPure) {
             in.PureMethod(recv, proxy, args, returns, pres, posts, None)(src)

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -422,8 +422,12 @@ object Parser {
       }
 
     lazy val functionSpec: Parser[PFunctionSpec] =
-      ("requires" ~> expression <~ eos).* ~ ("ensures" ~> expression <~ eos).* ~ "pure".? ^^ {
-        case pres ~ posts ~ isPure => PFunctionSpec(pres, posts, isPure.nonEmpty)
+      ("requires" ~ expression <~ eos | "preserves" ~ expression <~ eos | "ensures" ~ expression <~ eos).* ~ "pure".? ^^ {
+        case spec ~ isPure => 
+          val pres = spec.collect{case "requires" ~ exp => exp}
+          val preserves = spec.collect{case "preserves" ~ exp => exp}
+          val posts = spec.collect{case "ensures" ~ exp => exp}
+          PFunctionSpec(pres, preserves, posts, isPure.nonEmpty)
       }
 
     lazy val methodDecl: Parser[PMethodDecl] =

--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -98,7 +98,7 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context,
 
   private def addTransitiveDeps(r: SymbolTable.Regular): Unit = {
     def checkedNodesFromFuncSpec(spec: PFunctionSpec): Vector[PNode] =
-      spec.pres ++ spec.posts ++ (spec.pres ++ spec.posts).flatMap(_.subNodes)
+      spec.pres ++ spec.preserves ++ spec.posts ++ (spec.pres ++ spec.preserves ++ spec.posts).flatMap(_.subNodes)
         // TODO: check why this causes node not in tree exception
         // (try { (spec.pres ++ spec.posts) flatMap allChildren } catch { case e => Seq.empty })
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMemberTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMemberTyping.scala
@@ -102,7 +102,7 @@ trait GhostMemberTyping extends BaseTyping { this: TypeInfoImpl =>
     }
   }
 
-  private def isPurePostcondition(spec: PFunctionSpec): Messages = spec.posts flatMap isPureExpr
+  private def isPurePostcondition(spec: PFunctionSpec): Messages = (spec.posts ++ spec.preserves) flatMap isPureExpr
 
   private[typing] def nonVariadicArguments(args: Vector[PParameter]): Messages = args.flatMap {
     p: PParameter => error(p, s"Pure members cannot have variadic arguments, but got $p", p.typ.isInstanceOf[PVariadicType])

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
@@ -258,8 +258,9 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
   }
 
   implicit lazy val wellDefSpec: WellDefinedness[PSpecification] = createWellDef {
-    case PFunctionSpec(pres, posts, _) =>
-      pres.flatMap(assignableToSpec) ++ posts.flatMap(assignableToSpec) ++
+    case PFunctionSpec(pres, preserves, posts, _) =>
+      pres.flatMap(assignableToSpec) ++ preserves.flatMap(assignableToSpec) ++ posts.flatMap(assignableToSpec) ++
+      preserves.flatMap(e => allChildren(e).flatMap(illegalPreconditionNode)) ++ 
       pres.flatMap(e => allChildren(e).flatMap(illegalPreconditionNode))
 
     case PLoopSpec(invariants) => invariants.flatMap(assignableToSpec)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
@@ -21,7 +21,7 @@ class GhostLessPrinter(classifier: GhostClassifier) extends DefaultPrettyPrinter
           rec,
           filterParamList(args),
           filterResult(res),
-          PFunctionSpec(Vector.empty, Vector.empty),
+          PFunctionSpec(Vector.empty, Vector.empty, Vector.empty),
           body.map( b => (PBodyParameterInfo(Vector.empty), b._2) )
         )
       )
@@ -32,7 +32,7 @@ class GhostLessPrinter(classifier: GhostClassifier) extends DefaultPrettyPrinter
           id,
           filterParamList(args),
           filterResult(res),
-          PFunctionSpec(Vector.empty, Vector.empty),
+          PFunctionSpec(Vector.empty, Vector.empty, Vector.empty),
           body.map( b => (PBodyParameterInfo(Vector.empty), b._2) )
         )
       )

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
@@ -74,9 +74,10 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
     * Shows the Goified version of the function / method specification
     */
   override def showSpec(spec: PSpecification): Doc = spec match {
-    case PFunctionSpec(pres, posts, isPure) =>
+    case PFunctionSpec(pres, preserves, posts, isPure) =>
       (if (isPure) specComment <+> showPure else emptyDoc) <>
       hcat(pres map (p => specComment <+> showPre(p) <> line)) <>
+      hcat(preserves map (p => specComment <+> showPreserves(p) <> line)) <>
       hcat(posts map (p => specComment <+> showPost(p) <> line))
 
     case PLoopSpec(inv) =>
@@ -114,7 +115,7 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
           rec,
           getActualParams(args),
           getActualResult(res),
-          PFunctionSpec(Vector.empty, Vector.empty),
+          PFunctionSpec(Vector.empty, Vector.empty, Vector.empty),
           body
         )
       )
@@ -126,7 +127,7 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
           id,
           getActualParams(args),
           getActualResult(res),
-          PFunctionSpec(Vector.empty, Vector.empty),
+          PFunctionSpec(Vector.empty, Vector.empty, Vector.empty),
           body
         )
       )

--- a/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
+++ b/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
@@ -230,7 +230,7 @@ class GhostErasureUnitTests extends AnyFunSuite with Matchers with Inside {
         PIdnDef("foo"),
         inArgs.map(_._1),
         PResult(Vector()),
-        PFunctionSpec(Vector(), Vector()),
+        PFunctionSpec(Vector(), Vector(), Vector()),
         Some(PBodyParameterInfo(inArgs.collect{ case (n: PNamedParameter, true) => PIdnUse(n.id.name) }), PBlock(Vector(body)))
       ))
     )

--- a/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
+++ b/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
@@ -125,13 +125,13 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
 
   test("Parser: spec only function") {
     frontend.parseMember("func foo() { b.bar() }", specOnly = true) should matchPattern {
-      case Vector(PFunctionDecl(PIdnDef("foo"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), false), None)) =>
+      case Vector(PFunctionDecl(PIdnDef("foo"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), Vector(), false), None)) =>
     }
   }
   
   test("Parser: spec only function with nested blocks") {
     frontend.parseMember("func foo() { if(true) { b.bar() } else { foo() } }", specOnly = true) should matchPattern {
-      case Vector(PFunctionDecl(PIdnDef("foo"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), false), None)) =>
+      case Vector(PFunctionDecl(PIdnDef("foo"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), Vector(), false), None)) =>
     }
   }
   
@@ -164,7 +164,7 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
     val modes: Set[Boolean] = Set(false, true)
     modes.foreach(specOnly => {
       frontend.parseMember("func bar()", specOnly) should matchPattern {
-        case Vector(PFunctionDecl(PIdnDef("bar"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), false), None)) =>
+        case Vector(PFunctionDecl(PIdnDef("bar"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), Vector(), false), None)) =>
       }
     })
   }

--- a/src/test/scala/viper/gobra/typing/ExprTypingUnitTests.scala
+++ b/src/test/scala/viper/gobra/typing/ExprTypingUnitTests.scala
@@ -3354,7 +3354,7 @@ class ExprTypingUnitTests extends AnyFunSuite with Matchers with Inside {
         PUnnamedReceiver(PMethodReceiveName(PNamedOperand(PIdnUse("self")))),
         inArgs.map(_._1),
         PResult(Vector()),
-        PFunctionSpec(Vector(), Vector(), true),
+        PFunctionSpec(Vector(), Vector(), Vector(), true),
         Some(PBodyParameterInfo(inArgs.collect{ case (n: PNamedParameter, true) => PIdnUse(n.id.name) }), PBlock(Vector(body)))
       ))
     )

--- a/src/test/scala/viper/gobra/typing/TypeTypingUnitTests.scala
+++ b/src/test/scala/viper/gobra/typing/TypeTypingUnitTests.scala
@@ -362,7 +362,7 @@ class TypeTypingUnitTests extends AnyFunSuite with Matchers with Inside {
         PUnnamedReceiver(PMethodReceiveName(PNamedOperand(PIdnUse("self")))),
         stubParams(ts),
         PResult(Vector()),
-        PFunctionSpec(Vector(), Vector(), true),
+        PFunctionSpec(Vector(), Vector(), Vector(), true),
         None
       ))
     )


### PR DESCRIPTION
Allows usage of the "preserves" keyword. Assertions stated after  preserves are treated as both preconditions and postconditions.