### PR TITLE
Std lib changes from the verifiedSCION branch

### DIFF
--- a/src/main/resources/stubs/net/ip.gobra
+++ b/src/main/resources/stubs/net/ip.gobra
@@ -122,12 +122,12 @@ func (ip IP) IsGlobalUnicast() bool /*{
 
 // To4 converts the IPv4 address ip to a 4-byte representation.
 preserves forall i int :: 0 <= i && i < len(ip) ==> acc(&ip[i], 1/10000)
+ensures res != nil ==> len(res) == IPv4len
 ensures len(ip) == IPv4len ==> forall i int :: 0 <= i && i < len(ip) ==> &ip[i] == &res[i]
-ensures len(ip) == IPv6len && isZeros(ip[0:10]) && ip[10] == 255 && ip[11] == 255 ==> len(res) == IPv4len && forall i int :: 0 <= i && i < IPv4len ==> &ip[12+i] == &res[i]
-ensures (len(ip) == IPv6len && res != nil) ==> (len(res) == IPv4len && forall i int :: 0 <= i && i < IPv4len ==> &ip[12+i] == &res[i])
+ensures (len(ip) == IPv6len && isZeros(ip[0:10]) && ip[10] == 255 && ip[11] == 255) ==> res != nil
+ensures (len(ip) == IPv6len && res != nil) ==> (forall i int :: 0 <= i && i < IPv4len ==> &ip[12+i] == &res[i])
 ensures len(ip) != IPv4len && len(ip) != IPv6len ==> res == nil
 ensures len(ip) == IPv4len ==> len(res) == IPv4len
-ensures res != nil ==> len(res) == IPv4len
 decreases
 func (ip IP) To4() (res IP) {
 	if len(ip) == IPv4len {

--- a/src/main/resources/stubs/net/ip.gobra
+++ b/src/main/resources/stubs/net/ip.gobra
@@ -113,6 +113,7 @@ ensures len(ip) == IPv6len && isZeros(ip[0:10]) && ip[10] == 255 && ip[11] == 25
 ensures len(ip) != IPv4len && len(ip) != IPv6len ==> res == nil
 ensures len(ip) == IPv4len ==> len(res) == IPv4len
 ensures res != nil ==> len(res) == IPv4len
+decreases
 func (ip IP) To4() (res IP) {
 	if len(ip) == IPv4len {
 		return ip
@@ -153,6 +154,7 @@ preserves forall i int :: 0 <= i && i < len(ip) ==> acc(&ip[i], 1/10000)
 func (ip IP) Mask(mask IPMask) IP
 
 preserves forall i int :: 0 <= i && i < len(ip) ==> acc(&ip[i], 1/10000)
+decreases _
 func (ip IP) String() string
 
 // MarshalText implements the encoding.TextMarshaler interface.
@@ -186,6 +188,7 @@ func (ip *IP) UnmarshalText(text []byte) error
 // considered to be equal.
 preserves forall i int :: 0 <= i && i < len(ip) ==> acc(&ip[i], 1/10000)
 preserves forall i int :: 0 <= i && i < len(x) ==> acc(&x[i], 1/10000)
+decreases _
 func (ip IP) Equal(x IP) bool // {
 //	if len(ip) == len(x) {
 //		return bytealg.Equal(ip, x)
@@ -224,6 +227,7 @@ func (n *IPNet) String() string
 
 // ParseIP parses s as an IP address, returning the result.
 ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+decreases _
 func ParseIP(s string) (res IP)
 
 // ParseCIDR parses s as a CIDR notation IP address and prefix length,

--- a/src/main/resources/stubs/net/ip.gobra
+++ b/src/main/resources/stubs/net/ip.gobra
@@ -22,6 +22,20 @@ type IPNet struct {
 	Mask IPMask
 }
 
+pred (ip IP) Mem() {
+	(len(ip) == IPv4len || len(ip) == IPv6len) &&
+	forall i int :: 0 <= i && i < len(ip) ==> acc(&ip[i])
+}
+
+pred (mask IPMask) Mem() {
+	(len(mask) == IPv4len || len(mask) == IPv6len) &&
+	forall i int :: 0 <= i && i < len(mask) ==> acc(&mask[i])
+}
+
+pred (ipnet *IPNet) Mem() {
+	acc(ipnet) && ipnet.IP.Mem() && ipnet.Mask.Mem()
+}
+
 // IPv4 returns the IP address (in 16-byte form) of the
 // IPv4 address a.b.c.d.
 ensures len(res) == 4 && forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
@@ -110,6 +124,7 @@ func (ip IP) IsGlobalUnicast() bool /*{
 preserves forall i int :: 0 <= i && i < len(ip) ==> acc(&ip[i], 1/10000)
 ensures len(ip) == IPv4len ==> forall i int :: 0 <= i && i < len(ip) ==> &ip[i] == &res[i]
 ensures len(ip) == IPv6len && isZeros(ip[0:10]) && ip[10] == 255 && ip[11] == 255 ==> len(res) == IPv4len && forall i int :: 0 <= i && i < IPv4len ==> &ip[12+i] == &res[i]
+ensures (len(ip) == IPv6len && res != nil) ==> (len(res) == IPv4len && forall i int :: 0 <= i && i < IPv4len ==> &ip[12+i] == &res[i])
 ensures len(ip) != IPv4len && len(ip) != IPv6len ==> res == nil
 ensures len(ip) == IPv4len ==> len(res) == IPv4len
 ensures res != nil ==> len(res) == IPv4len

--- a/src/main/resources/stubs/net/iprawsock.gobra
+++ b/src/main/resources/stubs/net/iprawsock.gobra
@@ -38,7 +38,7 @@ type IPAddr struct {
 }
 
 pred (a *IPAddr) Mem() {
-    acc(a) && forall i int :: 0 <= i && i < len(a.IP) ==> acc(&(a.IP)[i])
+    acc(a) && a.IP.Mem()
 }
 
 (*IPAddr) implements Addr {

--- a/src/main/resources/stubs/net/iprawsock.gobra
+++ b/src/main/resources/stubs/net/iprawsock.gobra
@@ -38,7 +38,9 @@ type IPAddr struct {
 }
 
 pred (a *IPAddr) Mem() {
-    acc(a) && a.IP.Mem()
+    // The second conjunct should be eventually replaced by a.IP.Mem().
+    // However, doing this at the moment requires changes in the VerifiedSCION codebase.
+    acc(a) && forall i int :: 0 <= i && i < len(a.IP) ==> acc(&(a.IP)[i])
 }
 
 (*IPAddr) implements Addr {

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -294,14 +294,12 @@ type DNSError struct {
 pred (e *DNSError) Mem() { acc(e) }
 
 preserves e != nil ==> acc(e, 1/1000)
-trusted
 func (e *DNSError) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
 	s := "lookup " + e.Name
 	if e.Server != "" {
-		/* operation causes exception in Gobra */
 		s += " on " + e.Server
 	}
 	s += ": " + e.Err

--- a/src/main/resources/stubs/net/net.gobra
+++ b/src/main/resources/stubs/net/net.gobra
@@ -294,12 +294,14 @@ type DNSError struct {
 pred (e *DNSError) Mem() { acc(e) }
 
 preserves e != nil ==> acc(e, 1/1000)
+trusted
 func (e *DNSError) Error() string {
 	if e == nil {
 		return "<nil>"
 	}
 	s := "lookup " + e.Name
 	if e.Server != "" {
+		/* operation causes exception in Gobra */
 		s += " on " + e.Server
 	}
 	s += ": " + e.Err

--- a/src/main/resources/stubs/net/udpsock.gobra
+++ b/src/main/resources/stubs/net/udpsock.gobra
@@ -31,7 +31,9 @@ type UDPAddr struct {
 }
 
 pred (a *UDPAddr) Mem() {
-    acc(a) && a.IP.Mem()
+    // The second conjunct should be eventually replaced by a.IP.Mem().
+    // However, doing this at the moment requires changes in the VerifiedSCION codebase.
+    acc(a) && forall i int :: 0 <= i && i < len(a.IP) ==> acc(&(a.IP)[i])
 }
 
 (*UDPAddr) implements Addr {

--- a/src/main/resources/stubs/net/udpsock.gobra
+++ b/src/main/resources/stubs/net/udpsock.gobra
@@ -31,7 +31,7 @@ type UDPAddr struct {
 }
 
 pred (a *UDPAddr) Mem() {
-    acc(a) && (forall i int :: 0 <= i && i < len(a.IP) ==> acc(&(a.IP)[i]))
+    acc(a) && a.IP.Mem()
 }
 
 (*UDPAddr) implements Addr {

--- a/src/main/resources/stubs/strconv/atoi.gobra
+++ b/src/main/resources/stubs/strconv/atoi.gobra
@@ -25,6 +25,7 @@ type NumError struct {
 requires p > 0
 requires acc(e, p)
 ensures acc(e, p)
+decreases _
 func (e *NumError) Error(ghost p perm) string /*{
 	return "strconv." + e.Func + ": " + "parsing " + Quote(e.Num) + ": " + e.Err.Error()
 }*/
@@ -40,13 +41,15 @@ pure func (e *NumError) Unwrap() error { return e.Err }
 // const IntSize = intSize
 
 // ParseUint is like ParseInt but for unsigned numbers.
+requires base == 0 || (2 <= base && base <= 36)
 decreases _
 func ParseUint(s string, base int, bitSize int) (uint64, error)
 
 // ParseInt interprets a string s in the given base (0, 2 to 36) and
 // bit size (0 to 64) and returns the corresponding value i.
+requires base == 0 || (2 <= base && base <= 36)
 decreases _
-func ParseInt(s string, base int, bitSize int) (i int64, err error) 
+func ParseInt(s string, base int, bitSize int) (i int64, err error)
 
 // Atoi is equivalent to ParseInt(s, 10, 0), converted to type int.
 decreases _

--- a/src/main/resources/stubs/strconv/itoa.gobra
+++ b/src/main/resources/stubs/strconv/itoa.gobra
@@ -39,6 +39,7 @@ func FormatInt(i int64, base int) string {
 }
 
 // Itoa is equivalent to FormatInt(int64(i), 10).
+decreases
 func Itoa(i int) string {
 	return FormatInt(int64(i), 10)
 }

--- a/src/main/resources/stubs/strings/strings.gobra
+++ b/src/main/resources/stubs/strings/strings.gobra
@@ -104,21 +104,25 @@ func LastIndexByte(s string, c byte) int /*{
 // SplitN slices s into substrings separated by sep and returns a slice of
 // the substrings between those separators.
 ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+decreases _
 func SplitN(s, sep string, n int) (res []string)
 
 // SplitAfterN slices s into substrings after each instance of sep and
 // returns a slice of those substrings.
 ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+decreases _
 func SplitAfterN(s, sep string, n int) (res []string)
 
 // Split slices s into all substrings separated by sep and returns a slice of
 // the substrings between those separators.
 ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+decreases _
 func Split(s, sep string) (res []string) //{ return genSplit(s, sep, 0, -1) }
 
 // SplitAfter slices s into all substrings after each instance of sep and
 // returns a slice of those substrings.
 ensures forall i int :: 0 <= i && i < len(res) ==> acc(&res[i])
+decreases _
 func SplitAfter(s, sep string) (res []string) /*{
 	return genSplit(s, sep, len(sep), -1)
 }*/
@@ -230,13 +234,16 @@ pure func Repeat(s string, count int) (res string) /*{
 */
 
 // ToUpper returns s with all Unicode letters mapped to their upper case.
+decreases _
 func ToUpper(s string) string
 
 // ToLower returns s with all Unicode letters mapped to their lower case.
+decreases _
 func ToLower(s string) string
 
 // ToTitle returns a copy of the string s with all Unicode letters mapped to
 // their Unicode title case.
+decreases _
 func ToTitle(s string) string // { return Map(unicode.ToTitle, s) }
 
 // ToUpperSpecial returns a copy of the string s with all Unicode letters mapped to their
@@ -351,6 +358,7 @@ func LastIndexFunc(s string, f func(rune) bool) int {
 
 // Trim returns a slice of the string s with all leading and
 // trailing Unicode code points contained in cutset removed.
+decreases _
 func Trim(s, cutset string) string /*{
 	if s == "" || cutset == "" {
 		return s
@@ -363,6 +371,7 @@ func Trim(s, cutset string) string /*{
 // Unicode code points contained in cutset removed.
 //
 // To remove a prefix, use TrimPrefix instead.
+decreases _
 func TrimLeft(s, cutset string) string /*{
 	if s == "" || cutset == "" {
 		return s
@@ -375,6 +384,7 @@ func TrimLeft(s, cutset string) string /*{
 // Unicode code points contained in cutset removed.
 //
 // To remove a suffix, use TrimSuffix instead.
+decreases _
 func TrimRight(s, cutset string) string /*{
 	if s == "" || cutset == "" {
 		return s
@@ -399,6 +409,7 @@ func TrimPrefix(s, prefix string) string /*{
 
 // TrimSuffix returns s without the provided trailing suffix string.
 // If s doesn't end with suffix, s is returned unchanged.
+decreases _
 func TrimSuffix(s, suffix string) string /*{
 	if HasSuffix(s, suffix) {
 		return s[:len(s)-len(suffix)] // (joao): slicing a string is still unsupported
@@ -422,4 +433,5 @@ func ReplaceAll(s, oldS, newS string) string {
 func EqualFold(s, t string) bool
 
 // Index returns the index of the first instance of substr in s, or -1 if substr is not present in s.
+decreases _
 func Index(s, substr string) int

--- a/src/main/scala/viper/gobra/ast/internal/Program.scala
+++ b/src/main/scala/viper/gobra/ast/internal/Program.scala
@@ -888,10 +888,6 @@ sealed trait IntOperation extends Expr {
   override def typ: Type = IntT(Addressability.rValue)
 }
 
-sealed trait StringOperation extends Expr {
-  override val typ: Type = StringT(Addressability.rValue)
-}
-
 case class Negation(operand: Expr)(val info: Source.Parser.Info) extends BoolOperation
 
 sealed abstract class BinaryExpr(val operator: String) extends Expr {
@@ -953,8 +949,6 @@ case class ShiftRight(left: Expr, right: Expr)(val info: Source.Parser.Info) ext
   override val typ: Type = left.typ
 }
 case class BitNeg(op: Expr)(val info: Source.Parser.Info) extends IntOperation
-
-case class Concat(left: Expr, right: Expr)(val info: Source.Parser.Info) extends BinaryExpr("+") with StringOperation
 
 case class Conversion(newType: Type, expr: Expr)(val info: Source.Parser.Info) extends Expr {
   override def typ: Type = newType

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -1615,15 +1615,7 @@ object Desugar {
           case PAnd(left, right) => for {l <- go(left); r <- go(right)} yield in.And(l, r)(src)
           case POr(left, right) => for {l <- go(left); r <- go(right)} yield in.Or(l, r)(src)
 
-          case PAdd(left, right) =>
-            for {
-              l <- go(left)
-              r <- go(right)
-              res = (info.typ(left), info.typ(right)) match {
-                case (StringT, StringT) => in.Concat(l, r)(src)
-                case _ => in.Add(l, r)(src)
-              }
-            } yield res
+          case PAdd(left, right) => for {l <- go(left); r <- go(right)} yield in.Add(l, r)(src)
           case PSub(left, right) => for {l <- go(left); r <- go(right)} yield in.Sub(l, r)(src)
           case PMul(left, right) => for {l <- go(left); r <- go(right)} yield in.Mul(l, r)(src)
           case PMod(left, right) => for {l <- go(left); r <- go(right)} yield in.Mod(l, r)(src)

--- a/src/main/scala/viper/gobra/translator/encodings/FloatEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/FloatEncoding.scala
@@ -8,7 +8,6 @@ package viper.gobra.translator.encodings
 
 import org.bitbucket.inkytonik.kiama.==>
 import viper.gobra.ast.{internal => in}
-import viper.gobra.theory.Addressability
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.interfaces.{Collector, Context}
 import viper.gobra.translator.util.ViperWriter.CodeLevel.unit

--- a/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
@@ -64,7 +64,7 @@ class StringEncoding extends LeafTypeEncoding {
         unit(withSrc(vpr.DomainFuncApp(func = makeFunc(lit.s), Seq(), Map.empty), lit))
       case len @ in.Length(exp :: ctx.String()) =>
         for { e <- goE(exp) } yield withSrc(vpr.DomainFuncApp(func = lenFunc, Seq(e), Map.empty), len)
-      case concat @ in.Concat(l :: ctx.String(), r :: ctx.String()) =>
+      case concat @ in.Add(l :: ctx.String(), r :: ctx.String()) =>
         for {
           lEncoded <- goE(l)
           rEncoded <- goE(r)


### PR DESCRIPTION
This PR introduces small changes to the std lib (mostly termination measures) that are helpful to verify the SCION codebase. After this PR, the verified scion branch and master should be on par, with the exception of the support for the outline keyword (merged in the scion branch, not merged on master) which does not work well anyway.