### PR TITLE
ViperServer Backend Improvements

### DIFF
--- a/src/main/scala/viper/gobra/backend/Backend.scala
+++ b/src/main/scala/viper/gobra/backend/Backend.scala
@@ -10,6 +10,6 @@ import viper.gobra.util.GobraExecutionContext
 
 import scala.concurrent.Future
 
-trait Backend[I, C, R, P, O] {
-  def verify(id: I, config: C, reporter: R, program: P)(executor: GobraExecutionContext): Future[O]
+trait Backend[I, R, P, O] {
+  def verify(id: I, reporter: R, program: P)(executor: GobraExecutionContext): Future[O]
 }

--- a/src/main/scala/viper/gobra/backend/BackendVerifier.scala
+++ b/src/main/scala/viper/gobra/backend/BackendVerifier.scala
@@ -50,7 +50,7 @@ object BackendVerifier {
     val verifier = config.backend.create(exePaths, config)
     val programID = s"_programID_${config.inputs.map(_.name).mkString("_")}"
 
-    val verificationResult = verifier.verify(programID, config.backendConfig, BacktranslatingReporter(config.reporter, task.backtrack, config), task.program)(executor)
+    val verificationResult = verifier.verify(programID, BacktranslatingReporter(config.reporter, task.backtrack, config), task.program)(executor)
 
 
     verificationResult.map(

--- a/src/main/scala/viper/gobra/backend/Carbon.scala
+++ b/src/main/scala/viper/gobra/backend/Carbon.scala
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 
 class Carbon(commandLineArguments: Seq[String]) extends ViperVerifier {
 
-  override def verify(programID: String, reporter:Reporter, program: Program)(executor: GobraExecutionContext): Future[VerificationResult] = {
+  override def verify(programID: String, reporter: Reporter, program: Program)(executor: GobraExecutionContext): Future[VerificationResult] = {
     // directly declaring the parameter implicit somehow does not work as the compiler is unable to spot the inheritance
     implicit val _executor: GobraExecutionContext = executor
     Future {

--- a/src/main/scala/viper/gobra/backend/Carbon.scala
+++ b/src/main/scala/viper/gobra/backend/Carbon.scala
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 
 class Carbon(commandLineArguments: Seq[String]) extends ViperVerifier {
 
-  def verify(programID: String, config: ViperVerifierConfig, reporter:Reporter, program: Program)(executor: GobraExecutionContext): Future[VerificationResult] = {
+  override def verify(programID: String, reporter:Reporter, program: Program)(executor: GobraExecutionContext): Future[VerificationResult] = {
     // directly declaring the parameter implicit somehow does not work as the compiler is unable to spot the inheritance
     implicit val _executor: GobraExecutionContext = executor
     Future {

--- a/src/main/scala/viper/gobra/backend/Silicon.scala
+++ b/src/main/scala/viper/gobra/backend/Silicon.scala
@@ -16,7 +16,7 @@ import scala.concurrent.Future
 
 class Silicon(commandLineArguments: Seq[String]) extends ViperVerifier {
 
-  def verify(programID: String, config: ViperVerifierConfig, reporter: Reporter, program: Program)(executor: GobraExecutionContext): Future[VerificationResult] = {
+  override def verify(programID: String, reporter: Reporter, program: Program)(executor: GobraExecutionContext): Future[VerificationResult] = {
     // directly declaring the parameter implicit somehow does not work as the compiler is unable to spot the inheritance
     implicit val _executor: GobraExecutionContext = executor
     Future {

--- a/src/main/scala/viper/gobra/backend/ViperBackends.scala
+++ b/src/main/scala/viper/gobra/backend/ViperBackends.scala
@@ -43,9 +43,14 @@ object ViperBackends {
   abstract class ViperServerBackend(initialServer: Option[ViperCoreServer] = None) extends ViperBackend {
     private var server: Option[ViperCoreServer] = initialServer
 
-    /** should be implemented by classes implementing this abstract class */
+    /** abstract method that should return the backend-specific configuration. The configuration will then be passed
+      * on to the ViperServer instance.
+      */
     def getViperVerifierConfig(exePaths: Vector[String], config: Config): ViperVerifierConfig
 
+    /** returns a ViperServer instance with an underlying ViperCoreServer. A fresh ViperServer instance should be used
+      * for each verification. The underlying ViperCoreServer instance is reused if one already exists.
+      */
     def create(exePaths: Vector[String], config: Config)(implicit executionContext: GobraExecutionContext): ViperServer = {
       val initializedServer = getOrCreateServer(config)(executionContext)
       val executor = initializedServer.executor
@@ -55,6 +60,7 @@ object ViperBackends {
       new ViperServer(initializedServer, verifierConfig)(executor)
     }
 
+    /** returns an existing ViperCoreServer instance or otherwise creates a new one */
     protected def getOrCreateServer(config: Config)(executionContext: GobraExecutionContext): ViperCoreServer = {
       server.getOrElse({
         var serverConfig = List("--logLevel", config.logLevel.levelStr)
@@ -69,6 +75,7 @@ object ViperBackends {
       })
     }
 
+    /** resets the ViperCoreServer instance such that a new one will be created for the next verification */
     def resetServer(): Unit =
       server = None
   }

--- a/src/main/scala/viper/gobra/backend/ViperServer.scala
+++ b/src/main/scala/viper/gobra/backend/ViperServer.scala
@@ -49,19 +49,23 @@ object ViperServer {
   }
 }
 
+trait ViperVerifierConfig {
+  val partialCommandLine: List[String]
+}
+trait ViperServerWithSilicon extends ViperVerifierConfig
+trait ViperServerWithCarbon extends ViperVerifierConfig
+
 object ViperServerConfig {
   object EmptyConfigWithSilicon extends ViperServerWithSilicon {val partialCommandLine: List[String] = Nil}
   object EmptyConfigWithCarbon extends ViperServerWithCarbon {val partialCommandLine: List[String] = Nil}
   case class ConfigWithSilicon(partialCommandLine: List[String]) extends ViperServerWithSilicon
   case class ConfigWithCarbon(partialCommandLine: List[String]) extends ViperServerWithCarbon
 }
-trait ViperServerWithSilicon extends ViperVerifierConfig
-trait ViperServerWithCarbon extends ViperVerifierConfig
 
 class ViperServer(server: ViperCoreServer, backendConfig: ViperVerifierConfig)(implicit executor: VerificationExecutionContext) extends ViperVerifier {
   import ViperServer._
 
-  override def verify(programID: String, config: ViperVerifierConfig, reporter: Reporter, program: Program)(_ctx: GobraExecutionContext): Future[VerificationResult] = {
+  override def verify(programID: String, reporter: Reporter, program: Program)(_ctx: GobraExecutionContext): Future[VerificationResult] = {
     // convert ViperVerifierConfig to ViperBackendConfig:
 
     if(!server.isRunning) {

--- a/src/main/scala/viper/gobra/backend/ViperVerifier.scala
+++ b/src/main/scala/viper/gobra/backend/ViperVerifier.scala
@@ -12,17 +12,8 @@ import viper.silver.reporter.Reporter
 
 import scala.concurrent.Future
 
-object ViperVerifierConfig {
-  object EmptyConfig extends ViperVerifierConfig {val partialCommandLine: List[String] = Nil}
-  case class Config(partialCommandLine: List[String]) extends ViperVerifierConfig
-}
+trait ViperVerifier extends Backend[String, Reporter, silver.ast.Program, silver.verifier.VerificationResult] {
 
-trait ViperVerifierConfig {
-  val partialCommandLine: List[String]
-}
-
-trait ViperVerifier extends Backend[String, ViperVerifierConfig, Reporter, silver.ast.Program, silver.verifier.VerificationResult] {
-
-  def verify(programID: String, config: ViperVerifierConfig, reporter: Reporter, program: silver.ast.Program)(executor: GobraExecutionContext): Future[silver.verifier.VerificationResult]
+  def verify(programID: String, reporter: Reporter, program: silver.ast.Program)(executor: GobraExecutionContext): Future[silver.verifier.VerificationResult]
 
 }

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -14,7 +14,7 @@ import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, message, noMessag
 import org.bitbucket.inkytonik.kiama.util.{FileSource, Source}
 import org.rogach.scallop.{ScallopConf, ScallopOption, listArgConverter, singleArgConverter}
 import org.slf4j.LoggerFactory
-import viper.gobra.backend.{ViperBackend, ViperBackends, ViperVerifierConfig}
+import viper.gobra.backend.{ViperBackend, ViperBackends}
 import viper.gobra.GoVerifier
 import viper.gobra.frontend.PackageResolver.RegularImport
 import viper.gobra.reporting.{FileWriterReporter, GobraReporter, StdIOReporter}
@@ -29,7 +29,6 @@ case class Config(
                  includeDirs: Vector[Path] = Vector(),
                  reporter: GobraReporter = StdIOReporter(),
                  backend: ViperBackend = ViperBackends.SiliconBackend,
-                 backendConfig: ViperVerifierConfig = ViperVerifierConfig.EmptyConfig,
                  z3Exe: Option[String] = None,
                  boogieExe: Option[String] = None,
                  logLevel: Level = LoggerDefaults.DefaultLevel,
@@ -132,8 +131,8 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
   )(singleArgConverter({
     case "SILICON" => ViperBackends.SiliconBackend
     case "CARBON" => ViperBackends.CarbonBackend
-    case "VSWITHSILICON" => ViperBackends.ViperServerWithSilicon
-    case "VSWITHCARBON" => ViperBackends.ViperServerWithCarbon
+    case "VSWITHSILICON" => ViperBackends.ViperServerWithSilicon()
+    case "VSWITHCARBON" => ViperBackends.ViperServerWithCarbon()
     case _ => ViperBackends.SiliconBackend
   }))
 
@@ -307,9 +306,9 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
 
   // cache file should only be usable when using viper server
   validateOpt (backend, cacheFile) {
-    case (Some(ViperBackends.ViperServerWithSilicon), Some(_)) => Right()
-    case (Some(ViperBackends.ViperServerWithCarbon), Some(_)) => Right()
-    case (_, None) => Right()
+    case (Some(_: ViperBackends.ViperServerWithSilicon), Some(_)) => Right(())
+    case (Some(_: ViperBackends.ViperServerWithCarbon), Some(_)) => Right(())
+    case (_, None) => Right(())
     case (_, Some(_)) => Left("Cache file can only be specified when the backend uses Viper Server")
   }
 


### PR DESCRIPTION
Adapts ViperServer backend (reintegrated by @jogasser) to be usable by Gobra Server. In particular, Gobra Server creates a ViperCoreServer instance as part of its initialization. This PR enables Gobra Server to pass this server instance to either `ViperServerWithSilicon` or `ViperServerWithCarbon` instead of a new server instance being created.
Furthermore, `ViperVerifierConfig` has been removed as I've introduced it back then to route configuration options via Gobra to the backend but this does not seem to be necessary anymore and reduces complexity.