### PR TITLE
Fix issue #341

### DIFF
--- a/src/main/resources/stubs/net/iprawsock.gobra
+++ b/src/main/resources/stubs/net/iprawsock.gobra
@@ -41,7 +41,6 @@ pred (a *IPAddr) Mem() {
     acc(a) && forall i int :: 0 <= i && i < len(a.IP) ==> acc(&(a.IP)[i])
 }
 
-/* (joao) commented due to issue 341 (https://github.com/viperproject/gobra/issues/341)
 (*IPAddr) implements Addr {
 	(e *IPAddr) Network() string {
 		return e.Network()
@@ -51,7 +50,6 @@ pred (a *IPAddr) Mem() {
 		return e.String()
 	}
 }
-*/
 
 // Network returns the address's network name, "ip".
 ensures res == "ip"

--- a/src/main/resources/stubs/net/udpsock.gobra
+++ b/src/main/resources/stubs/net/udpsock.gobra
@@ -34,7 +34,6 @@ pred (a *UDPAddr) Mem() {
     acc(a) && (forall i int :: 0 <= i && i < len(a.IP) ==> acc(&(a.IP)[i]))
 }
 
-/* (joao) commented due to issue 341 (https://github.com/viperproject/gobra/issues/341)
 (*UDPAddr) implements Addr {
 	(e *UDPAddr) Network() string {
 		return e.Network()
@@ -44,7 +43,6 @@ pred (a *UDPAddr) Mem() {
 		return e.String()
 	}
 }
-*/
 
 // Network returns the address's network name, "udp".
 ensures res == "udp"

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -89,7 +89,10 @@ object Desugar {
     val combinedDefinedT = combineTableField(_.definedTypes)
     val combinedMethods = combineTableField(_.definedMethods)
     val combinedMPredicates = combineTableField(_.definedMPredicates)
-    val combinedImplementations = combineTableField(_.interfaceImplementations)
+    val combinedImplementations = {
+      val interfaceImplMaps = desugarers.flatMap(_.interfaceImplementations.toSeq)
+      interfaceImplMaps.groupMapReduce[in.InterfaceT, Set[in.Type]](_._1)(_._2)(_ ++ _)
+    }
     val combinedMemberProxies = computeMemberProxies(combinedMethods.values ++ combinedMPredicates.values, combinedImplementations, combinedDefinedT)
     val combineImpProofPredAliases = combineTableField(_.implementationProofPredicateAliases)
     val table = new in.LookupTable(

--- a/src/test/resources/regressions/issues/000341/pkg1/f1.gobra
+++ b/src/test/resources/regressions/issues/000341/pkg1/f1.gobra
@@ -1,0 +1,28 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg1
+
+import "net"
+
+type HostSVC uint16
+
+pred (h HostSVC) Mem() {
+	true
+}
+
+(HostSVC) implements net.Addr {
+	(e HostSVC) Network() string {
+		return e.Network()
+	}
+
+	(e HostSVC) String() string {
+		return e.String()
+	}
+}
+
+func (h HostSVC) String() string
+
+func (h HostSVC) Network() string {
+	return ""
+}

--- a/src/test/resources/regressions/issues/000341/pkg2/f2.gobra
+++ b/src/test/resources/regressions/issues/000341/pkg2/f2.gobra
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg2
+
+// ##(-I ../)
+
+import (
+  "pkg1"
+)
+
+type SCION struct {
+	SrcIA pkg1.HostSVC
+}


### PR DESCRIPTION
The problem is in the way we combine fields from the different desugarers during Desugaring. In particular, the current way it is implemented may make Gobra "forget" about interface implementations in imported packages.