### PR TITLE
Fix permission errors when accessing elements of a nil map

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -254,7 +254,7 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
         }
         case PMapValues(exp) => exprType(exp) match {
           case t: MathMapT => SetT(t.elem)
-          case t: MapT => SetT(t.key)
+          case t: MapT => SetT(t.elem)
           case t => violation(s"expected a map, but got $t")
         }
       }

--- a/src/test/resources/regressions/features/maps/maps-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/maps-simple1.gobra
@@ -128,3 +128,11 @@ func test15() (res map[int]int) {
     m := map[int]int{C1: C2, C2: C1}
 	return m
 }
+
+func test16() {
+	var m map[int]int = nil
+	x := m[1]
+	assert x == 0
+	x, contained := m[2]
+	assert x == 0 && !contained
+}

--- a/src/test/resources/regressions/features/maps/maps-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/maps-simple1.gobra
@@ -9,6 +9,8 @@ const C2 = 2
 func test1() {
 	var m1 map[string]int
 	assert m1 == nil && len(m1) == 0 
+	assert domain(m1) == set[string]{}
+	assert range(m1) == set[int]{}
 	m1 = make(map[string]int)
 	assert m1 != nil && len(m1) == 0
 }


### PR DESCRIPTION
Currently, Gobra requires access to a map in order to perform a lookup. However, that rules out the possibility of performing a lookup in a nil map, which should always be possible (nil maps are treated as empty maps in Go). This PR addresses that and fixes a couple of other issues.