### PR TITLE
Trusted Flag

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -44,6 +44,7 @@ import (
 ```go
 requires ... // preconditions 
 ensures  ... // postconditions 
+trusted      // trusted flag (optional)
 func min(xs []int) int {
   ... // function body (optional)
 }
@@ -52,6 +53,7 @@ func min(xs []int) int {
 ```go
 requires ... // preconditions 
 ensures  ... // postconditions 
+trusted      // trusted flag (optional)
 func (xs *list) contains(value int) bool {
   ... // method body (optional)
 }
@@ -59,7 +61,7 @@ func (xs *list) contains(value int) bool {
 - Functions and methods can be annotated with pre and postconditions. If omitted, they default to `true`.
 - Functions and methods are verified modularly. A call only uses the specification of the callee and cannot peek inside the body.
 - The body (including `{}`) may be omitted. In this case, Gobra assumes that the specification holds.
-
+- A function or method can be annotated with the `trusted` flag. Gobra then assumes the specification holds and ignores the body.
 
 #### Predicates
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
 
-sbt.version = 1.5.5
+sbt.version = 1.5.7

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -780,6 +780,7 @@ case class PFunctionSpec(
                       posts: Vector[PExpression],
                       terminationMeasures: Vector[PTerminationMeasure],
                       isPure: Boolean = false,
+                      isTrusted: Boolean = false
                       ) extends PSpecification
 
 case class PBodyParameterInfo(

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -108,6 +108,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
   }
 
   def showPure: Doc = "pure" <> line
+  def showTrusted: Doc = "trusted" <> line
   def showPre(pre: PExpression): Doc = "requires" <+> showExpr(pre)
   def showPreserves(preserves: PExpression): Doc = "preserves" <+> showExpr(preserves)
   def showPost(post: PExpression): Doc = "ensures" <+> showExpr(post)
@@ -122,8 +123,9 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
   }
 
   def showSpec(spec: PSpecification): Doc = spec match {
-    case PFunctionSpec(pres, preserves, posts, measures, isPure) =>
+    case PFunctionSpec(pres, preserves, posts, measures, isPure, isTrusted) =>
       (if (isPure) showPure else emptyDoc) <>
+      (if (isTrusted) showPure else emptyDoc) <>
       hcat(pres map (showPre(_) <> line)) <>
         hcat(preserves map (showPreserves(_) <> line)) <>
         hcat(posts map (showPost(_) <> line)) <>

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -125,7 +125,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
   def showSpec(spec: PSpecification): Doc = spec match {
     case PFunctionSpec(pres, preserves, posts, measures, isPure, isTrusted) =>
       (if (isPure) showPure else emptyDoc) <>
-      (if (isTrusted) showPure else emptyDoc) <>
+      (if (isTrusted) showTrusted else emptyDoc) <>
       hcat(pres map (showPre(_) <> line)) <>
         hcat(preserves map (showPreserves(_) <> line)) <>
         hcat(posts map (showPost(_) <> line)) <>

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -447,7 +447,8 @@ object Parser {
         name <- "func" ~> idnDef
         sig  <- signature
         body <- if (spec.isTrusted) nestedCurlyBracketsConsumer else specOnlyParser(blockWithBodyParameterInfo)
-      } yield PFunctionDecl(name, sig._1, sig._2, spec, body).at(spec)
+        // Need to update the position range, since otherwise only the body bzw signature position is accounted for
+      } yield PFunctionDecl(name, sig._1, sig._2, spec, body).range(spec, if (body.isDefined) body.get._2 else sig._2)
 
     lazy val functionSpec: Parser[PFunctionSpec] = {
       sealed trait FunctionSpecClause
@@ -489,7 +490,8 @@ object Parser {
         name <- idnDef
         sig  <- signature
         body <- if (spec.isTrusted) nestedCurlyBracketsConsumer else specOnlyParser(blockWithBodyParameterInfo)
-      } yield PMethodDecl(name, rcv, sig._1, sig._2, spec, body).at(spec)
+        // Need to update the position range, since otherwise only the body bzw signature position is accounted for
+      } yield PMethodDecl(name, rcv, sig._1, sig._2, spec, body).range(spec, if (body.isDefined) body.get._2 else sig._2)
 
     /**
       * Statements

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
@@ -258,7 +258,7 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
   }
 
   implicit lazy val wellDefSpec: WellDefinedness[PSpecification] = createWellDef {
-    case n@ PFunctionSpec(pres, preserves, posts, terminationMeasures, _) =>
+    case n@ PFunctionSpec(pres, preserves, posts, terminationMeasures, _, _) =>
       pres.flatMap(assignableToSpec) ++ preserves.flatMap(assignableToSpec) ++ posts.flatMap(assignableToSpec) ++
       preserves.flatMap(e => allChildren(e).flatMap(illegalPreconditionNode)) ++
       pres.flatMap(e => allChildren(e).flatMap(illegalPreconditionNode)) ++

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
@@ -73,8 +73,9 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
     * Shows the Goified version of the function / method specification
     */
   override def showSpec(spec: PSpecification): Doc = spec match {
-    case PFunctionSpec(pres, preserves, posts, measures, isPure) =>
+    case PFunctionSpec(pres, preserves, posts, measures, isPure, isTrusted) =>
       (if (isPure) specComment <+> showPure else emptyDoc) <>
+      (if (isTrusted) specComment <+> showTrusted else emptyDoc) <>
       hcat(pres map (p => specComment <+> showPre(p) <> line)) <>
       hcat(preserves map (p => specComment <+> showPreserves(p) <> line)) <>
       hcat(posts map (p => specComment <+> showPost(p) <> line)) <>

--- a/src/test/resources/regressions/features/trusted/trusted-functions.gobra
+++ b/src/test/resources/regressions/features/trusted/trusted-functions.gobra
@@ -1,0 +1,41 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg;
+
+requires x > 0 && y > 0
+ensures ret > 0
+trusted
+func positiveSumCorrectSpec(x int, y int) (ret int) {
+	return x + y
+}
+
+requires x < 0 && y < 0
+ensures ret > 0
+trusted
+func positiveSumIncorrectSpec(x int, y int) (ret int) {
+	return x + y
+}
+
+requires x > 0 && y > 0
+ensures ret > 0
+func positiveSumWithoutTrusted(x int, y int) (ret int) {
+	return x + y
+}
+
+trusted
+ensures ret < 0
+func testPositiveSumWithoutTrusted() (ret int) {
+    return positiveSumWithoutTrusted(-10, 12)
+}
+
+//:: ExpectedOutput(postcondition_error:assertion_error)
+ensures ret < 0
+func test1() (ret int){
+    return positiveSumCorrectSpec(10, 10);
+}
+
+func test2() int{
+    //:: ExpectedOutput(precondition_error:assertion_error)
+    return positiveSumCorrectSpec(-10, 10);
+}

--- a/src/test/resources/regressions/features/trusted/trusted-functions.gobra
+++ b/src/test/resources/regressions/features/trusted/trusted-functions.gobra
@@ -24,6 +24,12 @@ func positiveSumWithoutTrusted(x int, y int) (ret int) {
 }
 
 trusted
+func functionWithNonSupportedFeature() int{
+	some non supported go feature
+	return 0
+}
+
+trusted
 ensures ret < 0
 func testPositiveSumWithoutTrusted() (ret int) {
     return positiveSumWithoutTrusted(-10, 12)

--- a/src/test/resources/regressions/features/trusted/trusted-methods.gobra
+++ b/src/test/resources/regressions/features/trusted/trusted-methods.gobra
@@ -26,6 +26,12 @@ func test1() (ret IntType){
     return i.negateIncorrectSpec()
 }
 
+trusted
+func (x IntType) methodWithNonSupportedFeature() IntType{
+	some non supported go feature
+	return 0
+}
+
 func test2() IntType{
     var i IntType = -2
     //:: ExpectedOutput(precondition_error:assertion_error)

--- a/src/test/resources/regressions/features/trusted/trusted-methods.gobra
+++ b/src/test/resources/regressions/features/trusted/trusted-methods.gobra
@@ -1,0 +1,33 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg;
+
+type IntType int
+
+requires x > 0
+ensures ret < 0
+trusted
+func (x IntType) negateCorrectSpec() (ret IntType) {
+    return -x
+}
+
+requires x > 0
+ensures ret > 0
+trusted
+func (x IntType) negateIncorrectSpec() (ret IntType) {
+    return -x
+}
+
+//:: ExpectedOutput(postcondition_error:assertion_error)
+ensures ret < 0
+func test1() (ret IntType){
+    var i IntType = 2
+    return i.negateIncorrectSpec()
+}
+
+func test2() IntType{
+    var i IntType = -2
+    //:: ExpectedOutput(precondition_error:assertion_error)
+    return i.negateIncorrectSpec()
+}

--- a/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
@@ -110,36 +110,39 @@ class DetailedBenchmarkTests extends BenchmarkTests {
         Info.check(parsedPackage, c.inputs)(c).map(typeInfo => (parsedPackage, typeInfo))
       })
 
-    private val desugaring: NextStep[(PPackage, TypeInfo), Program, Vector[VerifierError]] =
+    private val desugaring: NextStep[(PPackage, TypeInfo), (Program, TypeInfo), Vector[VerifierError]] =
       NextStep("desugaring", typeChecking, { case (parsedPackage: PPackage, typeInfo: TypeInfo) =>
         assert(config.isDefined)
-        Right(Desugar.desugar(parsedPackage, typeInfo)(config.get))
+        Right(Desugar.desugar(parsedPackage, typeInfo)(config.get), typeInfo)
       })
 
-    private val internalTransforming = NextStep("internal transforming", desugaring, (program: Program) => {
-      assert(config.isDefined)
-      val c = config.get
-      if (c.checkOverflows) {
-        val result = OverflowChecksTransform.transform(program)
-        c.reporter report AppliedInternalTransformsMessage(c.inputs.map(_.name), () => result)
-        Right(result)
-      } else {
-        Right(program)
-      }
-    })
+    private val internalTransforming: NextStep[(Program, TypeInfo), (Program, TypeInfo), Vector[VerifierError]] =
+      NextStep("internal transforming", desugaring, { case (program: Program, typeInfo: TypeInfo) =>
+        assert(config.isDefined)
+        val c = config.get
+        if (c.checkOverflows) {
+          val result = OverflowChecksTransform.transform(program)
+          c.reporter report AppliedInternalTransformsMessage(c.inputs.map(_.name), () => result)
+          Right(result, typeInfo)
+        } else {
+          Right(program, typeInfo)
+        }
+      })
 
-    private val encoding = NextStep("Viper encoding", internalTransforming, (program: Program) => {
-      assert(config.isDefined)
-      Right(Translator.translate(program)(config.get))
-    })
+    private val encoding: NextStep[(Program, TypeInfo), (BackendVerifier.Task, TypeInfo), Vector[VerifierError]] =
+      NextStep("Viper encoding", internalTransforming, { case (program: Program, typeInfo: TypeInfo) =>
+        assert(config.isDefined)
+        Right(Translator.translate(program)(config.get), typeInfo)
+      })
 
-    private val verifying = NextStep("Viper verification", encoding, (viperTask: BackendVerifier.Task) => {
-      assert(config.isDefined)
-      val c = config.get
-      val resultFuture = BackendVerifier.verify(viperTask)(c)(executor)
-        .map(BackTranslator.backTranslate(_)(c))(executor)
-      Right(Await.result(resultFuture, Duration(timeoutSec, TimeUnit.SECONDS)))
-    })
+    private val verifying: NextStep[(BackendVerifier.Task, TypeInfo), VerifierResult, Vector[VerifierError]] =
+      NextStep("Viper verification", encoding, { case (viperTask: BackendVerifier.Task, typeInfo: TypeInfo) =>
+        assert(config.isDefined)
+        val c = config.get
+        val resultFuture = BackendVerifier.verify(viperTask, typeInfo)(c)(executor)
+          .map(BackTranslator.backTranslate(_)(c))(executor)
+        Right(Await.result(resultFuture, Duration(timeoutSec, TimeUnit.SECONDS)))
+      })
 
     private val lastStep = verifying
 

--- a/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
+++ b/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
@@ -131,13 +131,13 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
 
   test("Parser: spec only function") {
     frontend.parseMember("func foo() { b.bar() }", specOnly = true) should matchPattern {
-      case Vector(PFunctionDecl(PIdnDef("foo"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), Vector(), Vector(), false), None)) =>
+      case Vector(PFunctionDecl(PIdnDef("foo"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), Vector(), Vector(), false, false), None)) =>
     }
   }
   
   test("Parser: spec only function with nested blocks") {
     frontend.parseMember("func foo() { if(true) { b.bar() } else { foo() } }", specOnly = true) should matchPattern {
-      case Vector(PFunctionDecl(PIdnDef("foo"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), Vector(), Vector(), false), None)) =>
+      case Vector(PFunctionDecl(PIdnDef("foo"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), Vector(), Vector(), false, false), None)) =>
     }
   }
   
@@ -170,7 +170,7 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
     val modes: Set[Boolean] = Set(false, true)
     modes.foreach(specOnly => {
       frontend.parseMember("func bar()", specOnly) should matchPattern {
-        case Vector(PFunctionDecl(PIdnDef("bar"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), Vector(), Vector(), false), None)) =>
+        case Vector(PFunctionDecl(PIdnDef("bar"), Vector(), PResult(Vector()), PFunctionSpec(Vector(), Vector(), Vector(), Vector(), false, false), None)) =>
       }
     })
   }
@@ -2632,19 +2632,19 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
 
   test("Parser: should be able to parse normal termination measure") {
     frontend.parseMember("decreases n; func factorial (n int) int") should matchPattern {
-      case Vector(PFunctionDecl(PIdnDef("factorial"), Vector(PNamedParameter(PIdnDef("n"), PIntType())), PResult(Vector(PUnnamedParameter(PIntType()))), PFunctionSpec(Vector(), Vector(), Vector(), Vector(PTupleTerminationMeasure(Vector(PNamedOperand(PIdnUse("n"))), None)), false), None)) =>
+      case Vector(PFunctionDecl(PIdnDef("factorial"), Vector(PNamedParameter(PIdnDef("n"), PIntType())), PResult(Vector(PUnnamedParameter(PIntType()))), PFunctionSpec(Vector(), Vector(), Vector(), Vector(PTupleTerminationMeasure(Vector(PNamedOperand(PIdnUse("n"))), None)), false, false), None)) =>
     }
   }
 
   test("Parser: should be able to parse underscore termination measure") {
     frontend.parseMember("decreases _; func factorial (n int) int") should matchPattern {
-      case Vector(PFunctionDecl(PIdnDef("factorial"), Vector(PNamedParameter(PIdnDef("n"), PIntType())), PResult(Vector(PUnnamedParameter(PIntType()))), PFunctionSpec(Vector(), Vector(), Vector(), Vector(PWildcardMeasure(None)), false), None)) =>
+      case Vector(PFunctionDecl(PIdnDef("factorial"), Vector(PNamedParameter(PIdnDef("n"), PIntType())), PResult(Vector(PUnnamedParameter(PIntType()))), PFunctionSpec(Vector(), Vector(), Vector(), Vector(PWildcardMeasure(None)), false, false), None)) =>
     }
   }
 
   test("Parser: should be able to parse conditional termination measure" ) {
     frontend.parseMember("decreases n if n>1; decreases _ if n<2; func factorial (n int) int") should matchPattern {
-      case Vector(PFunctionDecl(PIdnDef("factorial"), Vector(PNamedParameter(PIdnDef("n"), PIntType())), PResult(Vector(PUnnamedParameter(PIntType()))), PFunctionSpec(Vector(), Vector(), Vector(), Vector(PTupleTerminationMeasure(Vector(PNamedOperand(PIdnUse("n"))), Some(PGreater(PNamedOperand(PIdnUse("n")), PIntLit(one, Decimal)))), PWildcardMeasure(Some(PLess(PNamedOperand(PIdnUse("n")), PIntLit(two, Decimal))))), false), None)) if one == 1 && two == 2 =>
+      case Vector(PFunctionDecl(PIdnDef("factorial"), Vector(PNamedParameter(PIdnDef("n"), PIntType())), PResult(Vector(PUnnamedParameter(PIntType()))), PFunctionSpec(Vector(), Vector(), Vector(), Vector(PTupleTerminationMeasure(Vector(PNamedOperand(PIdnUse("n"))), Some(PGreater(PNamedOperand(PIdnUse("n")), PIntLit(one, Decimal)))), PWildcardMeasure(Some(PLess(PNamedOperand(PIdnUse("n")), PIntLit(two, Decimal))))), false, false), None)) if one == 1 && two == 2 =>
     }
   }    
   

--- a/src/test/scala/viper/gobra/typing/ExprTypingUnitTests.scala
+++ b/src/test/scala/viper/gobra/typing/ExprTypingUnitTests.scala
@@ -3370,7 +3370,7 @@ class ExprTypingUnitTests extends AnyFunSuite with Matchers with Inside {
         PUnnamedReceiver(PMethodReceiveName(PNamedOperand(PIdnUse("self")))),
         inArgs.map(_._1),
         PResult(Vector()),
-        PFunctionSpec(Vector(), Vector(), Vector(), Vector(), true),
+        PFunctionSpec(Vector(), Vector(), Vector(), Vector(), isPure = true),
         Some(PBodyParameterInfo(inArgs.collect{ case (n: PNamedParameter, true) => PIdnUse(n.id.name) }), PBlock(Vector(body)))
       ))
     )

--- a/src/test/scala/viper/gobra/typing/TypeTypingUnitTests.scala
+++ b/src/test/scala/viper/gobra/typing/TypeTypingUnitTests.scala
@@ -362,7 +362,7 @@ class TypeTypingUnitTests extends AnyFunSuite with Matchers with Inside {
         PUnnamedReceiver(PMethodReceiveName(PNamedOperand(PIdnUse("self")))),
         stubParams(ts),
         PResult(Vector()),
-        PFunctionSpec(Vector(), Vector(), Vector(), Vector(), true),
+        PFunctionSpec(Vector(), Vector(), Vector(), Vector(), isPure = true),
         None
       ))
     )


### PR DESCRIPTION
- Adds a trusted flag to Gobra, which lets a user assume that the specification of a method or function holds without checking it. To achieve this, it ignores the body of the function or method
- Upgrades sbt to 1.5.7 to fix log4j CVE(see, https://www.scala-lang.org/blog-detail/2021/12/16/state-of-log4j-in-scala-ecosystem.html for more details)