### PR TITLE
Switch from Paths to Sources

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -6,10 +6,10 @@
 
 package viper.gobra
 
-import java.nio.file.{Files, Path}
+import java.nio.file.Paths
 import java.util.concurrent.ExecutionException
-
 import com.typesafe.scalalogging.StrictLogging
+import org.bitbucket.inkytonik.kiama.util.Source
 import viper.gobra.ast.frontend.PPackage
 import viper.gobra.ast.internal.Program
 import viper.gobra.ast.internal.transform.{CGEdgesTerminationTransform, OverflowChecksTransform}
@@ -49,10 +49,10 @@ trait GoVerifier {
   }
 
   def verify(config: Config)(executor: GobraExecutionContext): Future[VerifierResult] = {
-    verify(config.inputFiles, config)(executor)
+    verify(config.inputs, config)(executor)
   }
 
-  protected[this] def verify(input: Vector[Path], config: Config)(executor: GobraExecutionContext): Future[VerifierResult]
+  protected[this] def verify(input: Vector[Source], config: Config)(executor: GobraExecutionContext): Future[VerifierResult]
 }
 
 trait GoIdeVerifier {
@@ -61,7 +61,7 @@ trait GoIdeVerifier {
 
 class Gobra extends GoVerifier with GoIdeVerifier {
 
-  override def verify(input: Vector[Path], config: Config)(executor: GobraExecutionContext): Future[VerifierResult] = {
+  override def verify(input: Vector[Source], config: Config)(executor: GobraExecutionContext): Future[VerifierResult] = {
     // directly declaring the parameter implicit somehow does not work as the compiler is unable to spot the inheritance
     implicit val _executor: GobraExecutionContext = executor
 
@@ -122,8 +122,8 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     * The current config merged with the newly created config is then returned
     */
   def getAndMergeInFileConfig(config: Config): Config = {
-    val inFileConfigs = config.inputFiles.flatMap(path => {
-      val content = Files.readString(path)
+    val inFileConfigs = config.inputs.flatMap(input => {
+      val content = input.content
       val configs = for (m <- inFileConfigRegex.findAllMatchIn(content)) yield m.group(1)
       if (configs.isEmpty) {
         None
@@ -135,7 +135,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
         // modify all relative includeDirs such that they are resolved relatively to the current file:
         val resolvedConfig = inFileConfig.copy(includeDirs = inFileConfig.includeDirs.map(
           // it's important to convert includeDir to a string first as `path` might be a ZipPath and `includeDir` might not
-          includeDir => path.getParent.resolve(includeDir.toString)))
+          includeDir => Paths.get(input.name).getParent.resolve(includeDir.toString)))
         Some(resolvedConfig)
       }
     })
@@ -144,7 +144,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     inFileConfigs.foldLeft(config){ case (oldConfig, fileConfig) => oldConfig.merge(fileConfig) }
   }
 
-  private def performParsing(input: Vector[Path], config: Config): Either[Vector[VerifierError], PPackage] = {
+  private def performParsing(input: Vector[Source], config: Config): Either[Vector[VerifierError], PPackage] = {
     if (config.shouldParse) {
       Parser.parse(input)(config)
     } else {
@@ -177,7 +177,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
 
     if (config.checkOverflows) {
       val result = OverflowChecksTransform.transform(transformed)
-      config.reporter report AppliedInternalTransformsMessage(config.inputFiles.head, () => result)
+      config.reporter report AppliedInternalTransformsMessage(config.inputs.map(_.name), () => result)
       Right(result)
     } else {
       Right(transformed)

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -73,7 +73,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
 
       for {
         parsedPackage <- performParsing(input, finalConfig)
-        typeInfo <- performTypeChecking(parsedPackage, finalConfig)
+        typeInfo <- performTypeChecking(parsedPackage, input, finalConfig)
         program <- performDesugaring(parsedPackage, typeInfo, finalConfig)
         program <- performInternalTransformations(program, finalConfig)
         viperTask <- performViperEncoding(program, finalConfig)
@@ -152,9 +152,9 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     }
   }
 
-  private def performTypeChecking(parsedPackage: PPackage, config: Config): Either[Vector[VerifierError], TypeInfo] = {
+  private def performTypeChecking(parsedPackage: PPackage, input: Vector[Source], config: Config): Either[Vector[VerifierError], TypeInfo] = {
     if (config.shouldTypeCheck) {
-      Info.check(parsedPackage, isMainContext = true)(config)
+      Info.check(parsedPackage, input, isMainContext = true)(config)
     } else {
       Left(Vector())
     }

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -6,12 +6,11 @@
 
 package viper.gobra.ast.frontend
 
-import java.nio.file.Paths
 import org.bitbucket.inkytonik.kiama.rewriting.Rewritable
 import org.bitbucket.inkytonik.kiama.util.Messaging.Messages
 import org.bitbucket.inkytonik.kiama.util._
 import viper.gobra.ast.frontend.PNode.PPkg
-import viper.gobra.frontend.Source.FromFileSource
+import viper.gobra.frontend.Source.TransformableSource
 import viper.gobra.reporting.VerifierError
 import viper.gobra.util.{Decimal, NumBase}
 import viper.silver.ast.{LineColumnPosition, SourcePosition}
@@ -72,11 +71,7 @@ class PositionManager(val positions: Positions) extends Messaging(positions) {
   }
 
   def translate(start: Position, end: Position): SourcePosition = {
-    val path = start.source match {
-      case FileSource(filename, _) => Paths.get(filename)
-      case FromFileSource(path, _) => path
-      case StringSource(_, _) => null // StringSource stores some name but there is no guarantee that it corresponds to a valid file path
-    }
+    val path = start.source.toPath
     new SourcePosition(
       path,
       LineColumnPosition(start.line, start.column),

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -7,12 +7,11 @@
 package viper.gobra.ast.frontend
 
 import java.nio.file.Paths
-
 import org.bitbucket.inkytonik.kiama.rewriting.Rewritable
 import org.bitbucket.inkytonik.kiama.util.Messaging.Messages
 import org.bitbucket.inkytonik.kiama.util._
 import viper.gobra.ast.frontend.PNode.PPkg
-import viper.gobra.frontend.Parser.FromFileSource
+import viper.gobra.frontend.Source.FromFileSource
 import viper.gobra.reporting.VerifierError
 import viper.gobra.util.{Decimal, NumBase}
 import viper.silver.ast.{LineColumnPosition, SourcePosition}
@@ -76,7 +75,7 @@ class PositionManager(val positions: Positions) extends Messaging(positions) {
     val path = start.source match {
       case FileSource(filename, _) => Paths.get(filename)
       case FromFileSource(path, _) => path
-      case _ => ???
+      case StringSource(_, _) => null // StringSource stores some name but there is no guarantee that it corresponds to a valid file path
     }
     new SourcePosition(
       path,

--- a/src/main/scala/viper/gobra/backend/BackendVerifier.scala
+++ b/src/main/scala/viper/gobra/backend/BackendVerifier.scala
@@ -49,7 +49,7 @@ object BackendVerifier {
 
     val verifier = config.backend.create(exePaths)
 
-    val programID = s"_programID_${config.inputFiles.head}"
+    val programID = s"_programID_${config.inputs.map(_.name).mkString("_")}"
 
     val verificationResult = verifier.verify(programID, config.backendConfig, BacktranslatingReporter(config.reporter, task.backtrack, config), task.program)(executor)
 

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -7,16 +7,16 @@
 package viper.gobra.frontend
 
 import java.io.File
-import java.nio.file.{Files, Path}
-
+import java.nio.file.{Files, Path, Paths}
 import ch.qos.logback.classic.{Level, Logger}
 import com.typesafe.scalalogging.StrictLogging
 import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, message, noMessages}
+import org.bitbucket.inkytonik.kiama.util.{FileSource, Source}
 import org.rogach.scallop.{ScallopConf, ScallopOption, listArgConverter, singleArgConverter}
 import org.slf4j.LoggerFactory
 import viper.gobra.backend.{ViperBackend, ViperBackends, ViperVerifierConfig}
 import viper.gobra.GoVerifier
-import viper.gobra.frontend.PackageResolver.{FileResource, RegularImport}
+import viper.gobra.frontend.PackageResolver.RegularImport
 import viper.gobra.reporting.{FileWriterReporter, GobraReporter, StdIOReporter}
 import viper.gobra.util.{TypeBounds, Violation}
 
@@ -25,7 +25,7 @@ object LoggerDefaults {
   val DefaultLevel: Level = Level.INFO
 }
 case class Config(
-                 inputFiles: Vector[Path],
+                 inputs: Vector[Source],
                  moduleName: String = "",
                  includeDirs: Vector[Path] = Vector(),
                  reporter: GobraReporter = StdIOReporter(),
@@ -53,7 +53,7 @@ case class Config(
   def merge(other: Config): Config = {
     // this config takes precedence over other config
     Config(
-      inputFiles = (inputFiles ++ other.inputFiles).distinct,
+      inputs = (inputs ++ other.inputs).distinct,
       moduleName = moduleName,
       includeDirs = (includeDirs ++ other.includeDirs).distinct,
       reporter = reporter,
@@ -237,9 +237,23 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
                     includeOption: ScallopOption[List[File]]): Unit = validateOpt(inputOption, includeOption) { (inputOpt, includeOpt) =>
 
     def checkConversion(input: List[String], moduleName: String, includeDirs: Vector[Path]): Either[String, Vector[Path]] = {
-      val msgs = InputConverter.validate(input)
-      if (msgs.isEmpty) Right(InputConverter.convert(input, moduleName, includeDirs))
-      else Left(s"The following errors have occurred: ${msgs.map(_.label).mkString(",")}")
+      def validateSources(sources: Vector[Source]): Either[Messages, Vector[Path]] = {
+        val (remainingSources, paths) = sources.partitionMap {
+          case FileSource(name, _) => Right(Paths.get(name))
+          case s => Left(s)
+        }
+        if (remainingSources.isEmpty) Right(paths)
+        else Left(message(remainingSources, s"Expected file sources but got ${remainingSources}"))
+      }
+
+      val inputValidationMsgs = InputConverter.validate(input)
+      val paths = for {
+        _ <- if (inputValidationMsgs.isEmpty) Right(()) else Left(inputValidationMsgs)
+        sources = InputConverter.convert(input, moduleName, includeDirs)
+        paths <- validateSources(sources)
+      } yield paths
+
+      paths.left.map(msgs => s"The following errors have occurred: ${msgs.map(_.label).mkString(",")}")
     }
 
     def atLeastOneFile(files: Vector[Path]): Either[String, Unit] = {
@@ -284,7 +298,7 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
   verify()
 
   lazy val includeDirs: Vector[Path] = include.toOption.map(_.map(_.toPath).toVector).getOrElse(Vector())
-  lazy val inputFiles: Vector[Path] = InputConverter.convert(input.toOption.getOrElse(List()), module.getOrElse(""), includeDirs)
+  lazy val inputs: Vector[Source] = InputConverter.convert(input.toOption.getOrElse(List()), module.getOrElse(""), includeDirs)
 
   /** set log level */
 
@@ -316,24 +330,14 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
       }
     }
 
-    def convert(input: List[String], moduleName: String, includeDirs: Vector[Path]): Vector[Path] = {
+    def convert(input: List[String], moduleName: String, includeDirs: Vector[Path]): Vector[Source] = {
       val res = for {
         i <- identifyInput(input).toRight("invalid input")
-        files <- i match {
-          case Right(files) => Right(files)
-          case Left(_) =>
-            for {
-              // look for files in the current directory, i.e. use an empty importPath
-              resolvedResources <- PackageResolver.resolve(RegularImport(""), moduleName, includeDirs)
-              resolvedFiles = resolvedResources.flatMap({
-                case fileResource: FileResource => Some(fileResource.path)
-                case _ => None
-              })
-              // we do not need the underlying resources anymore as we are only using FileResources:
-              _ = resolvedResources.foreach(_.close())
-            } yield resolvedFiles
+        sources <- i match {
+          case Right(filePaths) => Right(filePaths.map(f => FileSource(f.toString)))
+          case Left(_) => PackageResolver.resolveSources(RegularImport(""), moduleName, includeDirs)
         }
-      } yield files
+      } yield sources
       assert(isInputOptional || res.isRight, s"validate function did not catch this problem: '${res.swap.getOrElse(None)}'")
       res.getOrElse(Vector())
     }
@@ -370,7 +374,7 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
   }
 
   lazy val config: Config = Config(
-    inputFiles = inputFiles,
+    inputs = inputs,
     moduleName = module(),
     includeDirs = includeDirs,
     reporter = FileWriterReporter(

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -38,7 +38,7 @@ object Desugar {
     val mainDesugarer = new Desugarer(pkg.positions, info)
     // combine all desugared results into one Viper program:
     val internalProgram = combine(mainDesugarer, mainDesugarer.packageD(pkg), importedPrograms)
-    config.reporter report DesugaredMessage(config.inputFiles.head, () => internalProgram)
+    config.reporter report DesugaredMessage(config.inputs.map(_.name), () => internalProgram)
     internalProgram
   }
 

--- a/src/main/scala/viper/gobra/frontend/Gobrafier.scala
+++ b/src/main/scala/viper/gobra/frontend/Gobrafier.scala
@@ -6,7 +6,8 @@
 
 package viper.gobra.frontend
 
-import viper.gobra.frontend.Parser.FromFileSource
+import org.bitbucket.inkytonik.kiama.util.Source
+import viper.gobra.frontend.Source.TransformableSource
 import viper.gobra.util.Constants
 
 import scala.util.matching.Regex
@@ -91,9 +92,11 @@ object Gobrafier {
     * Converts a .go program with annotations in comments to a .gobra program.
     * Does not apply any transformations if a .gobra program is provided.
     */
-  def gobrafy(source: FromFileSource): FromFileSource = source match {
-    case source if source.path.toString.endsWith(s".${PackageResolver.goExtension}") => FromFileSource(source.path, gobrafy(source.content))
-    case source => source
+  def gobrafy(source: Source): Source = {
+    def isGoFile(path: String): Boolean = path.endsWith(s".${PackageResolver.goExtension}")
+
+    if (isGoFile(source.name)) source.transformContent(gobrafy(source.content))
+    else source // is not a go file, keep the source unchanged
   }
 
   def gobrafy(content: String): String = {
@@ -214,7 +217,6 @@ object Gobrafier {
       val functionName = m.group(1)
       val actualArgs = m.group(2)
       val ghostArgs = m.group(3)
-      println(s"ghostArgs: $ghostArgs")
 
       functionName +
       parens(

--- a/src/main/scala/viper/gobra/frontend/Source.scala
+++ b/src/main/scala/viper/gobra/frontend/Source.scala
@@ -10,7 +10,8 @@ import org.bitbucket.inkytonik.kiama.util.{FileSource, Filenames, IO, Source, St
 import viper.gobra.util.Violation
 
 import java.io.Reader
-import java.nio.file.{Files, Path, Paths}
+import java.net.URI
+import java.nio.file.{FileSystem, Files, LinkOption, Path, Paths, WatchEvent, WatchKey, WatchService}
 import scala.io.BufferedSource
 
 /**
@@ -23,6 +24,20 @@ object Source {
       case FileSource(name, _) => FromFileSource(Paths.get(name), newContent)
       case FromFileSource(path, _) => FromFileSource(path, newContent)
       case _ => Violation.violation(s"encountered unknown source ${source.name}")
+    }
+
+    def toPath: Path = source match {
+      case FileSource(filename, _) => Paths.get(filename)
+      case FromFileSource(path, _) => path
+      case StringSource(_, _) =>
+        // StringSource stores some name but there is no guarantee that it corresponds to a valid file path
+        // there are the following ideas:
+        // - create a file adhoc if a filepath is really necessary (in the spirit of `StringSource.useAsFile`)
+        // - adapt Silver to not require a Path object but some abstraction
+        // - create an implementation implementing Path that simply stores the StringSource and leaves all functions
+        //    unimplemented. This works as long as nobody relies on any operations available for paths. It's also bad
+        //    style but at least any use fails in an understandable way (as opposed to simply returning `null` here)
+      ???
     }
   }
 
@@ -47,11 +62,13 @@ object Source {
     }
   }
 
-  def getSource(path: Path): FromFileSource = {
-    val inputStream = Files.newInputStream(path)
-    val bufferedSource = new BufferedSource(inputStream)
-    val content = bufferedSource.mkString
-    bufferedSource.close()
-    FromFileSource(path, content)
+  object FromFileSource {
+    def apply(path: Path): FromFileSource = {
+      val inputStream = Files.newInputStream(path)
+      val bufferedSource = new BufferedSource(inputStream)
+      val content = bufferedSource.mkString
+      bufferedSource.close()
+      FromFileSource(path, content)
+    }
   }
 }

--- a/src/main/scala/viper/gobra/frontend/Source.scala
+++ b/src/main/scala/viper/gobra/frontend/Source.scala
@@ -1,0 +1,57 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2021 ETH Zurich.
+
+package viper.gobra.frontend
+
+import org.bitbucket.inkytonik.kiama.util.{FileSource, Filenames, IO, Source, StringSource}
+import viper.gobra.util.Violation
+
+import java.io.Reader
+import java.nio.file.{Files, Path, Paths}
+import scala.io.BufferedSource
+
+/**
+  * Contains several utility functions for managing Sources, i.e. inputs to Gobra
+  */
+object Source {
+  implicit class TransformableSource[S <: Source](source: S) {
+    def transformContent(newContent: String): Source = source match {
+      case StringSource(_, name) => StringSource(newContent, name)
+      case FileSource(name, _) => FromFileSource(Paths.get(name), newContent)
+      case FromFileSource(path, _) => FromFileSource(path, newContent)
+      case _ => Violation.violation(s"encountered unknown source ${source.name}")
+    }
+  }
+
+  /**
+    * Represents a source that originates from a file (stored at `path`) but whose content has been transformed (and is now `content`)
+    * @param path original file's path
+    * @param content source's content after applying some transformations
+    */
+  case class FromFileSource(path: Path, content: String) extends Source {
+    override val name: String = path.toString
+    val shortName : Option[String] = Some(Filenames.dropCurrentPath(name))
+
+    def reader: Reader = IO.stringreader(content)
+
+    def useAsFile[T](fn : String => T) : T = {
+      // copied from StringSource
+      val filename = Filenames.makeTempFilename(name)
+      IO.createFile(filename, content)
+      val t = fn(filename)
+      IO.deleteFile(filename)
+      t
+    }
+  }
+
+  def getSource(path: Path): FromFileSource = {
+    val inputStream = Files.newInputStream(path)
+    val bufferedSource = new BufferedSource(inputStream)
+    val content = bufferedSource.mkString
+    bufferedSource.close()
+    FromFileSource(path, content)
+  }
+}

--- a/src/main/scala/viper/gobra/frontend/info/Info.scala
+++ b/src/main/scala/viper/gobra/frontend/info/Info.scala
@@ -7,6 +7,7 @@
 package viper.gobra.frontend.info
 
 import org.bitbucket.inkytonik.kiama.relation.Tree
+import org.bitbucket.inkytonik.kiama.util.Source
 import viper.gobra.ast.frontend.{PNode, PPackage}
 import viper.gobra.frontend.Config
 import viper.gobra.frontend.PackageResolver.AbstractImport
@@ -64,7 +65,7 @@ object Info {
     def getExternalErrors: Vector[VerifierError] = contextMap.values.collect { case Left(errs) => errs }.flatten.toVector
   }
 
-  def check(pkg: PPackage, context: Context = new Context, isMainContext: Boolean = false)(config: Config): Either[Vector[VerifierError], TypeInfo with ExternalTypeInfo] = {
+  def check(pkg: PPackage, sources: Vector[Source], context: Context = new Context, isMainContext: Boolean = false)(config: Config): Either[Vector[VerifierError], TypeInfo with ExternalTypeInfo] = {
     val tree = new GoTree(pkg)
     //    println(program.declarations.head)
     //    println("-------------------")
@@ -72,9 +73,10 @@ object Info {
     val info = new TypeInfoImpl(tree, context, isMainContext)(config: Config)
 
     val errors = info.errors
-    config.reporter report TypeCheckDebugMessage(config.inputs.map(_.name), () => pkg, () => getDebugInfo(pkg, info))
+    // use `sources` instead of `context.inputs` for reporting such that the message is correctly attributed in case of imports
+    config.reporter report TypeCheckDebugMessage(sources.map(_.name), () => pkg, () => getDebugInfo(pkg, info))
     if (errors.isEmpty) {
-      config.reporter report TypeCheckSuccessMessage(config.inputs.map(_.name), () => pkg, () => getErasedGhostCode(pkg, info), () => getGoifiedGhostCode(pkg, info))
+      config.reporter report TypeCheckSuccessMessage(sources.map(_.name), () => pkg, () => getErasedGhostCode(pkg, info), () => getGoifiedGhostCode(pkg, info))
       Right(info)
     } else {
       // remove duplicates as errors related to imported packages might occur multiple times
@@ -84,7 +86,7 @@ object Info {
       // however, the duplicate removal should happen after translation so that the error position is correctly
       // taken into account for the equality check.
       val typeErrors = pkg.positions.translate(errors, TypeError).distinct
-      config.reporter report TypeCheckFailureMessage(config.inputs.map(_.name), pkg.packageClause.id.name, () => pkg, typeErrors)
+      config.reporter report TypeCheckFailureMessage(sources.map(_.name), pkg.packageClause.id.name, () => pkg, typeErrors)
       Left(typeErrors)
     }
   }

--- a/src/main/scala/viper/gobra/frontend/info/Info.scala
+++ b/src/main/scala/viper/gobra/frontend/info/Info.scala
@@ -72,9 +72,9 @@ object Info {
     val info = new TypeInfoImpl(tree, context, isMainContext)(config: Config)
 
     val errors = info.errors
-    config.reporter report TypeCheckDebugMessage(config.inputFiles.head, () => pkg, () => getDebugInfo(pkg, info))
+    config.reporter report TypeCheckDebugMessage(config.inputs.map(_.name), () => pkg, () => getDebugInfo(pkg, info))
     if (errors.isEmpty) {
-      config.reporter report TypeCheckSuccessMessage(config.inputFiles.head, () => pkg, () => getErasedGhostCode(pkg, info), () => getGoifiedGhostCode(pkg, info))
+      config.reporter report TypeCheckSuccessMessage(config.inputs.map(_.name), () => pkg, () => getErasedGhostCode(pkg, info), () => getGoifiedGhostCode(pkg, info))
       Right(info)
     } else {
       // remove duplicates as errors related to imported packages might occur multiple times
@@ -84,7 +84,7 @@ object Info {
       // however, the duplicate removal should happen after translation so that the error position is correctly
       // taken into account for the equality check.
       val typeErrors = pkg.positions.translate(errors, TypeError).distinct
-      config.reporter report TypeCheckFailureMessage(config.inputFiles.head, pkg.packageClause.id.name, () => pkg, typeErrors)
+      config.reporter report TypeCheckFailureMessage(config.inputs.map(_.name), pkg.packageClause.id.name, () => pkg, typeErrors)
       Left(typeErrors)
     }
   }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -224,18 +224,16 @@ trait MemberResolution { this: TypeInfoImpl =>
 
   def tryPackageLookup(importTarget: AbstractImport, id: PIdnUse, errNode: PNode): Option[(Entity, Vector[MemberPath])] = {
     def parseAndTypeCheck(importTarget: AbstractImport): Either[Vector[VerifierError], ExternalTypeInfo] = {
-      val pkgFiles = PackageResolver.resolve(importTarget, config.moduleName, config.includeDirs).getOrElse(Vector())
+      val pkgSources = PackageResolver.resolveSources(importTarget, config.moduleName, config.includeDirs).getOrElse(Vector())
       val res = for {
-        nonEmptyPkgFiles <- if (pkgFiles.isEmpty)
+        nonEmptyPkgSources <- if (pkgSources.isEmpty)
           Left(Vector(NotFoundError(s"No source files for package '$importTarget' found")))
-          else Right(pkgFiles)
-        parsedProgram <- Parser.parse(nonEmptyPkgFiles.map(_.path), specOnly = true)(config)
+          else Right(pkgSources)
+        parsedProgram <- Parser.parse(nonEmptyPkgSources, specOnly = true)(config)
         // TODO maybe don't check whole file but only members that are actually used/imported
         // By parsing only declarations and their specification, there shouldn't be much left to type check anyways
         // Info.check would probably need some restructuring to type check only certain members
         info <- Info.check(parsedProgram, context)(config)
-        // we do no longer need them, so we close them:
-        _ = pkgFiles.map(_.close())
       } yield info
       res.fold(
         errs => context.addErrenousPackage(importTarget, errs),

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -233,7 +233,7 @@ trait MemberResolution { this: TypeInfoImpl =>
         // TODO maybe don't check whole file but only members that are actually used/imported
         // By parsing only declarations and their specification, there shouldn't be much left to type check anyways
         // Info.check would probably need some restructuring to type check only certain members
-        info <- Info.check(parsedProgram, context)(config)
+        info <- Info.check(parsedProgram, nonEmptyPkgSources, context)(config)
       } yield info
       res.fold(
         errs => context.addErrenousPackage(importTarget, errs),

--- a/src/main/scala/viper/gobra/reporting/DefaultMessageBackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/DefaultMessageBackTranslator.scala
@@ -20,8 +20,8 @@ class DefaultMessageBackTranslator(backTrackInfo: BackTrackInfo, config: Config)
   private def defaultTranslate: PartialFunction[Message, GobraMessage] = {
     case m: OverallSuccessMessage => GobraOverallSuccessMessage(m.verifier)
     case m: OverallFailureMessage => GobraOverallFailureMessage(m.verifier, translate(m.result))
-    case EntitySuccessMessage(verifier, Source(info), _, _) => GobraEntitySuccessMessage(verifier, info)
-    case EntityFailureMessage(verifier, Source(info), _, result, _) => GobraEntityFailureMessage(verifier, info, translate(result))
+    case m@ EntitySuccessMessage(verifier, Source(info), _, _) => GobraEntitySuccessMessage(verifier, m.concerning, info)
+    case m@ EntityFailureMessage(verifier, Source(info), _, result, _) => GobraEntityFailureMessage(verifier, m.concerning, info, translate(result))
   }
 
   private def translate(result: VerificationResult): VerifierResult =

--- a/src/main/scala/viper/gobra/reporting/Message.scala
+++ b/src/main/scala/viper/gobra/reporting/Message.scala
@@ -64,7 +64,7 @@ case class GobraEntityFailureMessage(verifier: String, concerning: Source.Verifi
     s"failure=${result.toString})"
 }
 
-case class PreprocessedInputMessage(input: Path, preprocessedContent: () => String) extends GobraMessage {
+case class PreprocessedInputMessage(input: String, preprocessedContent: () => String) extends GobraMessage {
   override val name: String = s"preprocessed_input_message"
 
   override def toString: String = s"preprocessed_input_message(" +
@@ -72,7 +72,7 @@ case class PreprocessedInputMessage(input: Path, preprocessedContent: () => Stri
     s"content=${preprocessedContent()})"
 }
 
-case class ParsedInputMessage(input: Path, ast: () => PProgram) extends GobraMessage {
+case class ParsedInputMessage(input: String, ast: () => PProgram) extends GobraMessage {
   override val name: String = s"parsed_input_message"
 
   override def toString: String = s"parsed_input_message(" +
@@ -90,58 +90,58 @@ case class ParserErrorMessage(input: Path, result: Vector[ParserError]) extends 
 
 sealed trait TypeCheckMessage extends GobraMessage {
   override val name: String = s"type_check_message"
-  val input: Path
+  val inputs: Vector[String]
   val ast: () => PPackage
 
   override def toString: String = s"type_check_message(" +
-    s"file=${input})"
+    s"files=${inputs})"
 }
 
-case class TypeCheckSuccessMessage(input: Path, ast: () => PPackage, erasedGhostCode: () => String, goifiedGhostCode: () => String) extends TypeCheckMessage {
+case class TypeCheckSuccessMessage(inputs: Vector[String], ast: () => PPackage, erasedGhostCode: () => String, goifiedGhostCode: () => String) extends TypeCheckMessage {
   override val name: String = s"type_check_success_message"
 
   override def toString: String = s"type_check_success_message(" +
-    s"file=${input})"
+    s"files=${inputs})"
 }
 
-case class TypeCheckFailureMessage(input: Path, packageName: PPkg, ast: () => PPackage, result: Vector[VerifierError]) extends TypeCheckMessage {
+case class TypeCheckFailureMessage(inputs: Vector[String], packageName: PPkg, ast: () => PPackage, result: Vector[VerifierError]) extends TypeCheckMessage {
   override val name: String = s"type_check_failure_message"
 
   override def toString: String = s"type_check_failure_message(" +
-    s"file=${input}, " +
+    s"files=${inputs}, " +
     s"package=$packageName, " +
     s"failures=${result.map(_.toString).mkString(",")})"
 }
 
-case class TypeCheckDebugMessage(input: Path, ast: () => PPackage, debugTypeInfo: () => String) extends TypeCheckMessage {
+case class TypeCheckDebugMessage(inputs: Vector[String], ast: () => PPackage, debugTypeInfo: () => String) extends TypeCheckMessage {
   override val name: String = s"type_check_debug_message"
 
   override def toString: String = s"type_check_debug_message(" +
-    s"file=${input}), " +
+    s"files=${inputs}), " +
     s"debugInfo=${debugTypeInfo()})"
 }
 
-case class DesugaredMessage(input: Path, internal: () => in.Program) extends GobraMessage {
+case class DesugaredMessage(inputs: Vector[String], internal: () => in.Program) extends GobraMessage {
   override val name: String = s"desugared_message"
 
   override def toString: String = s"desugared_message(" +
-    s"file=${input}, " +
+    s"files=${inputs}, " +
     s"internal=${internal().formatted})"
 }
 
-case class AppliedInternalTransformsMessage(input: Path, internal: () => in.Program) extends GobraMessage {
+case class AppliedInternalTransformsMessage(inputs: Vector[String], internal: () => in.Program) extends GobraMessage {
   override val name: String = s"transform_message"
 
   override def toString: String = s"transform_message(" +
-    s"file=${input}, " +
+    s"files=${inputs}, " +
     s"internal=${internal().formatted})"
 }
 
-case class GeneratedViperMessage(input: Path, vprAst: () => vpr.Program, backtrack: () => BackTranslator.BackTrackInfo) extends GobraMessage {
+case class GeneratedViperMessage(inputs: Vector[String], vprAst: () => vpr.Program, backtrack: () => BackTranslator.BackTrackInfo) extends GobraMessage {
   override val name: String = s"generated_viper_message"
 
   override def toString: String = s"generated_viper_message(" +
-    s"file=${input}, " +
+    s"files=${inputs}, " +
     s"vprFormated=$vprAstFormatted)"
 
   lazy val vprAstFormatted: String = silver.ast.pretty.FastPrettyPrinter.pretty(vprAst())

--- a/src/main/scala/viper/gobra/reporting/Message.scala
+++ b/src/main/scala/viper/gobra/reporting/Message.scala
@@ -7,10 +7,10 @@
 package viper.gobra.reporting
 
 import java.nio.file.Path
-
 import viper.gobra.ast.frontend.PNode.PPkg
 import viper.gobra.ast.frontend.{PPackage, PProgram}
 import viper.gobra.ast.{internal => in}
+import viper.gobra.reporting.Source.Verifier
 import viper.gobra.reporting.VerifierResult.Success
 import viper.silver
 import viper.silver.{ast => vpr}
@@ -46,7 +46,12 @@ case class GobraOverallFailureMessage(verifier: String, result: VerifierResult) 
     s"failure=${result.toString})"
 }
 
-case class GobraEntitySuccessMessage(verifier: String, concerning: Source.Verifier.Info) extends GobraVerificationResultMessage {
+sealed trait GobraEntityResultMessage extends GobraVerificationResultMessage {
+  val entity: vpr.Member
+  val concerning: Source.Verifier.Info
+}
+
+case class GobraEntitySuccessMessage(verifier: String, entity: vpr.Member, concerning: Source.Verifier.Info) extends GobraEntityResultMessage {
   override val name: String = s"entity_success_message"
   val result: VerifierResult = Success
 
@@ -55,7 +60,7 @@ case class GobraEntitySuccessMessage(verifier: String, concerning: Source.Verifi
     s"concerning=${concerning.toString})"
 }
 
-case class GobraEntityFailureMessage(verifier: String, concerning: Source.Verifier.Info, result: VerifierResult) extends GobraVerificationResultMessage {
+case class GobraEntityFailureMessage(verifier: String, entity: vpr.Member, concerning: Source.Verifier.Info, result: VerifierResult) extends GobraEntityResultMessage {
   override val name: String = s"entity_failure_message"
 
   override def toString: String = s"entity_failure_message(" +

--- a/src/main/scala/viper/gobra/reporting/Reporter.scala
+++ b/src/main/scala/viper/gobra/reporting/Reporter.scala
@@ -7,12 +7,11 @@
 package viper.gobra.reporting
 
 import java.nio.charset.StandardCharsets.UTF_8
-import java.nio.file.Path
-
+import java.nio.file.Paths
 import ch.qos.logback.classic.Level
 import org.apache.commons.io.FileUtils
 import viper.gobra.frontend.LoggerDefaults
-import viper.gobra.util.OutputUtil
+import viper.gobra.util.{OutputUtil, Violation}
 
 trait GobraReporter {
   val name: String
@@ -41,20 +40,26 @@ case class FileWriterReporter(name: String = "filewriter_reporter",
                               printInternal: Boolean = false,
                               printVpr: Boolean = false) extends GobraReporter {
   override def report(msg: GobraMessage): Unit = msg match {
-    case ParsedInputMessage(file, program) if unparse => write(file, "unparsed", program().formatted)
-    case TypeCheckSuccessMessage(file, _, erasedGhostCode, goifiedGhostCode) =>
-      if (eraseGhost) write(file, "ghostLess", erasedGhostCode())
-      if (goify) write(file, "go", goifiedGhostCode())
-    case TypeCheckDebugMessage(file, _, debugTypeInfo) if debug => write(file, "debugType", debugTypeInfo())
-    case DesugaredMessage(file, internal) if printInternal => write(file, "internal", internal().formatted)
-    case AppliedInternalTransformsMessage(file, internal) if printInternal => write(file, "internal", internal().formatted)
-    case m@GeneratedViperMessage(file, _, _) if printVpr => write(file, "vpr", m.vprAstFormatted)
+    case ParsedInputMessage(input, program) if unparse => write(input, "unparsed", program().formatted)
+    case TypeCheckSuccessMessage(inputs, _, erasedGhostCode, goifiedGhostCode) =>
+      if (eraseGhost) write(inputs, "ghostLess", erasedGhostCode())
+      if (goify) write(inputs, "go", goifiedGhostCode())
+    case TypeCheckDebugMessage(inputs, _, debugTypeInfo) if debug => write(inputs, "debugType", debugTypeInfo())
+    case DesugaredMessage(inputs, internal) if printInternal => write(inputs, "internal", internal().formatted)
+    case AppliedInternalTransformsMessage(inputs, internal) if printInternal => write(inputs, "internal", internal().formatted)
+    case m@GeneratedViperMessage(inputs, _, _) if printVpr => write(inputs, "vpr", m.vprAstFormatted)
     case CopyrightReport(text) => println(text)
     case _ => // ignore
   }
 
-  private def write(input: Path, fileExt: String, content: String): Unit = {
-    val outputFile = OutputUtil.postfixFile(input, fileExt)
+  private def write(inputs: Vector[String], fileExt: String, content: String): Unit = {
+    // this message belongs to multiple inputs. We simply pick the first one for the resulting file's name
+    Violation.violation(inputs.nonEmpty, s"expected at least one file path for which the following message was reported: '$content''")
+    write(inputs.head, fileExt, content)
+  }
+
+  private def write(input: String, fileExt: String, content: String): Unit = {
+    val outputFile = OutputUtil.postfixFile(Paths.get(input), fileExt)
     try {
       FileUtils.writeStringToFile(outputFile.toFile, content, UTF_8)
     } catch {

--- a/src/main/scala/viper/gobra/translator/Translator.scala
+++ b/src/main/scala/viper/gobra/translator/Translator.scala
@@ -37,7 +37,7 @@ object Translator {
       case (t, transformer) => transformer.transform(t)
     }
 
-    config.reporter report GeneratedViperMessage(config.inputFiles.head, () => transformedTask.program, () => transformedTask.backtrack)
+    config.reporter report GeneratedViperMessage(config.inputs.map(_.name), () => transformedTask.program, () => transformedTask.backtrack)
     transformedTask
   }
 

--- a/src/test/scala/viper/gobra/BenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/BenchmarkTests.scala
@@ -8,7 +8,7 @@ package viper.gobra
 
 import java.nio.file.Path
 import org.scalatest.{ConfigMap, DoNotDiscover}
-import viper.gobra.frontend.{Config, PackageResolver}
+import viper.gobra.frontend.{Config, PackageResolver, Source}
 import viper.gobra.reporting.{NoopReporter, VerifierError, VerifierResult}
 import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
 import viper.silver.ast.{NoPosition, Position}
@@ -61,7 +61,7 @@ trait GobraFrontendForTesting extends Frontend {
   override def init(verifier: Verifier): Unit = () // ignore verifier argument as we reuse the Gobra / Parser / TypeChecker / etc. instances for all tests
 
   override def reset(files: Seq[Path]): Unit =
-    config = Some(Config(inputFiles = files.toVector, reporter = NoopReporter, z3Exe = z3Exe))
+    config = Some(Config(inputs = files.toVector.map(Source.getSource), reporter = NoopReporter, z3Exe = z3Exe))
 
   def gobraResult: VerifierResult
 

--- a/src/test/scala/viper/gobra/BenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/BenchmarkTests.scala
@@ -8,7 +8,8 @@ package viper.gobra
 
 import java.nio.file.Path
 import org.scalatest.{ConfigMap, DoNotDiscover}
-import viper.gobra.frontend.{Config, PackageResolver, Source}
+import viper.gobra.frontend.Source.FromFileSource
+import viper.gobra.frontend.{Config, PackageResolver}
 import viper.gobra.reporting.{NoopReporter, VerifierError, VerifierResult}
 import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
 import viper.silver.ast.{NoPosition, Position}
@@ -61,7 +62,7 @@ trait GobraFrontendForTesting extends Frontend {
   override def init(verifier: Verifier): Unit = () // ignore verifier argument as we reuse the Gobra / Parser / TypeChecker / etc. instances for all tests
 
   override def reset(files: Seq[Path]): Unit =
-    config = Some(Config(inputs = files.toVector.map(Source.getSource), reporter = NoopReporter, z3Exe = z3Exe))
+    config = Some(Config(inputs = files.toVector.map(FromFileSource(_)), reporter = NoopReporter, z3Exe = z3Exe))
 
   def gobraResult: VerifierResult
 

--- a/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
@@ -106,7 +106,8 @@ class DetailedBenchmarkTests extends BenchmarkTests {
     private val typeChecking: NextStep[PPackage, (PPackage, TypeInfo), Vector[VerifierError]] =
       NextStep("type-checking", parsing, (parsedPackage: PPackage) => {
         assert(config.isDefined)
-        Info.check(parsedPackage)(config.get).map(typeInfo => (parsedPackage, typeInfo))
+        val c = config.get
+        Info.check(parsedPackage, c.inputs)(c).map(typeInfo => (parsedPackage, typeInfo))
       })
 
     private val desugaring: NextStep[(PPackage, TypeInfo), Program, Vector[VerifierError]] =

--- a/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
@@ -100,7 +100,7 @@ class DetailedBenchmarkTests extends BenchmarkTests {
     private val parsing = InitialStep("parsing", () => {
       assert(config.isDefined)
       val c = config.get
-      Parser.parse(c.inputFiles)(c)
+      Parser.parse(c.inputs)(c)
     })
 
     private val typeChecking: NextStep[PPackage, (PPackage, TypeInfo), Vector[VerifierError]] =
@@ -120,7 +120,7 @@ class DetailedBenchmarkTests extends BenchmarkTests {
       val c = config.get
       if (c.checkOverflows) {
         val result = OverflowChecksTransform.transform(program)
-        c.reporter report AppliedInternalTransformsMessage(c.inputFiles.head, () => result)
+        c.reporter report AppliedInternalTransformsMessage(c.inputs.map(_.name), () => result)
         Right(result)
       } else {
         Right(program)

--- a/src/test/scala/viper/gobra/GobraPackageTests.scala
+++ b/src/test/scala/viper/gobra/GobraPackageTests.scala
@@ -12,7 +12,8 @@ import ch.qos.logback.classic.Level
 import org.bitbucket.inkytonik.kiama.util.Source
 import org.rogach.scallop.exceptions.ValidationFailure
 import org.rogach.scallop.throwError
-import viper.gobra.frontend.{Config, ScallopGobraConfig, Source}
+import viper.gobra.frontend.Source.FromFileSource
+import viper.gobra.frontend.{Config, ScallopGobraConfig}
 import viper.gobra.reporting.{NoopReporter, ParserError}
 import viper.gobra.reporting.VerifierResult.{Failure, Success}
 import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
@@ -65,7 +66,7 @@ class GobraPackageTests extends GobraTests {
         val config = Config(
           logLevel = Level.INFO,
           reporter = NoopReporter,
-          inputs = input.files.toVector.map(Source.getSource),
+          inputs = input.files.toVector.map(FromFileSource(_)),
           includeDirs = Vector(currentDir),
           checkConsistency = true,
           z3Exe = z3Exe

--- a/src/test/scala/viper/gobra/GobraPackageTests.scala
+++ b/src/test/scala/viper/gobra/GobraPackageTests.scala
@@ -8,11 +8,11 @@ package viper.gobra
 
 import java.io.File
 import java.nio.file.Path
-
 import ch.qos.logback.classic.Level
+import org.bitbucket.inkytonik.kiama.util.Source
 import org.rogach.scallop.exceptions.ValidationFailure
 import org.rogach.scallop.throwError
-import viper.gobra.frontend.{Config, ScallopGobraConfig}
+import viper.gobra.frontend.{Config, ScallopGobraConfig, Source}
 import viper.gobra.reporting.{NoopReporter, ParserError}
 import viper.gobra.reporting.VerifierResult.{Failure, Success}
 import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
@@ -65,7 +65,7 @@ class GobraPackageTests extends GobraTests {
         val config = Config(
           logLevel = Level.INFO,
           reporter = NoopReporter,
-          inputFiles = input.files.toVector,
+          inputs = input.files.toVector.map(Source.getSource),
           includeDirs = Vector(currentDir),
           checkConsistency = true,
           z3Exe = z3Exe
@@ -110,8 +110,9 @@ class GobraPackageTests extends GobraTests {
 
   private def equalConfigs(config1: Config, config2: Config): Vector[GobraTestOuput] = {
     def equalFiles(v1: Vector[Path], v2: Vector[Path]): Boolean = v1.sortBy(_.toString).equals(v2.sortBy(_.toString))
+    def equalSources(v1: Vector[Source], v2: Vector[Source]): Boolean = v1.map(_.name).sorted.equals(v2.map(_.name).sorted)
 
-    val equal = (equalFiles(config1.inputFiles, config2.inputFiles)
+    val equal = (equalSources(config1.inputs, config2.inputs)
       && equalFiles(config1.includeDirs, config2.includeDirs)
       && config1.logLevel == config2.logLevel)
     if (equal) Vector()

--- a/src/test/scala/viper/gobra/GobraTests.scala
+++ b/src/test/scala/viper/gobra/GobraTests.scala
@@ -9,7 +9,8 @@ package viper.gobra
 import java.nio.file.Path
 import ch.qos.logback.classic.Level
 import org.scalatest.BeforeAndAfterAll
-import viper.gobra.frontend.{Config, PackageResolver, Source}
+import viper.gobra.frontend.Source.FromFileSource
+import viper.gobra.frontend.{Config, PackageResolver}
 import viper.gobra.reporting.VerifierResult.{Failure, Success}
 import viper.gobra.reporting.{NoopReporter, VerifierError}
 import viper.silver.testing.{AbstractOutput, AnnotatedTestInput, ProjectInfo, SystemUnderTest}
@@ -47,7 +48,7 @@ class GobraTests extends AbstractGobraTests with BeforeAndAfterAll {
         val config = Config(
           logLevel = Level.INFO,
           reporter = NoopReporter,
-          inputs = Vector(Source.getSource(input.file)),
+          inputs = Vector(FromFileSource(input.file)),
           // TODO: enable consistency checks as soon as inconsistencies have been fixed
           // checkConsistency = true,
           z3Exe = z3Exe

--- a/src/test/scala/viper/gobra/GobraTests.scala
+++ b/src/test/scala/viper/gobra/GobraTests.scala
@@ -7,15 +7,13 @@
 package viper.gobra
 
 import java.nio.file.Path
-
 import ch.qos.logback.classic.Level
 import org.scalatest.BeforeAndAfterAll
-import viper.gobra.frontend.{Config, PackageResolver}
+import viper.gobra.frontend.{Config, PackageResolver, Source}
 import viper.gobra.reporting.VerifierResult.{Failure, Success}
 import viper.gobra.reporting.{NoopReporter, VerifierError}
 import viper.silver.testing.{AbstractOutput, AnnotatedTestInput, ProjectInfo, SystemUnderTest}
 import viper.silver.utility.TimingUtils
-
 import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
 
 import scala.concurrent.Await
@@ -49,7 +47,7 @@ class GobraTests extends AbstractGobraTests with BeforeAndAfterAll {
         val config = Config(
           logLevel = Level.INFO,
           reporter = NoopReporter,
-          inputFiles = Vector(input.file),
+          inputs = Vector(Source.getSource(input.file)),
           // TODO: enable consistency checks as soon as inconsistencies have been fixed
           // checkConsistency = true,
           z3Exe = z3Exe

--- a/src/test/scala/viper/gobra/OverallBenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/OverallBenchmarkTests.scala
@@ -84,7 +84,7 @@ class OverallBenchmarkTests extends BenchmarkTests {
     private val overallPhase = Phase("Gobra.verify", () => {
       assert(config.isDefined)
       val c = config.get
-      val resultFuture = gobra.verify(c.inputFiles, c)(executor)
+      val resultFuture = gobra.verify(c.inputs, c)(executor)
       overallPhaseResult = Some(Await.result(resultFuture, Duration(timeoutSec, TimeUnit.SECONDS)))
     })
 

--- a/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
+++ b/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
@@ -244,7 +244,7 @@ class GhostErasureUnitTests extends AnyFunSuite with Matchers with Inside {
       )
       val tree = new Info.GoTree(pkg)
       val context = new Info.Context()
-      val config = Config(Vector())
+      val config = Config(inputs = Vector())
       val info = new TypeInfoImpl(tree, context)(config)
       info.errors match {
         case Vector(msgs) => fail(s"Type-checking failed: $msgs")
@@ -253,7 +253,7 @@ class GhostErasureUnitTests extends AnyFunSuite with Matchers with Inside {
 
       val ghostLess = new GhostLessPrinter(info).format(pkg)
       // try to parse ghostLess string:
-      val parseRes = Parser.parseProgram(StringSource(ghostLess, "Ghostless Program"), false)
+      val parseRes = Parser.parseProgram(StringSource(ghostLess, "Ghostless Program"), false)(config)
       parseRes match {
         case Right(prog) => prog
         case Left(messages) => fail(s"Parsing failed: $messages")
@@ -292,12 +292,13 @@ class GhostErasureUnitTests extends AnyFunSuite with Matchers with Inside {
     }
 
     def testProg(inputProg: String, expectedErasedProg: String): Assertion = {
-      val inputParseAst = Parser.parseProgram(StringSource(inputProg, "Input Program"))
+      val config = Config(inputs = Vector())
+      val inputParseAst = Parser.parseProgram(StringSource(inputProg, "Input Program"))(config)
       val ghostlessProg = inputParseAst match {
         case Right(prog) => ghostLessProg(prog)
         case Left(msgs) => fail(s"Parsing input program has failed with $msgs")
       }
-      val expectedParseAst = Parser.parseProgram(StringSource(expectedErasedProg, "Expected Program"))
+      val expectedParseAst = Parser.parseProgram(StringSource(expectedErasedProg, "Expected Program"))(config)
       expectedParseAst match {
         case Right(prog) => equal(ghostlessProg, prog)
         case Left(msgs) => fail(s"Parsing expected erased program has failed with $msgs")

--- a/src/test/scala/viper/gobra/typing/ExprTypingUnitTests.scala
+++ b/src/test/scala/viper/gobra/typing/ExprTypingUnitTests.scala
@@ -3390,7 +3390,7 @@ class ExprTypingUnitTests extends AnyFunSuite with Matchers with Inside {
       )
       val tree = new Info.GoTree(pkg)
       val context = new Info.Context()
-      val config = Config(inputFiles = Vector(), includeDirs = Vector())
+      val config = Config(inputs = Vector(), includeDirs = Vector())
       new TypeInfoImpl(tree, context)(config)
     }
 

--- a/src/test/scala/viper/gobra/typing/TypeTypingUnitTests.scala
+++ b/src/test/scala/viper/gobra/typing/TypeTypingUnitTests.scala
@@ -377,7 +377,7 @@ class TypeTypingUnitTests extends AnyFunSuite with Matchers with Inside {
       )
       val tree = new Info.GoTree(pkg)
       val context = new Info.Context()
-      val config = Config(inputFiles = Vector(), includeDirs = Vector())
+      val config = Config(inputs = Vector(), includeDirs = Vector())
       new TypeInfoImpl(tree, context)(config)
     }
 


### PR DESCRIPTION
This PR adapts Gobra to take a vector of `Source` instead of `Path` as input. This provides greater flexibility as a `Source` can either represent a file or simply some string. In particular, it allows Gobra Server to invoke Gobra with some (file)content that is not necessarily stored in local files.
Not however that this does not immediately enables Gobra Server to run on a remote machine as the entire import resolution mechanism still relies on the local filesystem. A proper abstraction would need to be implemented (e.g. with callbacks to query the directory structure and/or to retrieve files).