### PR TITLE
Fixes 326

### DIFF
--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -213,7 +213,7 @@ case class PureFunctionNotWellFormedError(info: Source.Verifier.Info) extends Ve
 
 case class ImpreciseContractNotWellFormedError(info: Source.Verifier.Info) extends VerificationError {
   override def localId: String = "imprecise_contract_not_well_formed"
-  override def localMessage: String  ="Contract is not well-formed"
+  override def localMessage: String = "Contract is not well-formed"
 }
 
 case class IfError(info: Source.Verifier.Info) extends VerificationError {
@@ -293,42 +293,42 @@ case class UncaughtReason(viperReason: viper.silver.verifier.ErrorReason) extend
 
 case class InsufficientPermissionError(info: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "permission_error"
-  override def message: String = s"permission to ${info.origin.tag.trim} might not suffice"
+  override def message: String = s"Permission to ${info.origin.tag.trim} might not suffice."
 }
 
 case class InsufficientPermissionFromTagError(tag: String) extends VerificationErrorReason {
   override def id: String = "permission_error"
-  override def message: String = s"permission to $tag might not suffice"
+  override def message: String = s"Permission to $tag might not suffice."
 }
 
 case class AssertionFalseError(info: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "assertion_error"
-  override def message: String = s"Assertion ${info.origin.tag.trim} might not hold"
+  override def message: String = s"Assertion ${info.origin.tag.trim} might not hold."
 }
 
 case class SeqIndexExceedsLengthError(node: Source.Verifier.Info, index: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "seq_index_exceeds_length_error"
-  override def message: String = s"Index ${index.origin.tag.trim} into ${node.origin.tag.trim} might exceed sequence length"
+  override def message: String = s"Index ${index.origin.tag.trim} into ${node.origin.tag.trim} might exceed sequence length."
 }
 
 case class SeqIndexNegativeError(node: Source.Verifier.Info, index: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "seq_index_negative_error"
-  override def message: String = s"Index ${index.origin.tag.trim} into ${node.origin.tag.trim} might be negative"
+  override def message: String = s"Index ${index.origin.tag.trim} into ${node.origin.tag.trim} might be negative."
 }
 
 case class MapKeyNotContained(node: Source.Verifier.Info, index: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "map_key_not_contained"
-  override def message: String = s"Key ${index.origin.tag.trim} might not be contained in ${node.origin.tag.trim}"
+  override def message: String = s"Key ${index.origin.tag.trim} might not be contained in ${node.origin.tag.trim}."
 }
 
 case class KeyNotComparableReason(info: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "key_not_comparable_reason"
-  override def message: String = s"Key in ${info.origin.tag.trim} is not comparable"
+  override def message: String = s"Key in ${info.origin.tag.trim} is not comparable."
 }
 
 case class RepeatedMapKeyReason(info: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "repeated_map_key_reason"
-  override def message: String = s"Map literal ${info.origin.tag.trim} might contain the key twice"
+  override def message: String = s"Map literal ${info.origin.tag.trim} might contain the key twice."
 }
 
 // João, 06/03/2021: unlike the other subtypes of VerificationErrorReason, DivisionByZeroReason has an Optional argument.
@@ -336,12 +336,12 @@ case class RepeatedMapKeyReason(info: Source.Verifier.Info) extends Verification
 // a corresponding Source.Verifier.Info. E.g. src/test/resources/regressions/features/fractional_permissions/fields/fail3.gobra
 case class DivisionByZeroReason(node: Option[Source.Verifier.Info]) extends VerificationErrorReason {
   override def id: String = "division_by_zero"
-  override def message: String = s"Divisor ${node.map(_.origin.tag.trim).getOrElse("expression")} might be zero"
+  override def message: String = s"Divisor ${node.map(_.origin.tag.trim).getOrElse("expression")} might be zero."
 }
 
 case class OverflowErrorReason(node: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "integer_overflow_error"
-  override def message: String = s"Expression ${node.origin.tag.trim} might cause integer overflow"
+  override def message: String = s"Expression ${node.origin.tag.trim} might cause integer overflow."
 }
 
 case class DynamicValueNotASubtypeReason(node: Source.Verifier.Info) extends VerificationErrorReason {


### PR DESCRIPTION
This PR adds the char `.` to the end of the `message` field of the subtypes of `VerificationErrorReason` in which it is missing.

PS: we do not need to change the messages of subtypes of `VerificationError`.