### PR TITLE
Improve specification of the net stub

### DIFF
--- a/src/main/resources/stubs/net/iprawsock.gobra
+++ b/src/main/resources/stubs/net/iprawsock.gobra
@@ -1,0 +1,261 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package net
+
+import (
+//  TODO(Gobra): imported packages not supported 
+//	"context"
+//	"syscall"
+)
+
+// BUG(mikio): On every POSIX platform, reads from the "ip4" network
+// using the ReadFrom or ReadFromIP method might not return a complete
+// IPv4 packet, including its header, even if there is space
+// available. This can occur even in cases where Read or ReadMsgIP
+// could return a complete packet. For this reason, it is recommended
+// that you do not use these methods if it is important to receive a
+// full packet.
+//
+// The Go 1 compatibility guidelines make it impossible for us to
+// change the behavior of these methods; use Read or ReadMsgIP
+// instead.
+
+// BUG(mikio): On JS and Plan 9, methods and functions related
+// to IPConn are not implemented.
+
+// BUG(mikio): On Windows, the File method of IPConn is not
+// implemented.
+
+// IPAddr represents the address of an IP end point.
+type IPAddr struct {
+// TODO(Gobra): cannot have fields and types with the same identifier
+//	IP   IP
+	Zone string // IPv6 scoped addressing zone
+}
+
+pred (a *IPAddr) mem() {
+    acc(a)
+}
+
+(*IPAddr) implements Addr {
+	(e *IPAddr) Network(ghost p perm) string {
+		return e.Network(p)
+	}
+
+	(e *IPAddr) String(ghost p perm) string {
+		return e.String(p)
+	}
+}
+
+// Network returns the address's network name, "ip".
+ensures res == "ip"
+func (a *IPAddr) Network(ghost p perm) (res string) { return "ip" }
+
+requires p > 0
+requires acc(a.mem(), p)
+ensures acc(a.mem(), p)
+func (a *IPAddr) String(ghost p perm) string // {
+//	if a == nil {
+//		return "<nil>"
+//	}
+//	ip := ipEmptyString(a.IP)
+//	if a.Zone != "" {
+//		return ip + "%" + a.Zone
+//	}
+//	return ip
+//}
+
+//func (a *IPAddr) isWildcard() bool {
+//	if a == nil || a.IP == nil {
+//		return true
+//	}
+//	return a.IP.IsUnspecified()
+//}
+
+//func (a *IPAddr) opAddr() Addr {
+//	if a == nil {
+//		return nil
+//	}
+//	return a
+//}
+
+// ResolveIPAddr returns an address of IP end point.
+//
+// The network must be an IP network name.
+//func ResolveIPAddr(network, address string) (*IPAddr, error) {
+//	if network == "" { // a hint wildcard for Go 1.0 undocumented behavior
+//		network = "ip"
+//	}
+//	afnet, _, err := parseNetwork(context.Background(), network, false)
+//	if err != nil {
+//		return nil, err
+//	}
+//	switch afnet {
+//	case "ip", "ip4", "ip6":
+//	default:
+//		return nil, UnknownNetworkError(network)
+//	}
+//	addrs, err := DefaultResolver.internetAddrList(context.Background(), afnet, address)
+//	if err != nil {
+//		return nil, err
+//	}
+//	return addrs.forResolve(network, address).(*IPAddr), nil
+//}
+
+// IPConn is the implementation of the Conn and PacketConn interfaces
+// for IP network connections.
+type IPConn struct {
+// TODO(Gobra): embedded fields not supported
+//	conn
+}
+
+pred (i *IPConn) mem() {
+    acc(i)
+}
+
+// SyscallConn returns a raw network connection.
+// This implements the syscall.Conn interface.
+//func (c *IPConn) SyscallConn() (syscall.RawConn, error) {
+//	if !c.ok() {
+//		return nil, syscall.EINVAL
+//	}
+//	return newRawConn(c.fd)
+//}
+
+// ReadFromIP acts like ReadFrom but returns an IPAddr.
+requires c.mem()
+requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+ensures c.mem()
+ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+ensures 0 <= retInt && retInt <= len(b)
+func (c *IPConn) ReadFromIP(b []byte) (retInt int, *IPAddr, error) // {
+//	if !c.ok() {
+//		return 0, nil, syscall.EINVAL
+//	}
+//	n, addr, err := c.readFrom(b)
+//	if err != nil {
+//		err = &OpError{Op: "read", Net: c.fd.net, Source: c.fd.laddr, Addr: c.fd.raddr, Err: err}
+//	}
+//	return n, addr, err
+//}
+
+// ReadFrom implements the PacketConn ReadFrom method.
+requires c.mem()
+requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+ensures c.mem()
+ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+ensures 0 <= retInt && retInt <= len(b)
+func (c *IPConn) ReadFrom(b []byte) (retInt int, Addr, error) // {
+//	if !c.ok() {
+//		return 0, nil, syscall.EINVAL
+//	}
+//	n, addr, err := c.readFrom(b)
+//	if err != nil {
+//		err = &OpError{Op: "read", Net: c.fd.net, Source: c.fd.laddr, Addr: c.fd.raddr, Err: err}
+//	}
+//	if addr == nil {
+//		return n, nil, err
+//	}
+//	return n, addr, err
+//}
+
+// ReadMsgIP reads a message from c, copying the payload into b and
+// the associated out-of-band data into oob. It returns the number of
+// bytes copied into b, the number of bytes copied into oob, the flags
+// that were set on the message and the source address of the message.
+//func (c *IPConn) ReadMsgIP(b, oob []byte) (n, oobn, flags int, addr *IPAddr, err error) {
+//	if !c.ok() {
+//		return 0, 0, 0, nil, syscall.EINVAL
+//	}
+//	n, oobn, flags, addr, err = c.readMsg(b, oob)
+//	if err != nil {
+//		err = &OpError{Op: "read", Net: c.fd.net, Source: c.fd.laddr, Addr: c.fd.raddr, Err: err}
+//	}
+//	return
+//}
+
+// WriteToIP acts like WriteTo but takes an IPAddr.
+requires p > 0
+requires c.mem() && acc(addr.mem(), p)
+requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+ensures c.mem() && acc(addr.mem(), p)
+ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+func (c *IPConn) WriteToIP(b []byte, addr *IPAddr, ghost p perm) (int, error) // {
+//	if !c.ok() {
+//		return 0, syscall.EINVAL
+//	}
+//	n, err := c.writeTo(b, addr)
+//	if err != nil {
+//		err = &OpError{Op: "write", Net: c.fd.net, Source: c.fd.laddr, Addr: addr.opAddr(), Err: err}
+//	}
+//	return n, err
+//}
+
+// WriteTo implements the PacketConn WriteTo method.
+requires p > 0
+requires c.mem() && acc(addr.mem(), p)
+requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+ensures c.mem() && acc(addr.mem(), p)
+ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+func (c *IPConn) WriteTo(b []byte, addr Addr, ghost p perm) (int, error) // {
+//	if !c.ok() {
+//		return 0, syscall.EINVAL
+//	}
+//	a, ok := addr.(*IPAddr)
+//	if !ok {
+//		return 0, &OpError{Op: "write", Net: c.fd.net, Source: c.fd.laddr, Addr: addr, Err: syscall.EINVAL}
+//	}
+//	n, err := c.writeTo(b, a)
+//	if err != nil {
+//		err = &OpError{Op: "write", Net: c.fd.net, Source: c.fd.laddr, Addr: a.opAddr(), Err: err}
+//	}
+//	return n, err
+//}
+
+// WriteMsgIP writes a message to addr via c, copying the payload from
+// b and the associated out-of-band data from oob. It returns the
+// number of payload and out-of-band bytes written.
+//func (c *IPConn) WriteMsgIP(b, oob []byte, addr *IPAddr) (n, oobn int, err error) {
+//	if !c.ok() {
+//		return 0, 0, syscall.EINVAL
+//	}
+//	n, oobn, err = c.writeMsg(b, oob, addr)
+//	if err != nil {
+//		err = &OpError{Op: "write", Net: c.fd.net, Source: c.fd.laddr, Addr: addr.opAddr(), Err: err}
+//	}
+//	return
+//}
+
+// func newIPConn(fd *netFD) *IPConn { return &IPConn{conn{fd}} }
+
+// DialIP acts like Dial for IP networks.
+//
+// The network must be an IP network name; see func Dial for details.
+//func DialIP(network string, laddr, raddr *IPAddr) (*IPConn, error) {
+//	if raddr == nil {
+//		return nil, &OpError{Op: "dial", Net: network, Source: laddr.opAddr(), Addr: nil, Err: errMissingAddress}
+//	}
+//	sd := &sysDialer{network: network, address: raddr.String()}
+//	c, err := sd.dialIP(context.Background(), laddr, raddr)
+//	if err != nil {
+//		return nil, &OpError{Op: "dial", Net: network, Source: laddr.opAddr(), Addr: raddr.opAddr(), Err: err}
+//	}
+//	return c, nil
+//}
+
+// ListenIP acts like ListenPacket for IP networks.
+//
+// The network must be an IP network name; see func Dial for details.
+//func ListenIP(network string, laddr *IPAddr) (*IPConn, error) {
+//	if laddr == nil {
+//		laddr = &IPAddr{}
+//	}
+//	sl := &sysListener{network: network, address: laddr.String()}
+//	c, err := sl.listenIP(context.Background(), laddr)
+//	if err != nil {
+//		return nil, &OpError{Op: "listen", Net: network, Source: nil, Addr: laddr.opAddr(), Err: err}
+//	}
+//	return c, nil
+//}

--- a/src/main/resources/stubs/net/iprawsock.gobra
+++ b/src/main/resources/stubs/net/iprawsock.gobra
@@ -1,6 +1,9 @@
-// Copyright 2010 The Go Authors. All rights reserved.
+// Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in https://golang.org/LICENSE
+
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/net/iprawsock.go
 
 package net
 

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -11,6 +11,7 @@ import "time"
 
 // Addr represents a network end point address.
 type Addr interface {
+	pred AddrMem()
 	Network() string
 	String() string
 }
@@ -18,72 +19,115 @@ type Addr interface {
 // Conn is a generic stream-oriented network connection.
 // Multiple goroutines may invoke methods on a Conn simultaneously.
 type Conn interface {
+	pred mem()
+
 	// Read reads data from the connection.
+	requires mem()
 	requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+	ensures mem()
 	ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
 	Read(b []byte) (n int, err error)
 
 	// Write writes data to the connection.
 	requires p > 0
+	requires mem()
 	requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+	ensures mem()
 	ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
 	Write(b []byte, ghost p perm) (n int, err error)
 
 	// Close closes the connection.
 	// Any blocked Read or Write operations will be unblocked and return errors.
+	requires mem()
+	ensures mem()
 	Close() error
 
 	// LocalAddr returns the local network address.
-	LocalAddr() Addr
+	requires p > 0
+	requires acc(mem(), p)
+	ensures acc(mem(), p)
+	LocalAddr(ghost p perm) Addr
 
 	// RemoteAddr returns the remote network address.
-	RemoteAddr() Addr
+	requires p > 0
+	requires acc(mem(), p)
+	ensures acc(mem(), p)
+	RemoteAddr(ghost p perm) Addr
 
 	// SetDeadline sets the read and write deadlines associated
 	// with the connection.
+	requires mem()
+	ensures mem()
 	SetDeadline(t time.Time) error
 
 	// SetReadDeadline sets the deadline for future Read calls
 	// and any currently-blocked Read call.
+	requires mem()
+	ensures mem()
 	SetReadDeadline(t time.Time) error
 
 	// SetWriteDeadline sets the deadline for future Write calls
 	// and any currently-blocked Write call.
+	requires mem()
+	ensures mem()
 	SetWriteDeadline(t time.Time) error
 }
 
 // PacketConn is a generic packet-oriented network connection.
 // Multiple goroutines may invoke methods on a PacketConn simultaneously.
 type PacketConn interface {
+	pred mem()
+
+	requires mem()
 	requires forall i int :: 0 <= i && i < len(p) ==> acc(&p[i])
+	ensures mem()
 	ensures forall i int :: 0 <= i && i < len(p) ==> acc(&p[i])
 	ensures 0 <= n && n <= len(p)
 	ReadFrom(p []byte) (n int, addr Addr, err error)
 
 	requires permission > 0
+	requires mem()
 	requires forall i int :: 0 <= i && i < len(p) ==> acc(&p[i], permission)
+	ensures mem()
 	ensures forall i int :: 0 <= i && i < len(p) ==> acc(&p[i], permission)
 	WriteTo(p []byte, addr Addr, ghost permission perm) (n int, err error)
 
+	requires mem()
+	ensures mem()
 	Close() error
 
-	LocalAddr() Addr
+	requires p > 0
+	requires acc(mem(), p)
+	ensures acc(mem(), p)
+	LocalAddr(ghost p perm) Addr
 
+	requires mem()
+	ensures mem()
 	SetDeadline(t time.Time) error
 
+	requires mem()
+	ensures mem()
 	SetReadDeadline(t time.Time) error
 
+	requires mem()
+	ensures mem()
 	SetWriteDeadline(t time.Time) error
 }
 
 // A Listener is a generic network listener for stream-oriented protocols.
 // Multiple goroutines may invoke methods on a Listener simultaneously.
 type Listener interface {
+	pred mem()
+
 	// Accept waits for and returns the next connection to the listener.
+	requires mem()
+	ensures mem()
 	Accept() (Conn, error)
 
 	// Close closes the listener.
 	// Any blocked Accept operations will be unblocked and return errors.
+	requires mem()
+	ensures mem()
 	Close() error
 
 	// Addr returns the listener's network address.
@@ -92,9 +136,19 @@ type Listener interface {
 
 // An Error represents a network error.
 type Error interface {
+	pred mem()
+
 	// error // (joao) support for embeddings is buggy
-	Timeout() bool   // Is the error a timeout?
-	Temporary() bool // Is the error temporary?
+
+	requires p > 0
+	requires acc(mem(), p)
+	ensures acc(mem(), p)
+	Timeout(ghost p perm) bool   // Is the error a timeout?
+
+	requires p > 0
+	requires acc(mem(), p)
+	ensures acc(mem(), p)
+	Temporary(ghost p perm) bool // Is the error temporary?
 }
 
 // Various errors contained in OpError.
@@ -115,16 +169,20 @@ type OpError struct {
 	Err error
 }
 
-requires acc(&e.Err, _)
-pure func (e *OpError) Unwrap() error { return e.Err }
+pred (op *OpError) mem() {
+	acc(op)
+}
 
-requires acc(&e.Err)
-ensures acc(&e.Err)
+requires acc(e.mem(), _)
+pure func (e *OpError) Unwrap() error { return unfolding acc(e.mem(), _) in e.Err }
+
+requires acc(e.mem())
+ensures acc(e.mem())
 func (e *OpError) Error() string 
 
 requires p > 0
-requires acc(e, p)
-ensures acc(e, p)
+requires acc(e.mem(), p)
+ensures acc(e.mem(), p)
 func (e *OpError) Timeout(ghost p perm) bool /*{
 	if ne, ok := e.Err.(*os.SyscallError); ok {
 		t, ok := ne.Err.(timeout)
@@ -135,8 +193,8 @@ func (e *OpError) Timeout(ghost p perm) bool /*{
 }*/
 
 requires p > 0
-requires acc(e, p)
-ensures acc(e, p)
+requires acc(e.mem(), p)
+ensures acc(e.mem(), p)
 func (e *OpError) Temporary(ghost p perm) bool /*{
 	if e.Op == "accept" && isConnError(e.Err) {
 		return true
@@ -149,6 +207,16 @@ func (e *OpError) Temporary(ghost p perm) bool /*{
 	t, ok := e.Err.(temporary)
 	return ok && t.Temporary()
 }*/
+
+(*OpError) implements Error {
+	(e *OpError) Timeout(ghost p perm) bool {
+		return e.Timeout(p)
+	}
+
+	(e *OpError) Temporary(ghost p perm) bool {
+		return e.Temporary(p)
+	}
+}
 
 // A ParseError is the error type of literal network address parsers.
 type ParseError struct {
@@ -165,8 +233,15 @@ type AddrError struct {
 	Addr string
 }
 
-/*
-func (e *AddrError) Error() string {
+pred (e *AddrError) mem() { acc(e) }
+
+requires p > 0
+requires e != nil ==> acc(e, p)
+ensures e == nil ==> ret == "<nil>"
+ensures e != nil ==> acc(e, p)
+ensures (e != nil && e.Addr != "") ==> ret == "address " + e.Addr + ": " + e.Err
+ensures (e != nil && e.Addr == "") ==> ret == e.Err
+func (e *AddrError) Error(ghost p perm) (ret string) {
 	if e == nil {
 		return "<nil>"
 	}
@@ -175,12 +250,29 @@ func (e *AddrError) Error() string {
 		s = "address " + e.Addr + ": " + s
 	}
 	return s
-}*/
+}
 
+// TODO: if the method is annotated with pure, then the implementation proof fails
+// because the "pure" annotation of the interface and implementation do not match
+requires acc(e.mem(), p)
+ensures acc(e.mem(), p)
 ensures !res
-pure func (e *AddrError) Timeout() (res bool)   { return false }
+/* pure */ func (e *AddrError) Timeout(ghost p perm) (res bool)   { return false }
+
+requires acc(e.mem(), p)
+ensures acc(e.mem(), p)
 ensures !res
-pure func (e *AddrError) Temporary() (res bool) { return false }
+/* pure */ func (e *AddrError) Temporary(ghost p perm) (res bool) { return false }
+
+(*AddrError) implements Error {
+	(e *AddrError) Timeout(ghost p perm) bool {
+		return e.Timeout(p)
+	}
+
+	(e *AddrError) Temporary(ghost p perm) bool {
+		return e.Temporary(p)
+	}
+}
 
 type UnknownNetworkError string
 
@@ -206,6 +298,8 @@ type DNSError struct {
 	IsNotFound  bool
 }
 
+pred (e *DNSError) mem() { acc(e) }
+
 requires p > 0
 requires e != nil ==> acc(e, p)
 ensures e != nil ==> acc(e, p)
@@ -222,14 +316,28 @@ func (e *DNSError) Error(ghost p perm) string {
 }
 
 // Timeout reports whether the DNS lookup is known to have timed out.
-requires acc(&e.IsTimeout, _)
-ensures res == e.IsTimeout
-pure func (e *DNSError) Timeout() (res bool) { return e.IsTimeout }
+requires p > 0
+requires acc(e.mem(), p)
+ensures acc(e.mem(), p)
+ensures unfolding acc(e.mem(), _) in res == e.IsTimeout
+/* pure */ func (e *DNSError) Timeout(ghost p perm) (res bool) { return unfolding acc(e.mem(), _) in e.IsTimeout }
 
 // Temporary reports whether the DNS error is known to be temporary.
-requires acc(&e.IsTimeout, _) && acc(&e.IsTemporary, _)
-ensures res == e.IsTimeout || e.IsTemporary
-pure func (e *DNSError) Temporary() (res bool) { return e.IsTimeout || e.IsTemporary }
+requires p > 0
+requires acc(e.mem(), p)
+ensures acc(e.mem(), p)
+ensures unfolding acc(e.mem(), _) in res == e.IsTimeout || e.IsTemporary
+/* pure */ func (e *DNSError) Temporary(ghost p perm) (res bool) { return unfolding acc(e.mem(), _) in e.IsTimeout || e.IsTemporary }
+
+(*DNSError) implements Error {
+	(e *DNSError) Timeout(ghost p perm) bool {
+		return e.Timeout(p)
+	}
+
+	(e *DNSError) Temporary(ghost p perm) bool {
+		return e.Temporary(p)
+	}
+}
 
 // Buffers contains zero or more runs of bytes to write.
 type Buffers [][]byte

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -12,8 +12,16 @@ import "time"
 // Addr represents a network end point address.
 type Addr interface {
 	pred mem()
-	Network() string
-	String() string
+
+	requires p > 0
+	requires acc(mem(), p)
+	ensures acc(mem(), p)
+	Network(ghost p perm) string
+
+	requires p > 0
+	requires acc(mem(), p)
+	ensures acc(mem(), p)
+	String(ghost p perm) string
 }
 
 // Conn is a generic stream-oriented network connection.

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -11,7 +11,7 @@ import "time"
 
 // Addr represents a network end point address.
 type Addr interface {
-	pred AddrMem()
+	pred mem()
 	Network() string
 	String() string
 }

--- a/src/main/resources/stubs/net/udpsock.gobra
+++ b/src/main/resources/stubs/net/udpsock.gobra
@@ -1,0 +1,289 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in https://golang.org/LICENSE
+
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/net/net.go
+
+package net
+
+import (
+// TODO(Gobra): imported packages not supported 
+//	"context"
+//	"internal/itoa"
+//	"syscall"
+)
+
+// BUG(mikio): On Plan 9, the ReadMsgUDP and
+// WriteMsgUDP methods of UDPConn are not implemented.
+
+// BUG(mikio): On Windows, the File method of UDPConn is not
+// implemented.
+
+// BUG(mikio): On JS, methods and functions related to UDPConn are not
+// implemented.
+
+// UDPAddr represents the address of a UDP end point.
+type UDPAddr struct {
+// TODO(Gobra): cannot have fields and types with the same identifier
+//	IP   IP
+	Port int
+	Zone string // IPv6 scoped addressing zone
+}
+
+pred (a *UDPAddr) mem() {
+    acc(a)
+}
+
+(*UDPAddr) implements Addr {
+	(e *UDPAddr) Network(ghost p perm) string {
+		return e.Network(p)
+	}
+
+	(e *UDPAddr) String(ghost p perm) string {
+		return e.String(p)
+	}
+}
+
+// Network returns the address's network name, "udp".
+ensures res == "udp"
+func (a *UDPAddr) Network(ghost p perm) (res string) { return "udp" }
+
+requires p > 0
+requires acc(a.mem(), p)
+ensures acc(a.mem(), p)
+func (a *UDPAddr) String(ghost p perm) string // {
+//	if a == nil {
+//		return "<nil>"
+//	}
+//	ip := ipEmptyString(a.IP)
+//	if a.Zone != "" {
+//		return JoinHostPort(ip+"%"+a.Zone, itoa.Itoa(a.Port))
+//	}
+//	return JoinHostPort(ip, itoa.Itoa(a.Port))
+//}
+
+//func (a *UDPAddr) isWildcard() bool {
+//	if a == nil || a.IP == nil {
+//		return true
+//	}
+//	return a.IP.IsUnspecified()
+//}
+
+//func (a *UDPAddr) opAddr() Addr {
+//	if a == nil {
+//		return nil
+//	}
+//	return a
+//}
+
+// ResolveUDPAddr returns an address of UDP end point.
+//
+// The network must be a UDP network name.
+//func ResolveUDPAddr(network, address string) (*UDPAddr, error) {
+//	switch network {
+//	case "udp", "udp4", "udp6":
+//	case "": // a hint wildcard for Go 1.0 undocumented behavior
+//		network = "udp"
+//	default:
+//		return nil, UnknownNetworkError(network)
+//	}
+//	addrs, err := DefaultResolver.internetAddrList(context.Background(), network, address)
+//	if err != nil {
+//		return nil, err
+//	}
+//	return addrs.forResolve(network, address).(*UDPAddr), nil
+//}
+
+// UDPConn is the implementation of the Conn and PacketConn interfaces
+// for UDP network connections.
+type UDPConn struct {
+// TODO(Gobra): embedded fields not supported
+//	conn
+}
+
+pred (u *UDPConn) mem() {
+    acc(u)
+}
+
+// SyscallConn returns a raw network connection.
+// This implements the syscall.Conn interface.
+//func (c *UDPConn) SyscallConn() (syscall.RawConn, error) {
+//	if !c.ok() {
+//		return nil, syscall.EINVAL
+//	}
+//	return newRawConn(c.fd)
+//}
+
+// ReadFromUDP acts like ReadFrom but returns a UDPAddr.
+requires c.mem()
+requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+ensures c.mem()
+ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+ensures 0 <= n && n <= len(b)
+func (c *UDPConn) ReadFromUDP(b []byte) (n int, addr *UDPAddr, err error) // {
+	// This function is designed to allow the caller to control the lifetime
+	// of the returned *UDPAddr and thereby prevent an allocation.
+	// See https://blog.filippo.io/efficient-go-apis-with-the-inliner/.
+	// The real work is done by readFromUDP, below.
+//	return c.readFromUDP(b, &UDPAddr{})
+//}
+
+// readFromUDP implements ReadFromUDP.
+requires c.mem()
+requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+requires addr.mem()
+ensures c.mem()
+ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+ensures 0 <= retInt && retInt <= len(b)
+func (c *UDPConn) readFromUDP(b []byte, addr *UDPAddr) (retInt int, *UDPAddr, error) // {
+//	if !c.ok() {
+//		return 0, nil, syscall.EINVAL
+//	}
+//	n, addr, err := c.readFrom(b, addr)
+//	if err != nil {
+//		err = &OpError{Op: "read", Net: c.fd.net, Source: c.fd.laddr, Addr: c.fd.raddr, Err: err}
+//	}
+//	return n, addr, err
+//}
+
+// ReadFrom implements the PacketConn ReadFrom method.
+requires c.mem()
+requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+ensures c.mem()
+ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i])
+ensures 0 <= retInt && retInt <= len(b)
+func (c *UDPConn) ReadFrom(b []byte) (retInt int, Addr, error) // {
+//	n, addr, err := c.readFromUDP(b, &UDPAddr{})
+//	if addr == nil {
+//		// Return Addr(nil), not Addr(*UDPConn(nil)).
+//		return n, nil, err
+//	}
+//	return n, addr, err
+//}
+
+// ReadMsgUDP reads a message from c, copying the payload into b and
+// the associated out-of-band data into oob. It returns the number of
+// bytes copied into b, the number of bytes copied into oob, the flags
+// that were set on the message and the source address of the message.
+//func (c *UDPConn) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *UDPAddr, err error) {
+//	if !c.ok() {
+//		return 0, 0, 0, nil, syscall.EINVAL
+//	}
+//	n, oobn, flags, addr, err = c.readMsg(b, oob)
+//	if err != nil {
+//		err = &OpError{Op: "read", Net: c.fd.net, Source: c.fd.laddr, Addr: c.fd.raddr, Err: err}
+//	}
+//	return
+//}
+
+// WriteToUDP acts like WriteTo but takes a UDPAddr.
+requires p > 0
+requires c.mem() && acc(addr.mem(), p)
+requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+ensures c.mem() && acc(addr.mem(), p)
+ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+func (c *UDPConn) WriteToUDP(b []byte, addr *UDPAddr, ghost p perm) (int, error) // {
+//	if !c.ok() {
+//		return 0, syscall.EINVAL
+//	}
+//	n, err := c.writeTo(b, addr)
+//	if err != nil {
+//		err = &OpError{Op: "write", Net: c.fd.net, Source: c.fd.laddr, Addr: addr.opAddr(), Err: err}
+//	}
+//	return n, err
+//}
+
+// WriteTo implements the PacketConn WriteTo method.
+requires p > 0
+requires c.mem() && acc(addr.mem(), p)
+requires forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+ensures c.mem() && acc(addr.mem(), p)
+ensures forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], p)
+func (c *UDPConn) WriteTo(b []byte, addr Addr, ghost p perm) (int, error) // {
+//	if !c.ok() {
+//		return 0, syscall.EINVAL
+//	}
+//	a, ok := addr.(*UDPAddr)
+//	if !ok {
+//		return 0, &OpError{Op: "write", Net: c.fd.net, Source: c.fd.laddr, Addr: addr, Err: syscall.EINVAL}
+//	}
+//	n, err := c.writeTo(b, a)
+//	if err != nil {
+//		err = &OpError{Op: "write", Net: c.fd.net, Source: c.fd.laddr, Addr: a.opAddr(), Err: err}
+//	}
+//	return n, err
+//}
+
+// WriteMsgUDP writes a message to addr via c if c isn't connected, or
+// to c's remote address if c is connected (in which case addr must be
+// nil). The payload is copied from b and the associated out-of-band
+// data is copied from oob. It returns the number of payload and
+// out-of-band bytes written.
+//func (c *UDPConn) WriteMsgUDP(b, oob []byte, addr *UDPAddr) (n, oobn int, err error) {
+//	if !c.ok() {
+//		return 0, 0, syscall.EINVAL
+//	}
+//	n, oobn, err = c.writeMsg(b, oob, addr)
+//	if err != nil {
+//		err = &OpError{Op: "write", Net: c.fd.net, Source: c.fd.laddr, Addr: addr.opAddr(), Err: err}
+//	}
+//	return
+//}
+
+// func newUDPConn(fd *netFD) *UDPConn { return &UDPConn{conn{fd}} }
+
+// DialUDP acts like Dial for UDP networks.
+//func DialUDP(network string, laddr, raddr *UDPAddr) (*UDPConn, error) {
+//	switch network {
+//	case "udp", "udp4", "udp6":
+//	default:
+//		return nil, &OpError{Op: "dial", Net: network, Source: laddr.opAddr(), Addr: raddr.opAddr(), Err: UnknownNetworkError(network)}
+//	}
+//	if raddr == nil {
+//		return nil, &OpError{Op: "dial", Net: network, Source: laddr.opAddr(), Addr: nil, Err: errMissingAddress}
+//	}
+//	sd := &sysDialer{network: network, address: raddr.String()}
+//	c, err := sd.dialUDP(context.Background(), laddr, raddr)
+//	if err != nil {
+//		return nil, &OpError{Op: "dial", Net: network, Source: laddr.opAddr(), Addr: raddr.opAddr(), Err: err}
+//	}
+//	return c, nil
+//}
+
+// ListenUDP acts like ListenPacket for UDP networks.
+//func ListenUDP(network string, laddr *UDPAddr) (*UDPConn, error) {
+//	switch network {
+//	case "udp", "udp4", "udp6":
+//	default:
+//		return nil, &OpError{Op: "listen", Net: network, Source: nil, Addr: laddr.opAddr(), Err: UnknownNetworkError(network)}
+//	}
+//	if laddr == nil {
+//		laddr = &UDPAddr{}
+//	}
+//	sl := &sysListener{network: network, address: laddr.String()}
+//	c, err := sl.listenUDP(context.Background(), laddr)
+//	if err != nil {
+//		return nil, &OpError{Op: "listen", Net: network, Source: nil, Addr: laddr.opAddr(), Err: err}
+//	}
+//	return c, nil
+//}
+
+// ListenMulticastUDP acts like ListenPacket for UDP networks but
+// takes a group address on a specific network interface.
+//func ListenMulticastUDP(network string, ifi *Interface, gaddr *UDPAddr) (*UDPConn, error) {
+//	switch network {
+//	case "udp", "udp4", "udp6":
+//	default:
+//		return nil, &OpError{Op: "listen", Net: network, Source: nil, Addr: gaddr.opAddr(), Err: UnknownNetworkError(network)}
+//	}
+//	if gaddr == nil || gaddr.IP == nil {
+//		return nil, &OpError{Op: "listen", Net: network, Source: nil, Addr: gaddr.opAddr(), Err: errMissingAddress}
+//	}
+//	sl := &sysListener{network: network, address: gaddr.String()}
+//	c, err := sl.listenMulticastUDP(context.Background(), ifi, gaddr)
+//	if err != nil {
+//		return nil, &OpError{Op: "listen", Net: network, Source: nil, Addr: gaddr.opAddr(), Err: err}
+//	}
+//	return c, nil
+//}

--- a/src/main/resources/stubs/net/udpsock.gobra
+++ b/src/main/resources/stubs/net/udpsock.gobra
@@ -3,7 +3,7 @@
 // license that can be found in https://golang.org/LICENSE
 
 // Signatures for the public declarations in file
-// https://github.com/golang/go/blob/master/src/net/net.go
+// https://github.com/golang/go/blob/master/src/net/udpsock.go
 
 package net
 

--- a/src/test/resources/regressions/features/stubs/stubs0.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs0.gobra
@@ -27,7 +27,7 @@ func testNet1(ip net.IP) {
 }
 
 // 2: file net/net.gobra
-requires acc(opErr)
+requires opErr.mem()
 func testNet2(opErr *net.OpError) error {
 	return opErr.Unwrap()
 }

--- a/src/test/resources/regressions/features/stubs/stubs1.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs1.gobra
@@ -7,15 +7,19 @@ import "net"
 
 func ipLen(ip net.IP) int
 
+requires conn.mem()
 func closePacketConn(conn net.PacketConn) error {
     return conn.Close()
 }
 
+requires ae.mem()
 func addrErrorTimeout(ae * net.AddrError) bool {
-    assert !ae.Timeout()
-    return ae.Timeout()
+    b := !ae.Timeout(1/2)
+    assert b
+    return ae.Timeout(1/2)
 }
 
+requires ae.mem()
 func addrErrorTimeoutInterface(ae net.Error) bool {
-    return ae.Timeout()
+    return ae.Timeout(1/2)
 }


### PR DESCRIPTION
This PR improves introduces a `mem()` predicate  in every interface defined in the `net.gobra` file. Furthermore, it adds two new files (`iprawsock.gobra` and `udpsock.gobra`) with definitions useful to verify scion. In these two files, the signal to noise ratio may be rather small, as I did not bother verifying members which are not immediately useful to my ends on verified scion or which rely on unsupported features of Gobra.