### PR TITLE
Add ReceiverNotInjectiveReason for injectivity errors

### DIFF
--- a/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
@@ -40,7 +40,7 @@ object DefaultErrorBackTranslator {
       case vprrea.AssertionFalse(CertainSource(info)) =>
         AssertionFalseError(info)
       case vprrea.AssertionFalse(CertainSynthesized(info)) =>
-        SynthesizedAssertionFalseError(info)
+        SynthesizedAssertionFalseReason(info)
       case vprrea.SeqIndexExceedsLength(CertainSource(node), CertainSource(index)) =>
         SeqIndexExceedsLengthError(node, index)
       case vprrea.SeqIndexNegative(CertainSource(node), CertainSource(index)) =>
@@ -61,12 +61,13 @@ object DefaultErrorBackTranslator {
       //      case vprrea.ReceiverNull(offendingNode) =>
       //      case vprrea.DivisionByZero(offendingNode) =>
       case vprrea.NegativePermission(CertainSource(info)) =>
-        NegativePermissionError(info)
+        NegativePermissionReason(info)
+      case vprrea.ReceiverNotInjective(CertainSource(info)) =>
+        ReceiverNotInjectiveReason(info)
       //      case vprrea.InvalidPermMultiplication(offendingNode) =>
       //      case vprrea.MagicWandChunkNotFound(offendingNode) =>
       //      case vprrea.NamedMagicWandChunkNotFound(offendingNode) =>
       //      case vprrea.MagicWandChunkOutdated(offendingNode) =>
-      //      case vprrea.ReceiverNotInjective(offendingNode) =>
       //      case vprrea.LabelledStateNotReached(offendingNode) =>
     }
 

--- a/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
@@ -62,12 +62,12 @@ object DefaultErrorBackTranslator {
       //      case vprrea.DivisionByZero(offendingNode) =>
       case vprrea.NegativePermission(CertainSource(info)) =>
         NegativePermissionReason(info)
-      case vprrea.ReceiverNotInjective(CertainSource(info)) =>
-        ReceiverNotInjectiveReason(info)
       //      case vprrea.InvalidPermMultiplication(offendingNode) =>
       //      case vprrea.MagicWandChunkNotFound(offendingNode) =>
       //      case vprrea.NamedMagicWandChunkNotFound(offendingNode) =>
       //      case vprrea.MagicWandChunkOutdated(offendingNode) =>
+      case vprrea.ReceiverNotInjective(CertainSource(info)) =>
+        ReceiverNotInjectiveReason(info)
       //      case vprrea.LabelledStateNotReached(offendingNode) =>
     }
 

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -359,17 +359,22 @@ case class ComparisonOnIncomparableInterfaces(node: Source.Verifier.Info) extend
   override def message: String = s"Both operands of ${node.origin.tag.trim} might not have comparable values."
 }
 
-case class SynthesizedAssertionFalseError(info: Source.Verifier.Info) extends VerificationErrorReason {
+case class SynthesizedAssertionFalseReason(info: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "assertion_error"
   override def message: String = info.comment.reduce[String] { case (l, r) => s"$l; $r" }
 }
 
-case class NegativePermissionError(info: Source.Verifier.Info) extends VerificationErrorReason {
+case class NegativePermissionReason(info: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "negative_permission_error"
   override def message: String = s"Expression ${info.origin.tag.trim} might be negative."
 }
 
-case class GoCallPreconditionError(node: Source.Verifier.Info) extends VerificationErrorReason {
+case class ReceiverNotInjectiveReason(info: Source.Verifier.Info) extends VerificationErrorReason {
+  override def id: String = "receiver_not_injective"
+  override def message: String = s"Receiver ${info.origin.tag.trim} might not be injective."
+}
+
+case class GoCallPreconditionReason(node: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "go_call_precondition_error"
   override def message: String = s"${node.origin.tag.trim} might not satisfy the precondition of the callee."
 }

--- a/src/main/scala/viper/gobra/translator/implementations/translator/StatementsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/StatementsImpl.scala
@@ -7,7 +7,7 @@
 package viper.gobra.translator.implementations.translator
 
 import viper.gobra.ast.{internal => in}
-import viper.gobra.reporting.{GoCallPreconditionError, PreconditionError, Source}
+import viper.gobra.reporting.{GoCallPreconditionReason, PreconditionError, Source}
 import viper.gobra.translator.Names
 import viper.gobra.translator.interfaces.translator.Statements
 import viper.gobra.translator.interfaces.{Collector, Context}
@@ -63,7 +63,7 @@ class StatementsImpl extends Statements {
         and = vu.bigAnd(preCondInstance)(pos, info, errT)
         exhale = vpr.Exhale(and)(pos, info, errT)
         _ <- errorT {
-          case err.ExhaleFailed(Source(info), _, _) => PreconditionError(info).dueTo(GoCallPreconditionError(info))
+          case err.ExhaleFailed(Source(info), _, _) => PreconditionError(info).dueTo(GoCallPreconditionReason(info))
         }
       } yield exhale
     }

--- a/src/test/resources/regressions/features/slices/slice-index-fail2.gobra
+++ b/src/test/resources/regressions/features/slices/slice-index-fail2.gobra
@@ -8,3 +8,12 @@ func foo(s []int) {
   //:: ExpectedOutput(assignment_error:permission_error)
   n := s[0]
 }
+
+requires forall i int :: 0 <= i && i < len(s) ==> acc(&s[i]) && acc(s[i])
+func bar(s []*int)
+
+func barRun() {
+  s := make([]*int, 2)
+  //:: ExpectedOutput(precondition_error:receiver_not_injective)
+  bar(s)
+}


### PR DESCRIPTION
Currently, "Receiver Not Injective Errors" cause Gobra to provide an unintelligible error message like
```
[info] Encountered an unexpected Viper reason. This is a bug. The following information is for debugging purposes:
[info]   Receiver of (ShArrayloc((sarray((ShStructget13of14(s_slayers_V10_CN17): Ref).val$_Slice_Ref): ShArray[Ref]), sadd((soffset((ShStructget13of14(s_slayers_V10_CN17): Ref).val$_Slice_Ref): Int), i_slayers_V17)): Ref).val$_Int [scion.gobra@423.65--423.71]  might not be injective.
[info]     error is ReceiverNotInjective
[info]     error offending node = (ShArrayloc((sarray((ShStructget13of14(s_slayers_V10_CN17): Ref).val$_Slice_Ref): ShArray[Ref]), sadd((soffset((ShStructget13of14(s_slayers_V10_CN17): Ref).val$_Slice_Ref): Int), i_slayers_V17)): Ref).val$_Int
[info]     error offending node src = Some(Info(raw[i],raw_slayers_V16[i_slayers_V17],Origin(scion.gobra@423.65--423.71,raw[i]),Vector()))
```

This PR fixes Gobra to provide better feedback.