### PR TITLE
added support for bytes.Equal

### DIFF
--- a/src/main/resources/stubs/bytes/bytes.gobra
+++ b/src/main/resources/stubs/bytes/bytes.gobra
@@ -1,0 +1,27 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in https://golang.org/LICENSE
+
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/bytes/bytes.go
+
+// Package bytes implements functions for the manipulation of byte slices.
+// It is analogous to the facilities of the strings package.
+package bytes
+
+import (
+	// "internal/bytealg"
+	// "unicode"
+	// "unicode/utf8"
+)
+
+// Equal reports whether a and b
+// are the same length and contain the same bytes.
+// A nil argument is equivalent to an empty slice.
+preserves forall i int :: 0 <= i && i < len(a) ==> acc(&a[i], _)
+preserves forall i int :: 0 <= i && i < len(b) ==> acc(&b[i], _)
+decreases
+func Equal(a, b []byte) bool {
+	// Neither cmd/compile nor gccgo allocates for these string conversions.
+	return string(a) == string(b)
+}


### PR DESCRIPTION
As Is:
- no support for package bytes

To Be:
- bytes.gobra has been added
- bytes.Equal has been verified