### PR TITLE
Ghost Interface Methods

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
@@ -57,7 +57,10 @@ trait NameResolution { this: TypeInfoImpl =>
         case decl: PTypeAlias => TypeAlias(decl, isGhost, this)
         case decl: PFunctionDecl => Function(decl, isGhost, this)
         case decl: PMethodDecl => MethodImpl(decl, isGhost, this)
-        case tree.parent.pair(spec: PMethodSig, tdef: PInterfaceType) => MethodSpec(spec, tdef, isGhost, this)
+        case tree.parent.pair(spec: PMethodSig, tdef: PInterfaceType) =>
+          // note that a ghost method is not wrapped in a ghost wrapper. Instead, `spec` has a ghost field.
+          // therefore, we do not use `isGhost` but `spec.isGhost`:
+          MethodSpec(spec, tdef, spec.isGhost, this)
 
         case decl: PFieldDecl => Field(decl, isGhost, this)
         case decl: PEmbeddedDecl => Embbed(decl, isGhost, this)

--- a/src/test/resources/regressions/features/interfaces/ghostMembers.gobra
+++ b/src/test/resources/regressions/features/interfaces/ghostMembers.gobra
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type someInterface interface {
+    ghost pure getValue() int
+}
+
+type someImplementation struct {
+    value int
+}
+// checks that `someImplementation` is indeed considered an implementation of `someInterface`, i.e., that the ghost
+// attribute in the interface and implementation is correctly handled.
+someImplementation implements someInterface
+
+ghost
+pure func (impl someImplementation) getValue() int {
+    return impl.value
+}


### PR DESCRIPTION
Previously, `ghost` annotations in an interface have not been correctly taken into account. In the added test case, Gobra used to complain that the implementation method is `ghost` but the declared method in the interface is not.