### PR TITLE
Update Viper Dependencies to 'v.21.07-release'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     container: gobraverifier/gobra-base:v5_z3_4.8.7
     env:
-      SILVER_REF: "21.07-RC"
-      SILICON_REF: "21.07-RC"
-      CARBON_REF: "21.07-RC"
+      SILVER_REF: "v.21.07-release"
+      SILICON_REF: "v.21.07-release"
+      CARBON_REF: "v.21.07-release"
     steps:
       - name: Checkout Gobra
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     container: gobraverifier/gobra-base:v5_z3_4.8.7
     env:
-      SILVER_REF: "v.21.01-release"
-      SILICON_REF: "v.21.01-release"
-      CARBON_REF: "v.21.01-release"
+      SILVER_REF: "21.07-RC"
+      SILICON_REF: "21.07-RC"
+      CARBON_REF: "21.07-RC"
     steps:
       - name: Checkout Gobra
         uses: actions/checkout@v2

--- a/artifact/Dockerfile
+++ b/artifact/Dockerfile
@@ -71,9 +71,9 @@ WORKDIR $HOME
 # - tag (e.g. "v.21.01-release")
 # - commit hash or
 # - branch name (e.g. "origin/artifact" - note the leading "origin/")
-ENV SILVER_COMMIT "21.07-RC"
-ENV CARBON_COMMIT "21.07-RC"
-ENV SILICON_COMMIT "21.07-RC"
+ENV SILVER_COMMIT "v.21.07-release"
+ENV CARBON_COMMIT "v.21.07-release"
+ENV SILICON_COMMIT "v.21.07-release"
 # GOBRA_COMMIT can be set while building the docker image by using `docker build --build-arg GOBRA_COMMIT=<some branch>`
 # by default, "origin/artifact1" is used:
 ARG GOBRA_COMMIT="origin/artifact1"

--- a/artifact/Dockerfile
+++ b/artifact/Dockerfile
@@ -71,9 +71,9 @@ WORKDIR $HOME
 # - tag (e.g. "v.21.01-release")
 # - commit hash or
 # - branch name (e.g. "origin/artifact" - note the leading "origin/")
-ENV SILVER_COMMIT "v.21.01-release"
-ENV CARBON_COMMIT "v.21.01-release"
-ENV SILICON_COMMIT "v.21.01-release"
+ENV SILVER_COMMIT "21.07-RC"
+ENV CARBON_COMMIT "21.07-RC"
+ENV SILICON_COMMIT "21.07-RC"
 # GOBRA_COMMIT can be set while building the docker image by using `docker build --build-arg GOBRA_COMMIT=<some branch>`
 # by default, "origin/artifact1" is used:
 ARG GOBRA_COMMIT="origin/artifact1"

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -262,11 +262,13 @@ func (e *AddrError) Error(ghost p perm) (ret string) {
 
 // TODO: if the method is annotated with pure, then the implementation proof fails
 // because the "pure" annotation of the interface and implementation do not match
+requires 0 <= p
 requires acc(e.mem(), p)
 ensures acc(e.mem(), p)
 ensures !res
 /* pure */ func (e *AddrError) Timeout(ghost p perm) (res bool)   { return false }
 
+requires 0 <= p
 requires acc(e.mem(), p)
 ensures acc(e.mem(), p)
 ensures !res

--- a/src/main/scala/viper/gobra/backend/Carbon.scala
+++ b/src/main/scala/viper/gobra/backend/Carbon.scala
@@ -20,7 +20,7 @@ class Carbon(commandLineArguments: Seq[String]) extends ViperVerifier {
     // directly declaring the parameter implicit somehow does not work as the compiler is unable to spot the inheritance
     implicit val _executor: GobraExecutionContext = executor
     Future {
-      val backend: carbon.CarbonVerifier = carbon.CarbonVerifier(List("startedBy" -> s"Unit test ${this.getClass.getSimpleName}"))
+      val backend: carbon.CarbonVerifier = carbon.CarbonVerifier(reporter, List("startedBy" -> s"Unit test ${this.getClass.getSimpleName}"))
       backend.parseCommandLine(commandLineArguments ++ Seq("--ignoreFile", "dummy.sil"))
 
       val startTime = System.currentTimeMillis()

--- a/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
@@ -288,6 +288,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
 
       case (CreateDebtChannelMethodTag, recv: in.ChannelT) =>
         /**
+          * requires dividend >= 0
           * requires divisor > 0
           * requires acc(c.SendChannel(), dividend/divisor /* p */)
           * ensures c.ClosureDebt(P, dividend, divisor /* p */) && c.Token(P)
@@ -301,6 +302,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
         val predicateParam = in.Parameter.In("P", in.PredT(Vector(), Addressability.inParameter))(src)
         val sendChannelInst = builtInMPredAccessible(BuiltInMemberTag.SendChannelMPredTag, recvParam, Vector())(src)(ctx)
         val pres: Vector[in.Assertion] = Vector(
+          in.ExprAssertion(in.AtLeastCmp(dividendParam, in.IntLit(0)(src))(src))(src),
           in.ExprAssertion(in.GreaterCmp(divisorParam, in.IntLit(0)(src))(src))(src),
           in.Access(sendChannelInst, in.FractionalPerm(dividendParam, divisorParam)(src))(src)
           // in.Access(sendChannelInst, permissionAmountParam)(src)
@@ -346,8 +348,9 @@ class BuiltInMembersImpl extends BuiltInMembers {
     (x.tag, x.argsT) match {
       case (CloseFunctionTag, Vector(channelT, dividendT, divisorT /* permissionAmountT */, predicateT)) =>
         /**
+          * requires dividend >= 0
           * requires divisor > 0
-          * requires acc(c.SendChannel(), dividene/divisor /* p */) && c.ClosureDebt(P, divisor - dividend, divisor /* 1-p */) && P()
+          * requires acc(c.SendChannel(), dividend/divisor /* p */) && c.ClosureDebt(P, divisor - dividend, divisor /* 1-p */) && P()
           * ensures c.Closed()
           * func close(c chan T, ghost dividend int, divisor int /* p perm */, P pred())
           */
@@ -370,6 +373,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
         )
         val closureDebtInst = builtInMPredAccessible(BuiltInMemberTag.ClosureDebtMPredTag, channelParam, closureDebtArgs)(src)(ctx)
         val pres: Vector[in.Assertion] = Vector(
+          in.ExprAssertion(in.AtLeastCmp(dividendParam, in.IntLit(0)(src))(src))(src),
           in.ExprAssertion(in.GreaterCmp(divisorParam, in.IntLit(0)(src))(src))(src),
           in.Access(sendChannelInst, in.FractionalPerm(dividendParam, divisorParam)(src))(src),
           // in.Access(sendChannelInst, permissionAmountParam)(src),

--- a/src/test/resources/regressions/features/defunc/waitgroup-simple1.gobra
+++ b/src/test/resources/regressions/features/defunc/waitgroup-simple1.gobra
@@ -26,6 +26,7 @@ func spawnThreads(n int) {
 	go worker(-1, wg, PredTrue!<!>) // spawns first worker
 	// { acc(wg.WaitGroupP(), 1/2) && acc(wg.WaitGroupStarted(), 1/2) && !wg.WaitMode() && wg.Token(PredTrue!<!>) }
 
+	invariant 0 <= i && i <= n
 	invariant acc(wg.WaitGroupP(), 1/2)
 	invariant acc(wg.WaitGroupStarted(), 1/2)
 	invariant !wg.WaitMode()

--- a/src/test/resources/regressions/features/fractional_permissions/perm-fail1.gobra
+++ b/src/test/resources/regressions/features/fractional_permissions/perm-fail1.gobra
@@ -19,7 +19,7 @@ func test2(i *int, ghost p perm) int {
 	return *i
 }
 
-requires p < 1/2
+requires 0 <= p && p < 1/2
 requires acc(i, p)
 ensures acc(i, 1/2)
 func test3(i *int, ghost p perm) int {


### PR DESCRIPTION
Updates to latest Viper release.
Currently, this PR tests against the release candidate but will be updated to the release when it's out.