### PR TITLE
verified termination of PutUint methods in encoding/binary

### DIFF
--- a/src/main/resources/stubs/encoding/binary/binary.gobra
+++ b/src/main/resources/stubs/encoding/binary/binary.gobra
@@ -22,16 +22,19 @@ type ByteOrder interface {
 
 	requires acc(&b[0]) && acc(&b[1])
 	ensures acc(&b[0]) && acc(&b[1])
+	decreases
 	PutUint16(b []byte, uint16)
 
 	requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 	ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
+	decreases
 	PutUint32(b []byte, uint32)
 
 	requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 	requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
 	ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 	ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+	decreases
 	PutUint64(b []byte, uint64)
 
 	pure String() string
@@ -117,6 +120,7 @@ pure func (e littleEndian) Uint16(b []byte) uint16 {
 
 requires acc(&b[0]) && acc(&b[1])
 ensures acc(&b[0]) && acc(&b[1])
+decreases
 func (e littleEndian) PutUint16(b []byte, v uint16) {
 	b[0] = byte(v)
 	b[1] = byte(v >> 8)
@@ -148,6 +152,7 @@ requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
 ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+decreases
 func (e littleEndian) PutUint64(b []byte, v uint64) {
 	b[0] = byte(v)
 	b[1] = byte(v >> 8)
@@ -204,6 +209,7 @@ requires acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 requires acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
 ensures acc(&b[0]) && acc(&b[1]) && acc(&b[2]) && acc(&b[3])
 ensures acc(&b[4]) && acc(&b[5]) && acc(&b[6]) && acc(&b[7])
+decreases
 func (e bigEndian) PutUint64(b []byte, v uint64) {
 	b[0] = byte(v >> 56)
 	b[1] = byte(v >> 48)


### PR DESCRIPTION
Changes:
- The PutUint methods of the interface `ByteOrder` in package `encoding/binary` have been extended with the `decreases` keyword 
