### PR TITLE
Fix 334

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,9 +102,9 @@ jobs:
       #   # run: pidstat 1 -r -p ALL --human -e java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions org.scalatest.run viper.gobra.GobraTests
       #   working-directory: gobra
 
-#      - name: Execute all tests
-#        run: sbt test
-#        working-directory: gobra
+      - name: Execute all tests
+        run: sbt test
+        working-directory: gobra
 
       - name: Terminate pidstat
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,43 +170,43 @@ jobs:
       - name: Echo
         run: echo "the full name is ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}"
 
-#      - name: Create annotations
-#      #TODO: proper comment
-#        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-#        uses: LouisBrunner/checks-action@v1.1.2
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          name: 'RAM Usage'
-#          conclusion: ${{ env.CONCLUSION }}
-#          output: |
-#            {
-#            "title": "RAM Usage",
-#            "summary": "Java RAM usage caused a ${{ env.JAVA_LEVEL }}.\nZ3 RAM usage caused a ${{ env.Z3_LEVEL }}."
-#            }
-#          # the required and optional JSON fields can be found in section "Properties of the `annotations` items" here:
-#          # https://docs.github.com/en/rest/reference/checks#create-a-check-run--parameters
-#          annotations: |
-#            [
-#              {
-#              "message": "Java used up to ${{ env.MAX_JAVA_GB }}GB RAM",
-#              "path": ".github/workflows/test.yml",
-#              "start_line": 1,
-#              "end_line": 1,
-#              "annotation_level": "${{ env.JAVA_LEVEL }}"
-#              },
-#              {
-#              "message": "Z3 used up to ${{ env.MAX_Z3_GB }}GB RAM",
-#              "path": ".github/workflows/test.yml",
-#              "start_line": 1,
-#              "end_line": 1,
-#              "annotation_level": "${{ env.Z3_LEVEL }}"
-#              }
-#            ]
-#
-#      - name: Upload RAM usage
-#      # TODO: check if this needs to be conditional
-#        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: pidstat.txt
-#          path: gobra/pidstat.txt
+      - name: Create annotations
+      #TODO: proper comment
+        if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}
+        uses: LouisBrunner/checks-action@v1.1.2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: 'RAM Usage'
+          conclusion: ${{ env.CONCLUSION }}
+          output: |
+            {
+            "title": "RAM Usage",
+            "summary": "Java RAM usage caused a ${{ env.JAVA_LEVEL }}.\nZ3 RAM usage caused a ${{ env.Z3_LEVEL }}."
+            }
+          # the required and optional JSON fields can be found in section "Properties of the `annotations` items" here:
+          # https://docs.github.com/en/rest/reference/checks#create-a-check-run--parameters
+          annotations: |
+            [
+              {
+              "message": "Java used up to ${{ env.MAX_JAVA_GB }}GB RAM",
+              "path": ".github/workflows/test.yml",
+              "start_line": 1,
+              "end_line": 1,
+              "annotation_level": "${{ env.JAVA_LEVEL }}"
+              },
+              {
+              "message": "Z3 used up to ${{ env.MAX_Z3_GB }}GB RAM",
+              "path": ".github/workflows/test.yml",
+              "start_line": 1,
+              "end_line": 1,
+              "annotation_level": "${{ env.Z3_LEVEL }}"
+              }
+            ]
+
+      - name: Upload RAM usage
+      # TODO: check if this needs to be conditional
+        if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: pidstat.txt
+          path: gobra/pidstat.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo "the full name is $GITHUB_REPOSITORY"
+        run: echo "the full name is ${{ github.event.pull_request.head.repo }}"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo $github.event.pull_request.head.repo.full_name
+        run: echo "repo.full_name: $github.event.pull_request.head.repo.full_name"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Create annotations
       #TODO: proper comment
         if: ${{ always() }}
-        # echo message format described in https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+        # message format described in https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
         run: |
           echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
           echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,8 +114,8 @@ jobs:
         if: ${{ always() }}
         shell: bash
         env:
-          JAVA_WARNING_THRESHOLD_GB: 4.5
-          JAVA_FAILURE_THRESHOLD_GB: 5.5
+          JAVA_WARNING_THRESHOLD_GB: 0
+          JAVA_FAILURE_THRESHOLD_GB: 0
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
           # Output levels according to severity. They identify the kinds of annotations to be printed by Github.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -120,8 +120,10 @@ jobs:
           Z3_FAILURE_THRESHOLD_GB: 1
           # Output levels according to severity. They identify the kinds of annotations to be printed by Github.
           # Currently, NOTICE_LEVEL has the same value as WARNING_LEVEL, i.e., "warning". Alternatively, one could use
-          # "debug" for the NOTICE_LEVEL.
-          NOTICE_LEVEL: "debug"
+          # "debug" for the NOTICE_LEVEL. However, this option requires enabling debug logging at the repository level,
+          # which causes additional (unwanted) debug messages to be printed.
+          # (https://docs.github.com/en/enterprise-server@2.22/actions/reference/workflow-commands-for-github-actions#setting-a-debug-message)
+          NOTICE_LEVEL: "warning"
           WARNING_LEVEL: "warning"
           FAILURE_LEVEL: "error"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,11 +115,13 @@ jobs:
         shell: bash
         env:
           JAVA_WARNING_THRESHOLD_GB: 4.5
-          JAVA_FAILURE_THRESHOLD_GB: 0.0
+          JAVA_FAILURE_THRESHOLD_GB: 5.5
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
-          # TODO: comment debug requiring a secret not available for forks, that's a compromise we must accept
-          NOTICE_LEVEL: "warning"
+          # Output levels according to severity. They identify the kinds of annotations to be printed by Github.
+          # Currently, NOTICE_LEVEL has the same value as WARNING_LEVEL, i.e., "warning". Alternatively, one could use
+          # "debug" for the NOTICE_LEVEL.
+          NOTICE_LEVEL: "debug"
           WARNING_LEVEL: "warning"
           FAILURE_LEVEL: "error"
 
@@ -172,14 +174,6 @@ jobs:
           echo "CONCLUSION=$CONCLUSION" >> $GITHUB_ENV
         working-directory: gobra
 
-# TODO: remove
-#      - name: Echo
-#        run: echo "the full name is ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}"
-#
-## TODO: remove
-#      - name: Create annotations test
-#        run: echo "::error file=.github/workflows/test.yml,line=1::Something went wrong"
-
       - name: Create annotations
       #TODO: proper comment
         if: ${{ always() }}
@@ -188,39 +182,6 @@ jobs:
           echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
           echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
           return $([ $CONCLUSION = "success" ])  
-
-# TODO
-# Make fail when conclusion is failure
-#        uses: LouisBrunner/checks-action@v1.1.2
-#        with:
-#          token: ${{ secrets.GITHUB_TOKEN }}
-#          name: 'RAM Usage'
-#          conclusion: ${{ env.CONCLUSION }}
-#          # Check what this does
-#          output: |
-#            {
-#            "title": "RAM Usage",
-#            "summary": "Java RAM usage caused a ${{ env.JAVA_LEVEL }}.\nZ3 RAM usage caused a ${{ env.Z3_LEVEL }}."
-#            }
-#          # the required and optional JSON fields can be found in section "Properties of the `annotations` items" here:
-#          # https://docs.github.com/en/rest/reference/checks#create-a-check-run--parameters
-#          annotations: |
-#            [
-#              {
-#              "message": "Java used up to ${{ env.MAX_JAVA_GB }}GB RAM",
-#              "path": ".github/workflows/test.yml",
-#              "start_line": 1,
-#              "end_line": 1,
-#              "annotation_level": "${{ env.JAVA_LEVEL }}"
-#              },
-#              {
-#              "message": "Z3 used up to ${{ env.MAX_Z3_GB }}GB RAM",
-#              "path": ".github/workflows/test.yml",
-#              "start_line": 1,
-#              "end_line": 1,
-#              "annotation_level": "${{ env.Z3_LEVEL }}"
-#              }
-#            ]
 
       - name: Upload RAM usage
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo "the full name is ${{ github.repository }}"
+        run: echo "the full name is ${{ GITHUB_REPOSITORY }}"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,8 +121,8 @@ jobs:
         if: ${{ always() }}
         shell: bash
         env:
-          JAVA_WARNING_THRESHOLD_GB: 0
-          JAVA_FAILURE_THRESHOLD_GB: 5.5
+          JAVA_WARNING_THRESHOLD_GB: 4.5
+          JAVA_FAILURE_THRESHOLD_GB: 0
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,7 +119,7 @@ jobs:
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
           # TODO: activate debug
-          NOTICE_LEVEL: "debug"
+          NOTICE_LEVEL: "warning"
           WARNING_LEVEL: "warning"
           FAILURE_LEVEL: "error"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,7 +169,7 @@ jobs:
 
       - name: Create annotations
       #TODO: proper comment
-        if: ${{ github.event.pull_request.head.repo.full_name == 'viperproject/gobra' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: LouisBrunner/checks-action@v1.1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload RAM usage
       # TODO: check if this needs to be conditional
-        if: ${{ github.event.pull_request.head.repo.full_name == 'viperproject/gobra' }}
+        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/upload-artifact@v2
         with:
           name: pidstat.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,10 @@ jobs:
       CARBON_REF: "v.21.07-release"
       CONCLUSION_SUCCESS: "success"
       CONCLUSION_FAILURE: "failure"
+      # Output levels according to severity. They identify the kinds of annotations to be printed by Github.
+      NOTICE_LEVEL: "info"
+      WARNING_LEVEL: "warning"
+      FAILURE_LEVEL: "error"
     steps:
       - name: Checkout Gobra
         uses: actions/checkout@v2
@@ -120,14 +124,6 @@ jobs:
           JAVA_FAILURE_THRESHOLD_GB: 5.5
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
-          # Output levels according to severity. They identify the kinds of annotations to be printed by Github.
-          # Currently, NOTICE_LEVEL has the same value as WARNING_LEVEL, i.e., "warning". Alternatively, one could use
-          # "debug" for the NOTICE_LEVEL. However, this option requires enabling debug logging at the repository level,
-          # which causes additional (unwanted) debug messages to be printed.
-          # (https://docs.github.com/en/enterprise-server@2.22/actions/reference/workflow-commands-for-github-actions#setting-a-debug-message)
-          NOTICE_LEVEL: "warning"
-          WARNING_LEVEL: "warning"
-          FAILURE_LEVEL: "error"
 
         # awk is used to perform the computations such that the computations are performed with floating point precision
         # we transform bash variables into awk variables to not cause problems with bash's variable substitution
@@ -183,8 +179,26 @@ jobs:
         # Outputs the memory consumption of JAVA and Z3. The message format is described in
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions .
         run: |
-          echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
-          echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
+          JAVA_MESSAGE="Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
+          Z3_MESSAGE="Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
+
+          if [ "${{ env.JAVA_LEVEL }}" = "${{ env.NOTICE_LEVEL }}" ]
+          then
+            echo "$JAVA_MESSAGE"
+          else
+            echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::$JAVA_MESSAGE"
+          fi 
+
+          if [ "${{ env.Z3_LEVEL }}" = "${{ env.NOTICE_LEVEL }}" ]
+          then
+            echo "$Z3_LEVEL"
+          else
+            echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::$Z3_MESSAGE"
+          fi 
+
+
+
+
           if [ $CONCLUSION = "${{ env.CONCLUSION_FAILURE }}" ]
           then
             # the whole step fails when this comparison fails

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,7 @@ jobs:
           MAX_Z3_GB=$(convertKbToGb $MAX_Z3_KB)
           JAVA_LEVEL=$(getLevel $MAX_JAVA_GB ${{ env.JAVA_WARNING_THRESHOLD_GB }} ${{ env.JAVA_FAILURE_THRESHOLD_GB }})
           Z3_LEVEL=$(getLevel $MAX_Z3_GB ${{ env.Z3_WARNING_THRESHOLD_GB }} ${{ env.Z3_FAILURE_THRESHOLD_GB }})
-          if [[ "$JAVA_LEVEL" = "$FAILURE_LEVEL" || "$Z3_LEVEL" = "$FAILURE_LEVEL" ]]
+          if [[ "$JAVA_LEVEL" = "${{ env.FAILURE_LEVEL }}" || "$Z3_LEVEL" = "${{ env.FAILURE_LEVEL }}" ]]
           then
             CONCLUSION="failure"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo "the full name is ${{ GITHUB_REPOSITORY }}"
+        run: echo "the full name is $GITHUB_REPOSITORY"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo "repo.full_name: $github.event.pull_request.head.repo.full_name"
+        run: echo "the full name is ${{ github.event.pull_request.head.repo.full_name }}"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           pidstat 1 -r -p ALL > pidstat.txt &
           echo "PIDSTAT_PID=$!" >> $GITHUB_ENV
-        working-directory: gobra
+#        working-directory: gobra
 
 #      # the following step executes the tests independently of sbt:
 #      # - name: Execute precompiled tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -125,7 +125,6 @@ jobs:
           JAVA_FAILURE_THRESHOLD_GB: 5.5
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
-
         # awk is used to perform the computations such that the computations are performed with floating point precision
         # we transform bash variables into awk variables to not cause problems with bash's variable substitution
         # after computing the memory usage (in KB) a few more computations are performed. At the very end, all (local)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
       SILVER_REF: "v.21.07-release"
       SILICON_REF: "v.21.07-release"
       CARBON_REF: "v.21.07-release"
+      CONCLUSION_SUCCESS: "success"
+      CONCLUSION_FAILURE: "failure"
     steps:
       - name: Checkout Gobra
         uses: actions/checkout@v2
@@ -165,9 +167,9 @@ jobs:
           Z3_LEVEL=$(getLevel $MAX_Z3_GB ${{ env.Z3_WARNING_THRESHOLD_GB }} ${{ env.Z3_FAILURE_THRESHOLD_GB }})
           if [[ "$JAVA_LEVEL" = "${{ env.FAILURE_LEVEL }}" || "$Z3_LEVEL" = "${{ env.FAILURE_LEVEL }}" ]]
           then
-            CONCLUSION="${{ env.FAILURE_LEVEL }}"
+            CONCLUSION="${{ env.CONCLUSION_FAILURE }}"
           else
-            CONCLUSION="success"
+            CONCLUSION="${{ env.CONCLUSION_SUCCESS }}"
           fi
           echo "MAX_JAVA_GB=$MAX_JAVA_GB" >> $GITHUB_ENV
           echo "MAX_Z3_GB=$MAX_Z3_GB" >> $GITHUB_ENV
@@ -183,7 +185,7 @@ jobs:
         run: |
           echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
           echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
-          if [ $CONCLUSION = "${{ env.FAILURE_LEVEL }}" ]
+          if [ $CONCLUSION = "${{ env.CONCLUSION_FAILURE }}" ]
           then
             # the whole step fails when this comparison fails
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,10 +101,10 @@ jobs:
       #   run: java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions -DGOBRATESTS_SAME_PACKAGE_DIR=src/test/resources/same_package org.scalatest.tools.Runner -R target/scala-2.13/test-classes -o
       #   # run: pidstat 1 -r -p ALL --human -e java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions org.scalatest.run viper.gobra.GobraTests
       #   working-directory: gobra
-
-      - name: Execute all tests
-        run: sbt test
-        working-directory: gobra
+#
+#      - name: Execute all tests
+#        run: sbt test
+#        working-directory: gobra
 
       - name: Terminate pidstat
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo "the full name is ${{ github.event.pull_request.head.repo.full_name }}"
+        run: echo "the full name is ${{ github.event_name }}"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,7 +186,7 @@ jobs:
           if [ $CONCLUSION = "success" ]
           then
             # the whole step fails when this comparison fails
-            false
+            exit 1
           fi
 
       - name: Upload RAM usage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,7 +165,7 @@ jobs:
           Z3_LEVEL=$(getLevel $MAX_Z3_GB ${{ env.Z3_WARNING_THRESHOLD_GB }} ${{ env.Z3_FAILURE_THRESHOLD_GB }})
           if [[ "$JAVA_LEVEL" = "${{ env.FAILURE_LEVEL }}" || "$Z3_LEVEL" = "${{ env.FAILURE_LEVEL }}" ]]
           then
-            CONCLUSION="failure"
+            CONCLUSION="${{ env.FAILURE_LEVEL }}"
           else
             CONCLUSION="success"
           fi
@@ -183,7 +183,7 @@ jobs:
         run: |
           echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
           echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
-          if [ $CONCLUSION = "failure" ]
+          if [ $CONCLUSION = "${{ env.FAILURE_LEVEL }}" ]
           then
             # the whole step fails when this comparison fails
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo ${{ github.event.pull_request.head.repo.full_name }}
+        run: echo $github.event.pull_request.head.repo.full_name
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,14 +88,14 @@ jobs:
 #      #   run: sbt test:assembly
 #      #   working-directory: gobra
 #
-#      - name: Start pidstat and execute it in the background
-#        # execute pidstat, redirect its output to a file, and store its PID in the env variable `PIDSTAT_PID` to later
-#        # terminate it
-#        run: |
-#          pidstat 1 -r -p ALL > pidstat.txt &
-#          echo "PIDSTAT_PID=$!" >> $GITHUB_ENV
-#        working-directory: gobra
-#
+      - name: Start pidstat and execute it in the background
+        # execute pidstat, redirect its output to a file, and store its PID in the env variable `PIDSTAT_PID` to later
+        # terminate it
+        run: |
+          pidstat 1 -r -p ALL > pidstat.txt &
+          echo "PIDSTAT_PID=$!" >> $GITHUB_ENV
+        working-directory: gobra
+
 #      # the following step executes the tests independently of sbt:
 #      # - name: Execute precompiled tests
 #      #   run: java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions -DGOBRATESTS_SAME_PACKAGE_DIR=src/test/resources/same_package org.scalatest.tools.Runner -R target/scala-2.13/test-classes -o
@@ -106,10 +106,10 @@ jobs:
 ##        run: sbt test
 ##        working-directory: gobra
 #
-#      - name: Terminate pidstat
-#        if: ${{ always() }}
-#        run: kill -INT $PIDSTAT_PID
-#
+      - name: Terminate pidstat
+        if: ${{ always() }}
+        run: kill -INT $PIDSTAT_PID
+
 #      - name: Get max RAM usage by Java and Z3
 #        if: ${{ always() }}
 #        shell: bash
@@ -206,10 +206,10 @@ jobs:
 #              }
 #            ]
 #
-#      - name: Upload RAM usage
-#      # TODO: check if this needs to be conditional
-#        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: pidstat.txt
-#          path: gobra/pidstat.txt
+      - name: Upload RAM usage
+      # TODO: check if this needs to be conditional
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: pidstat.txt
+          path: gobra/pidstat.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
         working-directory: gobra
 
       - name: Create annotations
-        if: ${{ always() }}
+        if: ${{ github.repository == 'viperproject/gobra' }}
         uses: LouisBrunner/checks-action@v1.1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -200,7 +200,7 @@ jobs:
             ]
 
       - name: Upload RAM usage
-        if: ${{ always() }}
+        if: ${{ github.repository == 'viperproject/gobra' }}
         uses: actions/upload-artifact@v2
         with:
           name: pidstat.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,43 +170,46 @@ jobs:
       - name: Echo
         run: echo "the full name is ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}"
 
-      - name: Create annotations
-      #TODO: proper comment
-        if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}
-        uses: LouisBrunner/checks-action@v1.1.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: 'RAM Usage'
-          conclusion: ${{ env.CONCLUSION }}
-          output: |
-            {
-            "title": "RAM Usage",
-            "summary": "Java RAM usage caused a ${{ env.JAVA_LEVEL }}.\nZ3 RAM usage caused a ${{ env.Z3_LEVEL }}."
-            }
-          # the required and optional JSON fields can be found in section "Properties of the `annotations` items" here:
-          # https://docs.github.com/en/rest/reference/checks#create-a-check-run--parameters
-          annotations: |
-            [
-              {
-              "message": "Java used up to ${{ env.MAX_JAVA_GB }}GB RAM",
-              "path": ".github/workflows/test.yml",
-              "start_line": 1,
-              "end_line": 1,
-              "annotation_level": "${{ env.JAVA_LEVEL }}"
-              },
-              {
-              "message": "Z3 used up to ${{ env.MAX_Z3_GB }}GB RAM",
-              "path": ".github/workflows/test.yml",
-              "start_line": 1,
-              "end_line": 1,
-              "annotation_level": "${{ env.Z3_LEVEL }}"
-              }
-            ]
+      - name: Create annotations test
+        run: echo "::error::Something went wrong"
 
-      - name: Upload RAM usage
-      # TODO: check if this needs to be conditional
-        if: ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: pidstat.txt
-          path: gobra/pidstat.txt
+#      - name: Create annotations
+#      #TODO: proper comment
+#        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+#        uses: LouisBrunner/checks-action@v1.1.2
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          name: 'RAM Usage'
+#          conclusion: ${{ env.CONCLUSION }}
+#          output: |
+#            {
+#            "title": "RAM Usage",
+#            "summary": "Java RAM usage caused a ${{ env.JAVA_LEVEL }}.\nZ3 RAM usage caused a ${{ env.Z3_LEVEL }}."
+#            }
+#          # the required and optional JSON fields can be found in section "Properties of the `annotations` items" here:
+#          # https://docs.github.com/en/rest/reference/checks#create-a-check-run--parameters
+#          annotations: |
+#            [
+#              {
+#              "message": "Java used up to ${{ env.MAX_JAVA_GB }}GB RAM",
+#              "path": ".github/workflows/test.yml",
+#              "start_line": 1,
+#              "end_line": 1,
+#              "annotation_level": "${{ env.JAVA_LEVEL }}"
+#              },
+#              {
+#              "message": "Z3 used up to ${{ env.MAX_Z3_GB }}GB RAM",
+#              "path": ".github/workflows/test.yml",
+#              "start_line": 1,
+#              "end_line": 1,
+#              "annotation_level": "${{ env.Z3_LEVEL }}"
+#              }
+#            ]
+#
+#      - name: Upload RAM usage
+#      # TODO: check if this needs to be conditional
+#        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: pidstat.txt
+#          path: gobra/pidstat.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,8 +114,8 @@ jobs:
         if: ${{ always() }}
         shell: bash
         env:
-          JAVA_WARNING_THRESHOLD_GB: 0
-          JAVA_FAILURE_THRESHOLD_GB: 0
+          JAVA_WARNING_THRESHOLD_GB: 4.5
+          JAVA_FAILURE_THRESHOLD_GB: 5.5
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
           # Output levels according to severity. They identify the kinds of annotations to be printed by Github.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,7 @@ jobs:
             # $2 is the threshold causing a warning
             # $3 is the threshold causing an error
             # writes ${{ env.NOTICE_LEVEL }}, ${{ env.WARNING_LEVEL}} or ${{ env.FAILURE_LEVEL }} to standard output
-            local result=$(awk -v value=$1 -v warnThres=$2 -v errThres=$3 'BEGIN { print (value>errThres) ? ${{ env.FAILURE_LEVEL }} : (value>warnThres) ? ${{ env.WARNING_LEVEL }} : ${{ env.NOTICE_LEVEL}} }')
+            local result=$(awk -v value=$1 -v warnThres=$2 -v errThres=$3 'BEGIN { print (value>errThres) ? "${{ env.FAILURE_LEVEL }}" : (value>warnThres) ? "${{ env.WARNING_LEVEL }}" : "${{ env.NOTICE_LEVEL}}" }')
             echo $result
           }
           MAX_JAVA_KB=$(getMaxMemOfProcessInKb 'java$')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,8 @@ jobs:
       CARBON_REF: "v.21.07-release"
       CONCLUSION_SUCCESS: "success"
       CONCLUSION_FAILURE: "failure"
-      # Output levels according to severity. They identify the kinds of annotations to be printed by Github.
+      # Output levels according to severity.
+      # They identify the kinds of annotations to be printed by Github.
       NOTICE_LEVEL: "info"
       WARNING_LEVEL: "warning"
       FAILURE_LEVEL: "error"
@@ -120,7 +121,7 @@ jobs:
         if: ${{ always() }}
         shell: bash
         env:
-          JAVA_WARNING_THRESHOLD_GB: 4.5
+          JAVA_WARNING_THRESHOLD_GB: 0
           JAVA_FAILURE_THRESHOLD_GB: 5.5
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
@@ -180,8 +181,6 @@ jobs:
         # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions .
         run: |
           JAVA_MESSAGE="Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
-          Z3_MESSAGE="Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
-
           if [ "${{ env.JAVA_LEVEL }}" = "${{ env.NOTICE_LEVEL }}" ]
           then
             echo "$JAVA_MESSAGE"
@@ -189,15 +188,13 @@ jobs:
             echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::$JAVA_MESSAGE"
           fi 
 
+          Z3_MESSAGE="Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
           if [ "${{ env.Z3_LEVEL }}" = "${{ env.NOTICE_LEVEL }}" ]
           then
             echo "$Z3_LEVEL"
           else
             echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::$Z3_MESSAGE"
           fi 
-
-
-
 
           if [ $CONCLUSION = "${{ env.CONCLUSION_FAILURE }}" ]
           then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,13 +177,13 @@ jobs:
         working-directory: gobra
 
       - name: Create annotations
-      #TODO: proper comment
         if: ${{ always() }}
-        # message format described in https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+        # Outputs the memory consumption of JAVA and Z3. The message format is described in
+        # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions .
         run: |
           echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
           echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
-          return $([ $CONCLUSION = "success" ])  
+          return $([ $CONCLUSION = "success" ]) # the whole step fails when this comparison fails
 
       - name: Upload RAM usage
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,7 @@ jobs:
         run: echo "the full name is ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}"
 
       - name: Create annotations test
-        run: echo "::error::Something went wrong"
+        run: echo "::error file=.github/workflows/test.yml,line=1::Something went wrong"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,9 @@ jobs:
           echo "CONCLUSION=$CONCLUSION" >> $GITHUB_ENV
         working-directory: gobra
 
+      - name: Echo
+        run: echo ${{ github.event.pull_request.head.repo.full_name }}
+
       - name: Create annotations
       #TODO: proper comment
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,8 +185,8 @@ jobs:
         if: ${{ always() }}
         # echo message format described in https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
         run: |
-          echo "::$JAVA_LEVEL file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
-          echo "::$Z3_LEVEL file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
+          echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
+          echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
           return $([ $CONCLUSION = "success" ])  
 
 # TODO

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,7 @@ jobs:
         run: |
           echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
           echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
-          if [ $CONCLUSION = "success" ]
+          if [ $CONCLUSION = "failure" ]
           then
             # the whole step fails when this comparison fails
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,10 +108,10 @@ jobs:
       #   run: java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions -DGOBRATESTS_SAME_PACKAGE_DIR=src/test/resources/same_package org.scalatest.tools.Runner -R target/scala-2.13/test-classes -o
       #   # run: pidstat 1 -r -p ALL --human -e java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions org.scalatest.run viper.gobra.GobraTests
       #   working-directory: gobra
-#
-#      - name: Execute all tests
-#        run: sbt test
-#        working-directory: gobra
+
+      - name: Execute all tests
+        run: sbt test
+        working-directory: gobra
 
       - name: Terminate pidstat
         if: ${{ always() }}
@@ -122,7 +122,7 @@ jobs:
         shell: bash
         env:
           JAVA_WARNING_THRESHOLD_GB: 4.5
-          JAVA_FAILURE_THRESHOLD_GB: 0
+          JAVA_FAILURE_THRESHOLD_GB: 5.5
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,168 +19,184 @@ jobs:
       SILICON_REF: "v.21.07-release"
       CARBON_REF: "v.21.07-release"
     steps:
-#      - name: Checkout Gobra
-#        uses: actions/checkout@v2
-#        with:
-#          path: gobra
-#
-#      # clone Viper dependencies
-#      - name: Checkout Silver
-#        uses: actions/checkout@v2
-#        with:
-#          repository: viperproject/silver
-#          ref: ${{ env.SILVER_REF }}
-#          path: silver
-#      - name: Checkout Silicon
-#        uses: actions/checkout@v2
-#        with:
-#          repository: viperproject/silicon
-#          ref: ${{ env.SILICON_REF }}
-#          path: silicon
-#      - name: Checkout Carbon
-#        uses: actions/checkout@v2
-#        with:
-#          repository: viperproject/carbon
-#          ref: ${{ env.CARBON_REF }}
-#          path: carbon
-#
-#      - name: Java Version
-#        run: java --version
-#      - name: Z3 Version
-#        run: z3 -version
-#      - name: Silver Commit
-#        run: echo "Silver commit:" $(git -C silver rev-parse HEAD)
-#      - name: Silicon Commit
-#        run: echo "Silicon commit:" $(git -C silicon rev-parse HEAD)
-#      - name: Carbon Commit
-#        run: echo "Carbon commit:" $(git -C carbon rev-parse HEAD)
-#
-#      # create symlinks between and to Viper dependencies:
-#      - name: Create Silicon's sym links
-#        run: ln --symbolic ../silver
-#        working-directory: silicon
-#      - name: Create Carbon's sym links
-#        run: ln --symbolic ../silver
-#        working-directory: carbon
-#      - name: Create Gobra's sym links
-#        run: ln --symbolic ../silver; ln --symbolic ../silicon; ln --symbolic ../carbon
-#        working-directory: gobra
-#
-#      - name: Set sbt cache variables
-#        run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV
-#        # note that the cache path is relative to the directory in which sbt is invoked.
-#
-#      - name: Cache SBT
-#        uses: actions/cache@v2
-#        with:
-#          path: |
-#            gobra/sbt-cache/.sbtboot
-#            gobra/sbt-cache/.boot
-#            gobra/sbt-cache/.ivy/cache
-#          # <x>/project/target and <x>/target, where <x> is e.g. 'gobra' or 'silicon', are intentionally not
-#          # included as several occurrences of NoSuchMethodError exceptions have been observed during CI runs. It seems
-#          # like sbt is unable to correctly compute source files that require a recompilation. Therefore, we have
-#          # disabled caching of compiled source files altogether
-#          key: ${{ runner.os }}-sbt-no-precompiled-sources-${{ hashFiles('**/build.sbt') }}
-#
-#      # compilation of gobra-test.jar is only necessary when tests should be executed independently of sbt
-#      # - name: Compile tests
-#      #   run: sbt test:assembly
-#      #   working-directory: gobra
-#
+      - name: Checkout Gobra
+        uses: actions/checkout@v2
+        with:
+          path: gobra
+
+      # clone Viper dependencies
+      - name: Checkout Silver
+        uses: actions/checkout@v2
+        with:
+          repository: viperproject/silver
+          ref: ${{ env.SILVER_REF }}
+          path: silver
+      - name: Checkout Silicon
+        uses: actions/checkout@v2
+        with:
+          repository: viperproject/silicon
+          ref: ${{ env.SILICON_REF }}
+          path: silicon
+      - name: Checkout Carbon
+        uses: actions/checkout@v2
+        with:
+          repository: viperproject/carbon
+          ref: ${{ env.CARBON_REF }}
+          path: carbon
+
+      - name: Java Version
+        run: java --version
+      - name: Z3 Version
+        run: z3 -version
+      - name: Silver Commit
+        run: echo "Silver commit:" $(git -C silver rev-parse HEAD)
+      - name: Silicon Commit
+        run: echo "Silicon commit:" $(git -C silicon rev-parse HEAD)
+      - name: Carbon Commit
+        run: echo "Carbon commit:" $(git -C carbon rev-parse HEAD)
+
+      # create symlinks between and to Viper dependencies:
+      - name: Create Silicon's sym links
+        run: ln --symbolic ../silver
+        working-directory: silicon
+      - name: Create Carbon's sym links
+        run: ln --symbolic ../silver
+        working-directory: carbon
+      - name: Create Gobra's sym links
+        run: ln --symbolic ../silver; ln --symbolic ../silicon; ln --symbolic ../carbon
+        working-directory: gobra
+
+      - name: Set sbt cache variables
+        run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV
+        # note that the cache path is relative to the directory in which sbt is invoked.
+
+      - name: Cache SBT
+        uses: actions/cache@v2
+        with:
+          path: |
+            gobra/sbt-cache/.sbtboot
+            gobra/sbt-cache/.boot
+            gobra/sbt-cache/.ivy/cache
+          # <x>/project/target and <x>/target, where <x> is e.g. 'gobra' or 'silicon', are intentionally not
+          # included as several occurrences of NoSuchMethodError exceptions have been observed during CI runs. It seems
+          # like sbt is unable to correctly compute source files that require a recompilation. Therefore, we have
+          # disabled caching of compiled source files altogether
+          key: ${{ runner.os }}-sbt-no-precompiled-sources-${{ hashFiles('**/build.sbt') }}
+
+      # compilation of gobra-test.jar is only necessary when tests should be executed independently of sbt
+      # - name: Compile tests
+      #   run: sbt test:assembly
+      #   working-directory: gobra
+
       - name: Start pidstat and execute it in the background
         # execute pidstat, redirect its output to a file, and store its PID in the env variable `PIDSTAT_PID` to later
         # terminate it
         run: |
           pidstat 1 -r -p ALL > pidstat.txt &
           echo "PIDSTAT_PID=$!" >> $GITHUB_ENV
+        working-directory: gobra
+
+      # the following step executes the tests independently of sbt:
+      # - name: Execute precompiled tests
+      #   run: java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions -DGOBRATESTS_SAME_PACKAGE_DIR=src/test/resources/same_package org.scalatest.tools.Runner -R target/scala-2.13/test-classes -o
+      #   # run: pidstat 1 -r -p ALL --human -e java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions org.scalatest.run viper.gobra.GobraTests
+      #   working-directory: gobra
+
+#      - name: Execute all tests
+#        run: sbt test
 #        working-directory: gobra
 
-#      # the following step executes the tests independently of sbt:
-#      # - name: Execute precompiled tests
-#      #   run: java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions -DGOBRATESTS_SAME_PACKAGE_DIR=src/test/resources/same_package org.scalatest.tools.Runner -R target/scala-2.13/test-classes -o
-#      #   # run: pidstat 1 -r -p ALL --human -e java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions org.scalatest.run viper.gobra.GobraTests
-#      #   working-directory: gobra
-#
-##      - name: Execute all tests
-##        run: sbt test
-##        working-directory: gobra
-#
       - name: Terminate pidstat
         if: ${{ always() }}
         run: kill -INT $PIDSTAT_PID
 
-#      - name: Get max RAM usage by Java and Z3
-#        if: ${{ always() }}
-#        shell: bash
-#        env:
-#          JAVA_WARNING_THRESHOLD_GB: 4.5
-#          JAVA_FAILURE_THRESHOLD_GB: 5.5
-#          Z3_WARNING_THRESHOLD_GB: 0.5
-#          Z3_FAILURE_THRESHOLD_GB: 1
-#        # awk is used to perform the computations such that the computations are performed with floating point precision
-#        # we transform bash variables into awk variables to not cause problems with bash's variable substitution
-#        # after computing the memory usage (in KB) a few more computations are performed. At the very end, all (local)
-#        # environment variables are exported to `$GITHUB_ENV` such that they will be available in the next step as well.
-#        run: |
-#          function getMaxMemOfProcessInKb {
-#            # $1 is the regex used to filter lines by the 10th column
-#            # - we use variable `max` to keep track of the maximum
-#            # - `curCount` stores the sum of all processes with the given name for a particular timestamp
-#            # - note that looking at the timestamp is only an approximation: pidstat might report different timestamps in the
-#            #   same "block" of outputs (i.e. the report every second)
-#            # - `$8` refers to the 8th column in the file which corresponds to the column storing RAM (in kb)
-#            # - `java$` matches only lines that end in the string 'java'
-#            # - variable `max` is printed after processing the entire file
-#            local result=$(awk -v processName=$1 -v max=0 -v curCount=0 -v curTimestamp=0 'processName~$10 {if(curTimestamp==$1){curCount=curCount+$8}else{curTimestamp=$1; curCount=$8}; if(curCount>max){max=curCount}}END{print max}' pidstat.txt)
-#            echo $result
-#          }
-#          function convertKbToGb {
-#            # $1 is the value [KB] that should be converted
-#            local result=$(awk -v value=$1 'BEGIN {print value / 1000 / 1000}')
-#            echo $result
-#          }
-#          function getLevel {
-#            # $1 is the value that should be comparing against the thresholds
-#            # $2 is the threshold causing a warning
-#            # $3 is the threshold causing an error
-#            # writes `notice`, `warning` or `failure` to standard output
-#            local result=$(awk -v value=$1 -v warnThres=$2 -v errThres=$3 'BEGIN { print (value>errThres) ? "failure" : (value>warnThres) ? "warning" : "notice"}')
-#            echo $result
-#          }
-#          MAX_JAVA_KB=$(getMaxMemOfProcessInKb 'java$')
-#          MAX_Z3_KB=$(getMaxMemOfProcessInKb 'z3$')
-#          MAX_JAVA_GB=$(convertKbToGb $MAX_JAVA_KB)
-#          MAX_Z3_GB=$(convertKbToGb $MAX_Z3_KB)
-#          JAVA_LEVEL=$(getLevel $MAX_JAVA_GB ${{ env.JAVA_WARNING_THRESHOLD_GB }} ${{ env.JAVA_FAILURE_THRESHOLD_GB }})
-#          Z3_LEVEL=$(getLevel $MAX_Z3_GB ${{ env.Z3_WARNING_THRESHOLD_GB }} ${{ env.Z3_FAILURE_THRESHOLD_GB }})
-#          if [[ "$JAVA_LEVEL" = "failure" || "$Z3_LEVEL" = "failure" ]]
-#          then
-#            CONCLUSION="failure"
-#          else
-#            CONCLUSION="success"
-#          fi
-#          echo "MAX_JAVA_GB=$MAX_JAVA_GB" >> $GITHUB_ENV
-#          echo "MAX_Z3_GB=$MAX_Z3_GB" >> $GITHUB_ENV
-#          echo "JAVA_LEVEL=$JAVA_LEVEL" >> $GITHUB_ENV
-#          echo "Z3_LEVEL=$Z3_LEVEL" >> $GITHUB_ENV
-#          echo "CONCLUSION=$CONCLUSION" >> $GITHUB_ENV
-#        working-directory: gobra
+      - name: Get max RAM usage by Java and Z3
+        if: ${{ always() }}
+        shell: bash
+        env:
+          JAVA_WARNING_THRESHOLD_GB: 4.5
+          JAVA_FAILURE_THRESHOLD_GB: 5.5
+          Z3_WARNING_THRESHOLD_GB: 0.5
+          Z3_FAILURE_THRESHOLD_GB: 1
+          # TODO: activate debug
+          NOTICE_LEVEL: "debug"
+          WARNING_LEVEL: "warning"
+          FAILURE_LEVEL: "error"
 
-      - name: Echo
-        run: echo "the full name is ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}"
+        # awk is used to perform the computations such that the computations are performed with floating point precision
+        # we transform bash variables into awk variables to not cause problems with bash's variable substitution
+        # after computing the memory usage (in KB) a few more computations are performed. At the very end, all (local)
+        # environment variables are exported to `$GITHUB_ENV` such that they will be available in the next step as well.
+        run: |
+          function getMaxMemOfProcessInKb {
+            # $1 is the regex used to filter lines by the 10th column
+            # - we use variable `max` to keep track of the maximum
+            # - `curCount` stores the sum of all processes with the given name for a particular timestamp
+            # - note that looking at the timestamp is only an approximation: pidstat might report different timestamps in the
+            #   same "block" of outputs (i.e. the report every second)
+            # - `$8` refers to the 8th column in the file which corresponds to the column storing RAM (in kb)
+            # - `java$` matches only lines that end in the string 'java'
+            # - variable `max` is printed after processing the entire file
+            local result=$(awk -v processName=$1 -v max=0 -v curCount=0 -v curTimestamp=0 'processName~$10 {if(curTimestamp==$1){curCount=curCount+$8}else{curTimestamp=$1; curCount=$8}; if(curCount>max){max=curCount}}END{print max}' pidstat.txt)
+            echo $result
+          }
+          function convertKbToGb {
+            # $1 is the value [KB] that should be converted
+            local result=$(awk -v value=$1 'BEGIN {print value / 1000 / 1000}')
+            echo $result
+          }
+          function getLevel {
+            # $1 is the value that should be comparing against the thresholds
+            # $2 is the threshold causing a warning
+            # $3 is the threshold causing an error
+            # writes $NOTICE_LEVEL, $WARNING_LEVEL or $FAILURE_LEVEL to standard output
+            local result=$(awk -v value=$1 -v warnThres=$2 -v errThres=$3 'BEGIN { print (value>errThres) ? $FAILURE_LEVEL : (value>warnThres) ? $WARNING_LEVEL : $NOTICE_LEVEL}')
+            echo $result
+          }
+          MAX_JAVA_KB=$(getMaxMemOfProcessInKb 'java$')
+          MAX_Z3_KB=$(getMaxMemOfProcessInKb 'z3$')
+          MAX_JAVA_GB=$(convertKbToGb $MAX_JAVA_KB)
+          MAX_Z3_GB=$(convertKbToGb $MAX_Z3_KB)
+          JAVA_LEVEL=$(getLevel $MAX_JAVA_GB ${{ env.JAVA_WARNING_THRESHOLD_GB }} ${{ env.JAVA_FAILURE_THRESHOLD_GB }})
+          Z3_LEVEL=$(getLevel $MAX_Z3_GB ${{ env.Z3_WARNING_THRESHOLD_GB }} ${{ env.Z3_FAILURE_THRESHOLD_GB }})
+          if [[ "$JAVA_LEVEL" = "$FAILURE_LEVEL" || "$Z3_LEVEL" = "$FAILURE_LEVEL" ]]
+          then
+            CONCLUSION="failure"
+          else
+            CONCLUSION="success"
+          fi
+          echo "MAX_JAVA_GB=$MAX_JAVA_GB" >> $GITHUB_ENV
+          echo "MAX_Z3_GB=$MAX_Z3_GB" >> $GITHUB_ENV
+          echo "JAVA_LEVEL=$JAVA_LEVEL" >> $GITHUB_ENV
+          echo "Z3_LEVEL=$Z3_LEVEL" >> $GITHUB_ENV
+          echo "CONCLUSION=$CONCLUSION" >> $GITHUB_ENV
+        working-directory: gobra
 
-      - name: Create annotations test
-        run: echo "::error file=.github/workflows/test.yml,line=1::Something went wrong"
+# TODO: remove
+#      - name: Echo
+#        run: echo "the full name is ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}"
+#
+## TODO: remove
+#      - name: Create annotations test
+#        run: echo "::error file=.github/workflows/test.yml,line=1::Something went wrong"
 
-#      - name: Create annotations
-#      #TODO: proper comment
-#        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+      - name: Create annotations
+      #TODO: proper comment
+        if: ${{ always() }}
+        # echo message format described in https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
+        run: |
+          echo "::$JAVA_LEVEL file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
+          echo "::$Z3_LEVEL file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
+          return $([ $CONCLUSION = "success" ])  
+
+# TODO
+# Make fail when conclusion is failure
 #        uses: LouisBrunner/checks-action@v1.1.2
 #        with:
 #          token: ${{ secrets.GITHUB_TOKEN }}
 #          name: 'RAM Usage'
 #          conclusion: ${{ env.CONCLUSION }}
+#          # Check what this does
 #          output: |
 #            {
 #            "title": "RAM Usage",
@@ -205,9 +221,8 @@ jobs:
 #              "annotation_level": "${{ env.Z3_LEVEL }}"
 #              }
 #            ]
-#
+
       - name: Upload RAM usage
-      # TODO: check if this needs to be conditional
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
           Z3_MESSAGE="Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
           if [ "${{ env.Z3_LEVEL }}" = "${{ env.NOTICE_LEVEL }}" ]
           then
-            echo "$Z3_LEVEL"
+            echo "$Z3_MESSAGE"
           else
             echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::$Z3_MESSAGE"
           fi 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,8 @@ jobs:
         working-directory: gobra
 
       - name: Create annotations
-        if: ${{ github.repository == 'viperproject/gobra' }}
+      #TODO: proper comment
+        if: ${{ github.event.pull_request.head.repo.full_name == 'viperproject/gobra' }}
         uses: LouisBrunner/checks-action@v1.1.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -200,7 +201,8 @@ jobs:
             ]
 
       - name: Upload RAM usage
-        if: ${{ github.repository == 'viperproject/gobra' }}
+      # TODO: check if this needs to be conditional
+        if: ${{ github.event.pull_request.head.repo.full_name == 'viperproject/gobra' }}
         uses: actions/upload-artifact@v2
         with:
           name: pidstat.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo "the full name is ${{ github.event_name }}"
+        run: echo "the full name is ${{ github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name) }}"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,10 +115,10 @@ jobs:
         shell: bash
         env:
           JAVA_WARNING_THRESHOLD_GB: 4.5
-          JAVA_FAILURE_THRESHOLD_GB: 5.5
+          JAVA_FAILURE_THRESHOLD_GB: 0.0
           Z3_WARNING_THRESHOLD_GB: 0.5
           Z3_FAILURE_THRESHOLD_GB: 1
-          # TODO: activate debug
+          # TODO: comment debug requiring a secret not available for forks, that's a compromise we must accept
           NOTICE_LEVEL: "warning"
           WARNING_LEVEL: "warning"
           FAILURE_LEVEL: "error"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,8 +149,8 @@ jobs:
             # $1 is the value that should be comparing against the thresholds
             # $2 is the threshold causing a warning
             # $3 is the threshold causing an error
-            # writes $NOTICE_LEVEL, $WARNING_LEVEL or $FAILURE_LEVEL to standard output
-            local result=$(awk -v value=$1 -v warnThres=$2 -v errThres=$3 'BEGIN { print (value>errThres) ? $FAILURE_LEVEL : (value>warnThres) ? $WARNING_LEVEL : $NOTICE_LEVEL}')
+            # writes ${{ env.NOTICE_LEVEL }}, ${{ env.WARNING_LEVEL}} or ${{ env.FAILURE_LEVEL }} to standard output
+            local result=$(awk -v value=$1 -v warnThres=$2 -v errThres=$3 'BEGIN { print (value>errThres) ? ${{ env.FAILURE_LEVEL }} : (value>warnThres) ? ${{ env.WARNING_LEVEL }} : ${{ env.NOTICE_LEVEL}} }')
             echo $result
           }
           MAX_JAVA_KB=$(getMaxMemOfProcessInKb 'java$')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,194 +19,194 @@ jobs:
       SILICON_REF: "v.21.07-release"
       CARBON_REF: "v.21.07-release"
     steps:
-      - name: Checkout Gobra
-        uses: actions/checkout@v2
-        with:
-          path: gobra
-
-      # clone Viper dependencies
-      - name: Checkout Silver
-        uses: actions/checkout@v2
-        with:
-          repository: viperproject/silver
-          ref: ${{ env.SILVER_REF }}
-          path: silver
-      - name: Checkout Silicon
-        uses: actions/checkout@v2
-        with:
-          repository: viperproject/silicon
-          ref: ${{ env.SILICON_REF }}
-          path: silicon
-      - name: Checkout Carbon
-        uses: actions/checkout@v2
-        with:
-          repository: viperproject/carbon
-          ref: ${{ env.CARBON_REF }}
-          path: carbon
-
-      - name: Java Version
-        run: java --version
-      - name: Z3 Version
-        run: z3 -version
-      - name: Silver Commit
-        run: echo "Silver commit:" $(git -C silver rev-parse HEAD)
-      - name: Silicon Commit
-        run: echo "Silicon commit:" $(git -C silicon rev-parse HEAD)
-      - name: Carbon Commit
-        run: echo "Carbon commit:" $(git -C carbon rev-parse HEAD)
-
-      # create symlinks between and to Viper dependencies:
-      - name: Create Silicon's sym links
-        run: ln --symbolic ../silver
-        working-directory: silicon
-      - name: Create Carbon's sym links
-        run: ln --symbolic ../silver
-        working-directory: carbon
-      - name: Create Gobra's sym links
-        run: ln --symbolic ../silver; ln --symbolic ../silicon; ln --symbolic ../carbon
-        working-directory: gobra
-
-      - name: Set sbt cache variables
-        run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV
-        # note that the cache path is relative to the directory in which sbt is invoked.
-
-      - name: Cache SBT
-        uses: actions/cache@v2
-        with:
-          path: |
-            gobra/sbt-cache/.sbtboot
-            gobra/sbt-cache/.boot
-            gobra/sbt-cache/.ivy/cache
-          # <x>/project/target and <x>/target, where <x> is e.g. 'gobra' or 'silicon', are intentionally not
-          # included as several occurrences of NoSuchMethodError exceptions have been observed during CI runs. It seems
-          # like sbt is unable to correctly compute source files that require a recompilation. Therefore, we have
-          # disabled caching of compiled source files altogether
-          key: ${{ runner.os }}-sbt-no-precompiled-sources-${{ hashFiles('**/build.sbt') }}
-
-      # compilation of gobra-test.jar is only necessary when tests should be executed independently of sbt
-      # - name: Compile tests
-      #   run: sbt test:assembly
-      #   working-directory: gobra
-
-      - name: Start pidstat and execute it in the background
-        # execute pidstat, redirect its output to a file, and store its PID in the env variable `PIDSTAT_PID` to later
-        # terminate it
-        run: |
-          pidstat 1 -r -p ALL > pidstat.txt &
-          echo "PIDSTAT_PID=$!" >> $GITHUB_ENV
-        working-directory: gobra
-
-      # the following step executes the tests independently of sbt:
-      # - name: Execute precompiled tests
-      #   run: java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions -DGOBRATESTS_SAME_PACKAGE_DIR=src/test/resources/same_package org.scalatest.tools.Runner -R target/scala-2.13/test-classes -o
-      #   # run: pidstat 1 -r -p ALL --human -e java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions org.scalatest.run viper.gobra.GobraTests
-      #   working-directory: gobra
-
-#      - name: Execute all tests
-#        run: sbt test
+#      - name: Checkout Gobra
+#        uses: actions/checkout@v2
+#        with:
+#          path: gobra
+#
+#      # clone Viper dependencies
+#      - name: Checkout Silver
+#        uses: actions/checkout@v2
+#        with:
+#          repository: viperproject/silver
+#          ref: ${{ env.SILVER_REF }}
+#          path: silver
+#      - name: Checkout Silicon
+#        uses: actions/checkout@v2
+#        with:
+#          repository: viperproject/silicon
+#          ref: ${{ env.SILICON_REF }}
+#          path: silicon
+#      - name: Checkout Carbon
+#        uses: actions/checkout@v2
+#        with:
+#          repository: viperproject/carbon
+#          ref: ${{ env.CARBON_REF }}
+#          path: carbon
+#
+#      - name: Java Version
+#        run: java --version
+#      - name: Z3 Version
+#        run: z3 -version
+#      - name: Silver Commit
+#        run: echo "Silver commit:" $(git -C silver rev-parse HEAD)
+#      - name: Silicon Commit
+#        run: echo "Silicon commit:" $(git -C silicon rev-parse HEAD)
+#      - name: Carbon Commit
+#        run: echo "Carbon commit:" $(git -C carbon rev-parse HEAD)
+#
+#      # create symlinks between and to Viper dependencies:
+#      - name: Create Silicon's sym links
+#        run: ln --symbolic ../silver
+#        working-directory: silicon
+#      - name: Create Carbon's sym links
+#        run: ln --symbolic ../silver
+#        working-directory: carbon
+#      - name: Create Gobra's sym links
+#        run: ln --symbolic ../silver; ln --symbolic ../silicon; ln --symbolic ../carbon
 #        working-directory: gobra
-
-      - name: Terminate pidstat
-        if: ${{ always() }}
-        run: kill -INT $PIDSTAT_PID
-
-      - name: Get max RAM usage by Java and Z3
-        if: ${{ always() }}
-        shell: bash
-        env:
-          JAVA_WARNING_THRESHOLD_GB: 4.5
-          JAVA_FAILURE_THRESHOLD_GB: 5.5
-          Z3_WARNING_THRESHOLD_GB: 0.5
-          Z3_FAILURE_THRESHOLD_GB: 1
-        # awk is used to perform the computations such that the computations are performed with floating point precision
-        # we transform bash variables into awk variables to not cause problems with bash's variable substitution
-        # after computing the memory usage (in KB) a few more computations are performed. At the very end, all (local)
-        # environment variables are exported to `$GITHUB_ENV` such that they will be available in the next step as well.
-        run: |
-          function getMaxMemOfProcessInKb {
-            # $1 is the regex used to filter lines by the 10th column
-            # - we use variable `max` to keep track of the maximum
-            # - `curCount` stores the sum of all processes with the given name for a particular timestamp
-            # - note that looking at the timestamp is only an approximation: pidstat might report different timestamps in the
-            #   same "block" of outputs (i.e. the report every second)
-            # - `$8` refers to the 8th column in the file which corresponds to the column storing RAM (in kb)
-            # - `java$` matches only lines that end in the string 'java'
-            # - variable `max` is printed after processing the entire file
-            local result=$(awk -v processName=$1 -v max=0 -v curCount=0 -v curTimestamp=0 'processName~$10 {if(curTimestamp==$1){curCount=curCount+$8}else{curTimestamp=$1; curCount=$8}; if(curCount>max){max=curCount}}END{print max}' pidstat.txt)
-            echo $result
-          }
-          function convertKbToGb {
-            # $1 is the value [KB] that should be converted
-            local result=$(awk -v value=$1 'BEGIN {print value / 1000 / 1000}')
-            echo $result
-          }
-          function getLevel {
-            # $1 is the value that should be comparing against the thresholds
-            # $2 is the threshold causing a warning
-            # $3 is the threshold causing an error
-            # writes `notice`, `warning` or `failure` to standard output
-            local result=$(awk -v value=$1 -v warnThres=$2 -v errThres=$3 'BEGIN { print (value>errThres) ? "failure" : (value>warnThres) ? "warning" : "notice"}')
-            echo $result
-          }
-          MAX_JAVA_KB=$(getMaxMemOfProcessInKb 'java$')
-          MAX_Z3_KB=$(getMaxMemOfProcessInKb 'z3$')
-          MAX_JAVA_GB=$(convertKbToGb $MAX_JAVA_KB)
-          MAX_Z3_GB=$(convertKbToGb $MAX_Z3_KB)
-          JAVA_LEVEL=$(getLevel $MAX_JAVA_GB ${{ env.JAVA_WARNING_THRESHOLD_GB }} ${{ env.JAVA_FAILURE_THRESHOLD_GB }})
-          Z3_LEVEL=$(getLevel $MAX_Z3_GB ${{ env.Z3_WARNING_THRESHOLD_GB }} ${{ env.Z3_FAILURE_THRESHOLD_GB }})
-          if [[ "$JAVA_LEVEL" = "failure" || "$Z3_LEVEL" = "failure" ]]
-          then
-            CONCLUSION="failure"
-          else
-            CONCLUSION="success"
-          fi
-          echo "MAX_JAVA_GB=$MAX_JAVA_GB" >> $GITHUB_ENV
-          echo "MAX_Z3_GB=$MAX_Z3_GB" >> $GITHUB_ENV
-          echo "JAVA_LEVEL=$JAVA_LEVEL" >> $GITHUB_ENV
-          echo "Z3_LEVEL=$Z3_LEVEL" >> $GITHUB_ENV
-          echo "CONCLUSION=$CONCLUSION" >> $GITHUB_ENV
-        working-directory: gobra
+#
+#      - name: Set sbt cache variables
+#        run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV
+#        # note that the cache path is relative to the directory in which sbt is invoked.
+#
+#      - name: Cache SBT
+#        uses: actions/cache@v2
+#        with:
+#          path: |
+#            gobra/sbt-cache/.sbtboot
+#            gobra/sbt-cache/.boot
+#            gobra/sbt-cache/.ivy/cache
+#          # <x>/project/target and <x>/target, where <x> is e.g. 'gobra' or 'silicon', are intentionally not
+#          # included as several occurrences of NoSuchMethodError exceptions have been observed during CI runs. It seems
+#          # like sbt is unable to correctly compute source files that require a recompilation. Therefore, we have
+#          # disabled caching of compiled source files altogether
+#          key: ${{ runner.os }}-sbt-no-precompiled-sources-${{ hashFiles('**/build.sbt') }}
+#
+#      # compilation of gobra-test.jar is only necessary when tests should be executed independently of sbt
+#      # - name: Compile tests
+#      #   run: sbt test:assembly
+#      #   working-directory: gobra
+#
+#      - name: Start pidstat and execute it in the background
+#        # execute pidstat, redirect its output to a file, and store its PID in the env variable `PIDSTAT_PID` to later
+#        # terminate it
+#        run: |
+#          pidstat 1 -r -p ALL > pidstat.txt &
+#          echo "PIDSTAT_PID=$!" >> $GITHUB_ENV
+#        working-directory: gobra
+#
+#      # the following step executes the tests independently of sbt:
+#      # - name: Execute precompiled tests
+#      #   run: java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions -DGOBRATESTS_SAME_PACKAGE_DIR=src/test/resources/same_package org.scalatest.tools.Runner -R target/scala-2.13/test-classes -o
+#      #   # run: pidstat 1 -r -p ALL --human -e java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions org.scalatest.run viper.gobra.GobraTests
+#      #   working-directory: gobra
+#
+##      - name: Execute all tests
+##        run: sbt test
+##        working-directory: gobra
+#
+#      - name: Terminate pidstat
+#        if: ${{ always() }}
+#        run: kill -INT $PIDSTAT_PID
+#
+#      - name: Get max RAM usage by Java and Z3
+#        if: ${{ always() }}
+#        shell: bash
+#        env:
+#          JAVA_WARNING_THRESHOLD_GB: 4.5
+#          JAVA_FAILURE_THRESHOLD_GB: 5.5
+#          Z3_WARNING_THRESHOLD_GB: 0.5
+#          Z3_FAILURE_THRESHOLD_GB: 1
+#        # awk is used to perform the computations such that the computations are performed with floating point precision
+#        # we transform bash variables into awk variables to not cause problems with bash's variable substitution
+#        # after computing the memory usage (in KB) a few more computations are performed. At the very end, all (local)
+#        # environment variables are exported to `$GITHUB_ENV` such that they will be available in the next step as well.
+#        run: |
+#          function getMaxMemOfProcessInKb {
+#            # $1 is the regex used to filter lines by the 10th column
+#            # - we use variable `max` to keep track of the maximum
+#            # - `curCount` stores the sum of all processes with the given name for a particular timestamp
+#            # - note that looking at the timestamp is only an approximation: pidstat might report different timestamps in the
+#            #   same "block" of outputs (i.e. the report every second)
+#            # - `$8` refers to the 8th column in the file which corresponds to the column storing RAM (in kb)
+#            # - `java$` matches only lines that end in the string 'java'
+#            # - variable `max` is printed after processing the entire file
+#            local result=$(awk -v processName=$1 -v max=0 -v curCount=0 -v curTimestamp=0 'processName~$10 {if(curTimestamp==$1){curCount=curCount+$8}else{curTimestamp=$1; curCount=$8}; if(curCount>max){max=curCount}}END{print max}' pidstat.txt)
+#            echo $result
+#          }
+#          function convertKbToGb {
+#            # $1 is the value [KB] that should be converted
+#            local result=$(awk -v value=$1 'BEGIN {print value / 1000 / 1000}')
+#            echo $result
+#          }
+#          function getLevel {
+#            # $1 is the value that should be comparing against the thresholds
+#            # $2 is the threshold causing a warning
+#            # $3 is the threshold causing an error
+#            # writes `notice`, `warning` or `failure` to standard output
+#            local result=$(awk -v value=$1 -v warnThres=$2 -v errThres=$3 'BEGIN { print (value>errThres) ? "failure" : (value>warnThres) ? "warning" : "notice"}')
+#            echo $result
+#          }
+#          MAX_JAVA_KB=$(getMaxMemOfProcessInKb 'java$')
+#          MAX_Z3_KB=$(getMaxMemOfProcessInKb 'z3$')
+#          MAX_JAVA_GB=$(convertKbToGb $MAX_JAVA_KB)
+#          MAX_Z3_GB=$(convertKbToGb $MAX_Z3_KB)
+#          JAVA_LEVEL=$(getLevel $MAX_JAVA_GB ${{ env.JAVA_WARNING_THRESHOLD_GB }} ${{ env.JAVA_FAILURE_THRESHOLD_GB }})
+#          Z3_LEVEL=$(getLevel $MAX_Z3_GB ${{ env.Z3_WARNING_THRESHOLD_GB }} ${{ env.Z3_FAILURE_THRESHOLD_GB }})
+#          if [[ "$JAVA_LEVEL" = "failure" || "$Z3_LEVEL" = "failure" ]]
+#          then
+#            CONCLUSION="failure"
+#          else
+#            CONCLUSION="success"
+#          fi
+#          echo "MAX_JAVA_GB=$MAX_JAVA_GB" >> $GITHUB_ENV
+#          echo "MAX_Z3_GB=$MAX_Z3_GB" >> $GITHUB_ENV
+#          echo "JAVA_LEVEL=$JAVA_LEVEL" >> $GITHUB_ENV
+#          echo "Z3_LEVEL=$Z3_LEVEL" >> $GITHUB_ENV
+#          echo "CONCLUSION=$CONCLUSION" >> $GITHUB_ENV
+#        working-directory: gobra
 
       - name: Echo
         run: echo ${{ github.event.pull_request.head.repo.full_name }}
 
-      - name: Create annotations
-      #TODO: proper comment
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: LouisBrunner/checks-action@v1.1.2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          name: 'RAM Usage'
-          conclusion: ${{ env.CONCLUSION }}
-          output: |
-            {
-            "title": "RAM Usage",
-            "summary": "Java RAM usage caused a ${{ env.JAVA_LEVEL }}.\nZ3 RAM usage caused a ${{ env.Z3_LEVEL }}."
-            }
-          # the required and optional JSON fields can be found in section "Properties of the `annotations` items" here:
-          # https://docs.github.com/en/rest/reference/checks#create-a-check-run--parameters
-          annotations: |
-            [
-              {
-              "message": "Java used up to ${{ env.MAX_JAVA_GB }}GB RAM",
-              "path": ".github/workflows/test.yml",
-              "start_line": 1,
-              "end_line": 1,
-              "annotation_level": "${{ env.JAVA_LEVEL }}"
-              },
-              {
-              "message": "Z3 used up to ${{ env.MAX_Z3_GB }}GB RAM",
-              "path": ".github/workflows/test.yml",
-              "start_line": 1,
-              "end_line": 1,
-              "annotation_level": "${{ env.Z3_LEVEL }}"
-              }
-            ]
-
-      - name: Upload RAM usage
-      # TODO: check if this needs to be conditional
-        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: actions/upload-artifact@v2
-        with:
-          name: pidstat.txt
-          path: gobra/pidstat.txt
+#      - name: Create annotations
+#      #TODO: proper comment
+#        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+#        uses: LouisBrunner/checks-action@v1.1.2
+#        with:
+#          token: ${{ secrets.GITHUB_TOKEN }}
+#          name: 'RAM Usage'
+#          conclusion: ${{ env.CONCLUSION }}
+#          output: |
+#            {
+#            "title": "RAM Usage",
+#            "summary": "Java RAM usage caused a ${{ env.JAVA_LEVEL }}.\nZ3 RAM usage caused a ${{ env.Z3_LEVEL }}."
+#            }
+#          # the required and optional JSON fields can be found in section "Properties of the `annotations` items" here:
+#          # https://docs.github.com/en/rest/reference/checks#create-a-check-run--parameters
+#          annotations: |
+#            [
+#              {
+#              "message": "Java used up to ${{ env.MAX_JAVA_GB }}GB RAM",
+#              "path": ".github/workflows/test.yml",
+#              "start_line": 1,
+#              "end_line": 1,
+#              "annotation_level": "${{ env.JAVA_LEVEL }}"
+#              },
+#              {
+#              "message": "Z3 used up to ${{ env.MAX_Z3_GB }}GB RAM",
+#              "path": ".github/workflows/test.yml",
+#              "start_line": 1,
+#              "end_line": 1,
+#              "annotation_level": "${{ env.Z3_LEVEL }}"
+#              }
+#            ]
+#
+#      - name: Upload RAM usage
+#      # TODO: check if this needs to be conditional
+#        if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: pidstat.txt
+#          path: gobra/pidstat.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,9 +102,9 @@ jobs:
       #   # run: pidstat 1 -r -p ALL --human -e java -Xss128m -XshowSettings:vm -cp target/scala-2.13/gobra-test.jar -Dlogback.configurationFile=conf/logback.xml -DGOBRATESTS_REGRESSIONS_DIR=src/test/resources/regressions org.scalatest.run viper.gobra.GobraTests
       #   working-directory: gobra
 
-      - name: Execute all tests
-        run: sbt test
-        working-directory: gobra
+#      - name: Execute all tests
+#        run: sbt test
+#        working-directory: gobra
 
       - name: Terminate pidstat
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo "the full name is ${{ github.event.pull_request.head.repo }}"
+        run: echo "the full name is ${{ github.event.pull_request.head.repo.full_name }}"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,7 +168,7 @@ jobs:
 #        working-directory: gobra
 
       - name: Echo
-        run: echo "the full name is ${{ github.event.pull_request.head.repo.full_name }}"
+        run: echo "the full name is ${{ github.repository }}"
 
 #      - name: Create annotations
 #      #TODO: proper comment

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -183,7 +183,11 @@ jobs:
         run: |
           echo "::${{ env.JAVA_LEVEL }} file=.github/workflows/test.yml,line=1::Java used up to ${{ env.MAX_JAVA_GB }}GB of RAM"
           echo "::${{ env.Z3_LEVEL }} file=.github/workflows/test.yml,line=1::Z3 used up to ${{ env.MAX_Z3_GB }}GB of RAM"
-          return $([ $CONCLUSION = "success" ]) # the whole step fails when this comparison fails
+          if [ $CONCLUSION = "success" ]
+          then
+            # the whole step fails when this comparison fails
+            false
+          fi
 
       - name: Upload RAM usage
         if: ${{ always() }}


### PR DESCRIPTION
Fixes issue #334. Instead of using `LouisBrunner/checks-action@v1.1.2` to publish the RAM usage annotations, this PR uses Github's [workflow actions](https://docs.github.com/en/enterprise-server@2.22/actions/reference/workflow-commands-for-github-actions), thus circumventing the need for a GITHUB_TOKEN that has write access to the repository. Consequently, PRs originating from forks can now successfully run this step.

One unfortunate consequence of these changes is that all annotations are published either as warnings or errors; there is no way to output an "info" annotation via workflow actions that I am aware of (there is a way to output debug annotations but that has unintended consequences, as described in a comment in the `test.yml` file).

@ArquintL I opted not to have a distinction on the origin of the PR (fork or not). This way, we provide a consistent experience for all PRs and it greatly simplifies our script.

I tested these changes with a PR originating from my fork (#335).