### PR TITLE
Implicit Conversion for Predicate Arguments

### DIFF
--- a/src/main/scala/viper/gobra/ast/frontend/AstPattern.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/AstPattern.scala
@@ -6,6 +6,7 @@
 
 package viper.gobra.ast.frontend
 
+import viper.gobra.frontend.info.base.Type.PredT
 import viper.gobra.frontend.info.base.{SymbolTable => st}
 import viper.gobra.frontend.info.implementation.resolution.MemberPath
 
@@ -65,11 +66,13 @@ object AstPattern {
   case class ReceivedPredicate(recv: PExpression, id: PIdnUse, path: Vector[MemberPath], symb: st.MPredicate) extends PredicateKind with Symbolic
   case class ImplicitlyReceivedInterfacePredicate(id: PIdnUse, symb: st.MPredicateSpec) extends PredicateKind with Symbolic // for predicate references within an interface definition
   case class PredicateExpr(typ: PType, id: PIdnUse, path: Vector[MemberPath], symb: st.MPredicate) extends PredicateKind with Symbolic
-  case class PredExprInstance(base: PExpression, args: Vector[PExpression]) extends PredicateKind
+  case class PredExprInstance(base: PExpression, args: Vector[PExpression], typ: PredT) extends PredicateKind
 
-  sealed trait BuiltInPredicateKind extends PredicateKind
+  sealed trait BuiltInPredicateKind extends PredicateKind with Symbolic {
+    def symb: st.BuiltInGhostEntity
+  }
 
-  case class BuiltInPredicate(id: PIdnUse, symb: st.BuiltInFPredicate) extends BuiltInPredicateKind with Symbolic
-  case class BuiltInReceivedPredicate(recv: PExpression, id: PIdnUse, path: Vector[MemberPath], symb: st.BuiltInMPredicate) extends BuiltInPredicateKind with Symbolic
-  case class BuiltInPredicateExpr(typ: PType, id: PIdnUse, path: Vector[MemberPath], symb: st.BuiltInMPredicate) extends BuiltInPredicateKind with Symbolic
+  case class BuiltInPredicate(id: PIdnUse, symb: st.BuiltInFPredicate) extends BuiltInPredicateKind
+  case class BuiltInReceivedPredicate(recv: PExpression, id: PIdnUse, path: Vector[MemberPath], symb: st.BuiltInMPredicate) extends BuiltInPredicateKind
+  case class BuiltInPredicateExpr(typ: PType, id: PIdnUse, path: Vector[MemberPath], symb: st.BuiltInMPredicate) extends BuiltInPredicateKind
 }

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -2936,7 +2936,8 @@ object Desugar {
         abstractType.typing(argsForTyping)
       }
 
-      /** args must not include the receiver in the case of received predicates */
+      /** args must not include the receiver in the case of received predicates in order that the FunctionT corresponding
+        * to the given predicate symbol has the same amount of parameters / parameter types */
       def convertArgs(args: Vector[in.Expr]): Vector[in.Expr] = {
         p.predicate match {
           case b: ap.BuiltInPredicateKind => arguments(getBuiltInPredType(b), args)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/AmbiguityResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/AmbiguityResolution.scala
@@ -105,7 +105,7 @@ trait AmbiguityResolution { this: TypeInfoImpl =>
           resolve(e) match {
             case Some(p: ap.FunctionKind) => Some(ap.FunctionCall(p, n.args))
             case Some(p: ap.PredicateKind) => Some(ap.PredicateCall(p, n.args))
-            case _ if exprType(e).isInstanceOf[PredT] => Some(ap.PredExprInstance(e, n.args))
+            case _ if exprType(e).isInstanceOf[PredT] => Some(ap.PredExprInstance(e, n.args, exprType(e).asInstanceOf[PredT]))
             case _ => None
           }
         case _ => violation(s"unexpected case reached: type conversion with arguments ${n.args}, expected single argument instead")

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -805,7 +805,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
                 case c => Violation.violation(s"This case should be unreachable, but got $c")
               }
 
-            case Some(ap.PredExprInstance(base, args)) =>
+            case Some(ap.PredExprInstance(base, args, _)) =>
               val index = args.indexWhere(_.eq(expr))
               violation(index >= 0, errorMessage)
               typ(base) match {

--- a/src/test/resources/regressions/features/interfaces/predicateWithInterfaceParam.gobra
+++ b/src/test/resources/regressions/features/interfaces/predicateWithInterfaceParam.gobra
@@ -1,0 +1,29 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type AnInterface interface {
+    pure getVal() int
+}
+
+type AnImplementation struct {}
+
+pure func (impl *AnImplementation) getVal() int {
+    return 42
+}
+
+pred somePredicate(param AnInterface) {
+    param.getVal() == 42
+}
+
+func client() {
+    impl := &AnImplementation{}
+    fold somePredicate(impl)
+    unfold somePredicate(impl)
+    // this also works with first class predicates:
+    fold somePredicate!<_!>(impl)
+    unfold somePredicate!<_!>(impl)
+    fold somePredicate!<impl!>()
+    unfold somePredicate!<impl!>()
+}


### PR DESCRIPTION
Using a struct for an interface parameter in function performs an implicit conversion `toInterface` such that the encoded Viper program is well typed. This implicit conversion is however not done for predicates, which is fixed by this PR.
The added unit test illustrates the problem best