### PR TITLE
Mathematical Maps, Sets, Multisets, Options, and Sequences with Declared Types

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostTypeTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostTypeTyping.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.frontend.info.implementation.typing.ghost
 
-import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error, noMessages}
+import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, noMessages}
 import viper.gobra.ast.frontend._
 import viper.gobra.frontend.info.base.Type._
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
@@ -15,16 +15,11 @@ import viper.gobra.frontend.info.implementation.typing.BaseTyping
 trait GhostTypeTyping extends BaseTyping { this : TypeInfoImpl =>
 
   private[typing] def wellDefGhostType(typ : PGhostType) : Messages = typ match {
-    case PSequenceType(elem) => isType(elem).out ++
-      error(typ, s"sequences of custom defined types are currently not supported", elem.isInstanceOf[PNamedOperand])
-    case PSetType(elem) => isType(elem).out ++
-      error(typ, s"sets of custom defined types are currently not supported", elem.isInstanceOf[PNamedOperand])
-    case PMultisetType(elem) => isType(elem).out ++
-      error(typ, s"multisets of custom defined types are currently not supported", elem.isInstanceOf[PNamedOperand])
-    case PMathematicalMapType(key, value) => isType(key).out ++ isType(value).out ++
-      error(typ, s"maps of custom defined types are currently not supported", key.isInstanceOf[PNamedOperand] || value.isInstanceOf[PNamedOperand])
-    case POptionType(elem) => isType(elem).out ++
-      error(typ, s"options of custom defined types are currently not supported", elem.isInstanceOf[PNamedOperand])
+    case PSequenceType(elem) => isType(elem).out
+    case PSetType(elem) => isType(elem).out
+    case PMultisetType(elem) => isType(elem).out
+    case PMathematicalMapType(key, value) => isType(key).out ++ isType(value).out
+    case POptionType(elem) => isType(elem).out
     case n: PGhostSliceType => isType(n.elem).out
 
     case _: PDomainType => noMessages

--- a/src/test/resources/regressions/features/maps/maps-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/maps-declared-type-simple1.gobra
@@ -1,0 +1,24 @@
+package pkg
+
+type cell struct {
+		val int
+}
+
+func test1() {
+    m1 := map[int]cell { 0: cell{42} }
+    m2 := map[cell]int { cell{42}: 0 }
+    assert m1[0] == cell{42}
+    assert m2[cell{42}] == 0
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+func test2() {
+    c := &cell{42}
+    m1 := map[int]*cell { 0: c }
+    m2 := map[*cell]int { c: 0 }
+    assert m1[0] == c
+    assert m2[c] == 0
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}

--- a/src/test/resources/regressions/features/maps/maps-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/maps-declared-type-simple1.gobra
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 package pkg
 
 type cell struct {

--- a/src/test/resources/regressions/features/maps/math-maps-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/math-maps-declared-type-simple1.gobra
@@ -1,0 +1,24 @@
+package pkg
+
+type cell struct {
+		val int
+}
+
+func test1() {
+    m1 := dict[int]cell { 0: cell{42} }
+    m2 := dict[cell]int { cell{42}: 0 }
+    assert m1[0] == cell{42}
+    assert m2[cell{42}] == 0
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+func test2() {
+    c := &cell{42}
+    m1 := dict[int]*cell { 0: c }
+    m2 := dict[*cell]int { c: 0 }
+    assert m1[0] == c
+    assert m2[c] == 0
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}

--- a/src/test/resources/regressions/features/maps/math-maps-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/math-maps-declared-type-simple1.gobra
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 package pkg
 
 type cell struct {

--- a/src/test/resources/regressions/features/multisets/multiset-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/multisets/multiset-declared-type-simple1.gobra
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 package pkg
 
 type cell struct {

--- a/src/test/resources/regressions/features/multisets/multiset-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/multisets/multiset-declared-type-simple1.gobra
@@ -1,0 +1,20 @@
+package pkg
+
+type cell struct {
+		val int
+}
+
+func test1() {
+    ms := mset[cell] { cell{42} }
+    assert cell{42} in ms
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+func test2() {
+    c := &cell{42}
+    ms := mset[*cell] { c }
+    assert c in ms
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}

--- a/src/test/resources/regressions/features/multisets/multiset-type-simple2.gobra
+++ b/src/test/resources/regressions/features/multisets/multiset-type-simple2.gobra
@@ -9,7 +9,6 @@ type Point struct {
 }
 
 func foo() {
-  // sequences of custom defined types are not supported currently
-  //:: ExpectedOutput(type_error)
-  ghost var xs seq[Point]
+  // sequences of custom defined types are supported
+  ghost var xs mset[Point]
 }

--- a/src/test/resources/regressions/features/options/options-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/options/options-declared-type-simple1.gobra
@@ -1,0 +1,38 @@
+package pkg
+
+type cell struct {
+		val int
+}
+
+func test1() {
+    opt := some(cell{42})
+    assert get(opt) == cell{42}
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+func test2() {
+    c := &cell{42}
+    opt := some(c)
+    assert get(opt) == c
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+requires opt != none[cell]
+requires get(opt).val == 42
+func test3(ghost opt option[cell]) {
+    c := get(opt)
+    assert c.val == 42
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+requires opt != none[*cell]
+requires acc(get(opt)) && get(opt).val == 42
+func test4(ghost opt option[*cell]) {
+    c := get(opt)
+    assert c.val == 42
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}

--- a/src/test/resources/regressions/features/options/options-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/options/options-declared-type-simple1.gobra
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 package pkg
 
 type cell struct {

--- a/src/test/resources/regressions/features/sequences/seq-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-declared-type-simple1.gobra
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 package pkg
 
 type cell struct {

--- a/src/test/resources/regressions/features/sequences/seq-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-declared-type-simple1.gobra
@@ -1,0 +1,20 @@
+package pkg
+
+type cell struct {
+		val int
+}
+
+func test1() {
+    s := seq[cell] { 1: cell{42} }
+    assert s[1] == cell{42}
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+func test2() {
+    c := &cell{42}
+    s := seq[*cell] { 0: c }
+    assert s[0] == c
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}

--- a/src/test/resources/regressions/features/sequences/seq-type-simple2.gobra
+++ b/src/test/resources/regressions/features/sequences/seq-type-simple2.gobra
@@ -9,7 +9,6 @@ type Point struct {
 }
 
 func foo() {
-  // sequences of custom defined types are not supported currently
-  //:: ExpectedOutput(type_error)
-  ghost var xs set[Point]
+  // sequences of custom defined types are supported
+  ghost var xs seq[Point]
 }

--- a/src/test/resources/regressions/features/sets/set-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/sets/set-declared-type-simple1.gobra
@@ -1,0 +1,20 @@
+package pkg
+
+type cell struct {
+		val int
+}
+
+func test1() {
+    s := set[cell] { cell{42} }
+    assert cell{42} in s
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+func test2() {
+    c := &cell{42}
+    s := set[*cell] { c }
+    assert c in s
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}

--- a/src/test/resources/regressions/features/sets/set-declared-type-simple1.gobra
+++ b/src/test/resources/regressions/features/sets/set-declared-type-simple1.gobra
@@ -1,3 +1,6 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
 package pkg
 
 type cell struct {

--- a/src/test/resources/regressions/features/sets/set-type-simple2.gobra
+++ b/src/test/resources/regressions/features/sets/set-type-simple2.gobra
@@ -9,7 +9,6 @@ type Point struct {
 }
 
 func foo() {
-  // sequences of custom defined types are not supported currently
-  //:: ExpectedOutput(type_error)
-  ghost var xs mset[Point]
+  // sequences of custom defined types are supported
+  ghost var xs set[Point]
 }


### PR DESCRIPTION
Previously, declared types have not been allowed for the data structures mentioned in the title.
This PR removes these (artificial) restrictions and adds corresponding test cases checking that the encoding works properly.