### PR TITLE
Parser Improvements

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -1032,7 +1032,7 @@ object Parser {
         ) <~ not("(" | "{")
 
     lazy val typ : Parser[PType] =
-      "(" ~> typ <~ ")" | typeLit | qualifiedType | namedType | ghostTypeLit
+      "(" ~> typ <~ ")" | typeLit | ghostTypeLit | qualifiedType | namedType
 
     lazy val ghostTyp : Parser[PGhostType] =
       "(" ~> ghostTyp <~ ")" | ghostTypeLit

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -1129,7 +1129,7 @@ object Parser {
       declaredType ^^ PInterfaceName
 
     lazy val methodSpec: Parser[PMethodSig] =
-      "ghost".? ~ functionSpec ~ idnDef ~ signature ^^ { case isGhost ~ spec ~ id ~ sig => PMethodSig(id, sig._1, sig._2, spec, isGhost.isDefined) }
+      ("ghost".? <~ eos.?) ~ functionSpec ~ idnDef ~ signature ^^ { case isGhost ~ spec ~ id ~ sig => PMethodSig(id, sig._1, sig._2, spec, isGhost.isDefined) }
 
     lazy val predicateSpec: Parser[PMPredicateSig] =
       ("pred" ~> idnDef) ~ parameters ^^ PMPredicateSig

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -347,8 +347,8 @@ object Parser {
     /**
       * Optionally consumes nested curly brackets with arbitrary content if `specOnly` is turned on, otherwise optionally applies the parser `p`
       */
-    def specOnlyParser[T](p: Parser[T]): Parser[Option[T]] =
-      if (specOnly) nestedCurlyBracketsConsumer.? ^^ (_.flatten)
+    def specOnlyParser[T](isPure: Boolean, p: Parser[T]): Parser[Option[T]] =
+      if (specOnly && !isPure) nestedCurlyBracketsConsumer.? ^^ (_.flatten)
       else p.?
 
     /**
@@ -446,7 +446,7 @@ object Parser {
         spec <- functionSpec
         name <- "func" ~> idnDef
         sig  <- signature
-        body <- if (spec.isTrusted) nestedCurlyBracketsConsumer else specOnlyParser(blockWithBodyParameterInfo)
+        body <- if (spec.isTrusted) nestedCurlyBracketsConsumer else specOnlyParser(spec.isPure, blockWithBodyParameterInfo)
         // the start position has to be manually set as Kiama would otherwise only use the body's position as start & finish
       } yield PFunctionDecl(name, sig._1, sig._2, spec, body).from(spec)
 
@@ -489,7 +489,7 @@ object Parser {
         rcv  <- "func" ~> receiver
         name <- idnDef
         sig  <- signature
-        body <- if (spec.isTrusted) nestedCurlyBracketsConsumer else specOnlyParser(blockWithBodyParameterInfo)
+        body <- if (spec.isTrusted) nestedCurlyBracketsConsumer else specOnlyParser(spec.isPure, blockWithBodyParameterInfo)
         // the start position has to be manually set as Kiama would otherwise only use the body's position as start & finish
       } yield PMethodDecl(name, rcv, sig._1, sig._2, spec, body).from(spec)
 

--- a/src/test/resources/regressions/features/maps/math-maps-simple2.gobra
+++ b/src/test/resources/regressions/features/maps/math-maps-simple2.gobra
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package mathmaps
+
+ghost
+requires key in domain(m)
+ensures  value in range(m)
+ensures  m == resM
+func test(m dict[string]int, key string) (value int, resM dict[string]int) {
+    value := m[key]
+    resM := m
+}


### PR DESCRIPTION
Still a PR for the old parser but I need the following 3 improvements:
- keep bodies of pure functions & methods in imported packages (saves writing an artificial postcondition with the same assertion)
- 'ghost' can be on its own line in interface declarations (thus, one can write similar looking spec as one is used to write for regular functions/methods)
- ghost types can be parsed as one would expect. Without this change, the newly created test case could not be parsed

@jcp19 does the first improvement cause performance problems in VerifiedSCION? Alternatively, we could introduce an annotation `transparent` or `opaque` (depending on what the default should be) or a CLI option such that the behavior could be controlled