### PR TITLE
added stubs for As, Is, and Unwrap methods of errors package

### DIFF
--- a/src/main/resources/stubs/errors/wrap.gobra
+++ b/src/main/resources/stubs/errors/wrap.gobra
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/errors/wrap.go
+
 package errors
 
 // (tlino) the methods aren't verified yet

--- a/src/main/resources/stubs/errors/wrap.gobra
+++ b/src/main/resources/stubs/errors/wrap.gobra
@@ -1,4 +1,4 @@
-// Copyright 2018 The Go Authors. All rights reserved.
+// Copyright 2009 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in https://golang.org/LICENSE
 

--- a/src/main/resources/stubs/errors/wrap.gobra
+++ b/src/main/resources/stubs/errors/wrap.gobra
@@ -12,6 +12,7 @@ package errors
 // 	"internal/reflectlite"
 // )
 
+// (tlino) TODO: verify this method
 // Unwrap returns the result of calling the Unwrap method on err, if err's
 // type contains an Unwrap method returning error.
 // Otherwise, Unwrap returns nil.
@@ -26,6 +27,9 @@ func Unwrap(err error) error //{
 // 	return u.Unwrap()
 // }
 
+// (tlino) For now, we do not require any predicate to hold.
+// (tlino) We assume that we have read permission to target.
+// (tlino) TODO: verify this method, depends on the internal/reflectlite package
 // Is reports whether any error in err's chain matches target.
 //
 // The chain consists of err itself followed by the sequence of errors obtained by
@@ -65,6 +69,9 @@ func Is(err, target error) bool //{
 // 	}
 // }
 
+// (tlino) For now, we do not require any predicate to hold.
+// (tlino) We assume that we have read permission to target and write permission to err.
+// (tlino) TODO: verify this method, depends on the internal/reflectlite package
 // As finds the first error in err's chain that matches target, and if one is found, sets
 // target to that error value and returns true. Otherwise, it returns false.
 //

--- a/src/main/resources/stubs/errors/wrap.gobra
+++ b/src/main/resources/stubs/errors/wrap.gobra
@@ -15,7 +15,7 @@ package errors
 // Unwrap returns the result of calling the Unwrap method on err, if err's
 // type contains an Unwrap method returning error.
 // Otherwise, Unwrap returns nil.
-decreases
+decreases _
 func Unwrap(err error) error //{
 // 	u, ok := err.(interface {
 // 		Unwrap() error
@@ -42,7 +42,7 @@ func Unwrap(err error) error //{
 // then Is(MyError{}, fs.ErrExist) returns true. See syscall.Errno.Is for
 // an example in the standard library. An Is method should only shallowly
 // compare err and the target and not call Unwrap on either.
-decreases
+decreases _
 func Is(err, target error) bool //{
 // 	if target == nil {
 // 		return err == target
@@ -81,7 +81,7 @@ func Is(err, target error) bool //{
 //
 // As panics if target is not a non-nil pointer to either a type that implements
 // error, or to any interface type.
-decreases
+decreases _
 func As(err error, target interface{}) bool //{
 // 	if target == nil {
 // 		panic("errors: target cannot be nil")

--- a/src/main/resources/stubs/errors/wrap.gobra
+++ b/src/main/resources/stubs/errors/wrap.gobra
@@ -1,6 +1,6 @@
 // Copyright 2018 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in https://golang.org/LICENSE
 
 // Signatures for the public declarations in file
 // https://github.com/golang/go/blob/master/src/errors/wrap.go

--- a/src/main/resources/stubs/errors/wrap.gobra
+++ b/src/main/resources/stubs/errors/wrap.gobra
@@ -1,0 +1,109 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package errors
+
+// (tlino) the methods aren't verified yet
+// import (
+// 	"internal/reflectlite"
+// )
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+decreases
+func Unwrap(err error) error //{
+// 	u, ok := err.(interface {
+// 		Unwrap() error
+// 	})
+// 	if !ok {
+// 		return nil
+// 	}
+// 	return u.Unwrap()
+// }
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+//
+// An error type might provide an Is method so it can be treated as equivalent
+// to an existing error. For example, if MyError defines
+//
+//	func (m MyError) Is(target error) bool { return target == fs.ErrExist }
+//
+// then Is(MyError{}, fs.ErrExist) returns true. See syscall.Errno.Is for
+// an example in the standard library. An Is method should only shallowly
+// compare err and the target and not call Unwrap on either.
+decreases
+func Is(err, target error) bool //{
+// 	if target == nil {
+// 		return err == target
+// 	}
+
+// 	isComparable := reflectlite.TypeOf(target).Comparable()
+// 	for {
+// 		if isComparable && err == target {
+// 			return true
+// 		}
+// 		if x, ok := err.(interface{ Is(error) bool }); ok && x.Is(target) {
+// 			return true
+// 		}
+// 		// TODO: consider supporting target.Is(err). This would allow
+// 		// user-definable predicates, but also may allow for coping with sloppy
+// 		// APIs, thereby making it easier to get away with them.
+// 		if err = Unwrap(err); err == nil {
+// 			return false
+// 		}
+// 	}
+// }
+
+// As finds the first error in err's chain that matches target, and if one is found, sets
+// target to that error value and returns true. Otherwise, it returns false.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// An error type might provide an As method so it can be treated as if it were a
+// different error type.
+//
+// As panics if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type.
+decreases
+func As(err error, target interface{}) bool //{
+// 	if target == nil {
+// 		panic("errors: target cannot be nil")
+// 	}
+// 	val := reflectlite.ValueOf(target)
+// 	typ := val.Type()
+// 	if typ.Kind() != reflectlite.Ptr || val.IsNil() {
+// 		panic("errors: target must be a non-nil pointer")
+// 	}
+// 	targetType := typ.Elem()
+// 	if targetType.Kind() != reflectlite.Interface && !targetType.Implements(errorType) {
+// 		panic("errors: *target must be interface or implement error")
+// 	}
+// 	for err != nil {
+// 		if reflectlite.TypeOf(err).AssignableTo(targetType) {
+// 			val.Elem().Set(reflectlite.ValueOf(err))
+// 			return true
+// 		}
+// 		if x, ok := err.(interface{ As(interface{}) bool }); ok && x.As(target) {
+// 			return true
+// 		}
+// 		err = Unwrap(err)
+// 	}
+// 	return false
+// }
+
+// (tlino) depends on reflectlite
+// var errorType = reflectlite.TypeOf((*error)(nil)).Elem()


### PR DESCRIPTION
As Is:
- errors package is not supported

To Be:
- adds stubs for the errors.Is, errors.As, and errors.Unwrap methods