### PR TITLE
Predicate Foldability

### DIFF
--- a/src/main/scala/viper/gobra/ast/frontend/AstPattern.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/AstPattern.scala
@@ -61,15 +61,18 @@ object AstPattern {
   case class PredicateCall(predicate: PredicateKind, args: Vector[PExpression]) extends Assertion
 
   sealed trait PredicateKind extends Assertion
+  sealed trait SymbolicPredicateKind extends PredicateKind with Symbolic {
+    def symb: st.Predicate
+  }
 
-  case class Predicate(id: PIdnUse, symb: st.FPredicate) extends PredicateKind with Symbolic
-  case class ReceivedPredicate(recv: PExpression, id: PIdnUse, path: Vector[MemberPath], symb: st.MPredicate) extends PredicateKind with Symbolic
-  case class ImplicitlyReceivedInterfacePredicate(id: PIdnUse, symb: st.MPredicateSpec) extends PredicateKind with Symbolic // for predicate references within an interface definition
-  case class PredicateExpr(typ: PType, id: PIdnUse, path: Vector[MemberPath], symb: st.MPredicate) extends PredicateKind with Symbolic
+  case class Predicate(id: PIdnUse, symb: st.FPredicate) extends SymbolicPredicateKind
+  case class ReceivedPredicate(recv: PExpression, id: PIdnUse, path: Vector[MemberPath], symb: st.MPredicate) extends SymbolicPredicateKind
+  case class ImplicitlyReceivedInterfacePredicate(id: PIdnUse, symb: st.MPredicateSpec) extends SymbolicPredicateKind // for predicate references within an interface definition
+  case class PredicateExpr(typ: PType, id: PIdnUse, path: Vector[MemberPath], symb: st.MPredicate) extends SymbolicPredicateKind
   case class PredExprInstance(base: PExpression, args: Vector[PExpression], typ: PredT) extends PredicateKind
 
   sealed trait BuiltInPredicateKind extends PredicateKind with Symbolic {
-    def symb: st.BuiltInGhostEntity
+    def symb: st.BuiltInPredicate
   }
 
   case class BuiltInPredicate(id: PIdnUse, symb: st.BuiltInFPredicate) extends BuiltInPredicateKind

--- a/src/main/scala/viper/gobra/frontend/info/base/BuiltInMemberTag.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/BuiltInMemberTag.scala
@@ -34,14 +34,18 @@ object BuiltInMemberTag {
     override def ghost: Boolean = true
   }
 
+  sealed trait BuiltInPredicateTag extends GhostBuiltInMember {
+    def isAbstract: Boolean
+  }
+
   sealed trait BuiltInFunctionTag extends BuiltInMemberTag {
     def isPure: Boolean
   }
-  sealed trait BuiltInFPredicateTag extends GhostBuiltInMember
+  sealed trait BuiltInFPredicateTag extends BuiltInPredicateTag
   sealed trait BuiltInMethodTag extends BuiltInMemberTag {
     def isPure: Boolean
   }
-  sealed trait BuiltInMPredicateTag extends GhostBuiltInMember
+  sealed trait BuiltInMPredicateTag extends BuiltInPredicateTag
 
 
   /** Built-in Function Tags */
@@ -72,6 +76,7 @@ object BuiltInMemberTag {
   case object PredTrueFPredTag extends BuiltInFPredicateTag {
     override def identifier: String = "PredTrue"
     override def name: String = "PredTrueFPredTag"
+    override def isAbstract: Boolean = false
   }
 
 
@@ -133,31 +138,37 @@ object BuiltInMemberTag {
   case object IsChannelMPredTag extends BuiltInMPredicateTag {
     override def identifier: String = "IsChannel"
     override def name: String = "IsChannelMPredTag"
+    override def isAbstract: Boolean = true
   }
 
   case object SendChannelMPredTag extends BuiltInMPredicateTag {
     override def identifier: String = "SendChannel"
     override def name: String = "SendChannelMPredTag"
+    override def isAbstract: Boolean = true
   }
 
   case object RecvChannelMPredTag extends BuiltInMPredicateTag {
     override def identifier: String = "RecvChannel"
     override def name: String = "RecvChannelMPredTag"
+    override def isAbstract: Boolean = true
   }
 
   case object ClosedMPredTag extends BuiltInMPredicateTag {
     override def identifier: String = "Closed"
     override def name: String = "ClosedMPredTag"
+    override def isAbstract: Boolean = true
   }
 
   case object ClosureDebtMPredTag extends BuiltInMPredicateTag {
     override def identifier: String = "ClosureDebt"
     override def name: String = "ClosureDebtMPredTag"
+    override def isAbstract: Boolean = true
   }
 
   case object TokenMPredTag extends BuiltInMPredicateTag {
     override def identifier: String = "Token"
     override def name: String = "TokenMPredTag"
+    override def isAbstract: Boolean = true
   }
 
 

--- a/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
@@ -10,7 +10,7 @@ import org.bitbucket.inkytonik.kiama.util.Messaging.Messages
 import org.bitbucket.inkytonik.kiama.util.{Entity, Environments}
 import viper.gobra.ast.frontend._
 import viper.gobra.frontend.info.ExternalTypeInfo
-import viper.gobra.frontend.info.base.BuiltInMemberTag.{BuiltInFPredicateTag, BuiltInFunctionTag, BuiltInMPredicateTag, BuiltInMemberTag, BuiltInMethodTag}
+import viper.gobra.frontend.info.base.BuiltInMemberTag.{BuiltInFPredicateTag, BuiltInFunctionTag, BuiltInMPredicateTag, BuiltInMemberTag, BuiltInMethodTag, BuiltInPredicateTag}
 
 
 object SymbolTable extends Environments[Entity] {
@@ -237,9 +237,12 @@ object SymbolTable extends Environments[Entity] {
   sealed trait BuiltInActualEntity extends BuiltInEntity with ActualRegular {
     override def ghost: Boolean = tag.ghost
   }
-  sealed trait BuiltInGhostEntity extends BuiltInEntity with GhostRegular
 
   sealed trait BuiltInMethodLike extends BuiltInEntity with TypeMember
+
+  sealed trait BuiltInPredicate extends BuiltInEntity with GhostRegular {
+    override def tag: BuiltInPredicateTag
+  }
 
   case class BuiltInFunction(tag: BuiltInFunctionTag, rep: PNode, context: ExternalTypeInfo) extends BuiltInActualEntity {
     def isPure: Boolean = tag.isPure
@@ -247,8 +250,8 @@ object SymbolTable extends Environments[Entity] {
   case class BuiltInMethod(tag: BuiltInMethodTag, rep: PNode, context: ExternalTypeInfo) extends BuiltInActualEntity with BuiltInMethodLike with ActualTypeMember {
     def isPure: Boolean = tag.isPure
   }
-  case class BuiltInFPredicate(tag: BuiltInFPredicateTag, rep: PNode, context: ExternalTypeInfo) extends BuiltInGhostEntity
-  case class BuiltInMPredicate(tag: BuiltInMPredicateTag, rep: PNode, context: ExternalTypeInfo) extends BuiltInGhostEntity with BuiltInMethodLike with GhostTypeMember
+  case class BuiltInFPredicate(tag: BuiltInFPredicateTag, rep: PNode, context: ExternalTypeInfo) extends BuiltInPredicate
+  case class BuiltInMPredicate(tag: BuiltInMPredicateTag, rep: PNode, context: ExternalTypeInfo) extends BuiltInPredicate with BuiltInMethodLike with GhostTypeMember
 
 
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -422,6 +422,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
         }
 
     case n: PUnfolding => isExpr(n.op).out ++ isPureExpr(n.op) ++
+      wellDefFoldable(n.pred) ++
       error(
         n.pred,
         s"unfolding predicate expression instance ${n.pred} not supported",

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
@@ -9,6 +9,7 @@ package viper.gobra.frontend.info.implementation.typing.ghost
 import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error, noMessages}
 import viper.gobra.ast.frontend.{AstPattern => ap}
 import viper.gobra.ast.frontend._
+import viper.gobra.frontend.info.base.{SymbolTable => st}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.frontend.info.implementation.typing.BaseTyping
 
@@ -27,13 +28,26 @@ trait GhostStmtTyping extends BaseTyping { this: TypeInfoImpl =>
     case PApplyWand(wand) => assignableToSpec(wand)
   }
 
-  private def wellDefFoldable(acc: PPredicateAccess): Messages =
+  private[typing] def wellDefFoldable(acc: PPredicateAccess): Messages = {
+    def isNonAbstract(p: st.Predicate): Messages = p match {
+      case fp: st.FPredicate => error(acc, s"abstract predicates are not foldable", fp.decl.body.isEmpty)
+      case st.MPredicateImpl(decl, _) => error(acc, s"abstract predicates are not foldable", decl.body.isEmpty)
+      case _: st.MPredicateSpec => noMessages // interface well-definedness will make sure that implementations implement the declared predicates
+    }
+
     resolve(acc.pred) match {
       case Some(_: ap.PredExprInstance) =>
         error(
           acc,
           s"expected a predicate constructor, but got ${acc.pred.base}",
           !acc.pred.base.isInstanceOf[PPredConstructor])
-      case _ => noMessages
+      case Some(ap.PredicateCall(pred, _)) => pred match {
+        case p: ap.SymbolicPredicateKind => isNonAbstract(p.symb)
+        case p: ap.BuiltInPredicateKind => error(acc, s"abstract predicates are not foldable", p.symb.tag.isAbstract)
+        case _: ap.PredExprInstance => error(acc, s"predicate expression calls are not foldable")
+      }
+
+      case _ => error(acc, s"unexpected predicate access")
     }
+  }
 }

--- a/src/test/resources/regressions/features/predicates/foldability.gobra
+++ b/src/test/resources/regressions/features/predicates/foldability.gobra
@@ -1,0 +1,79 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// this test checks that not all predicate calls are permitted in fold/unfold/unfolding stmts/exprs
+
+pred AbstractFPred()
+
+type SomeStruct struct{}
+pred (s SomeStruct) AbstractMPred()
+
+type SomeInterface interface {
+    pred InterfacePred()
+}
+
+func fPred() bool {
+    //:: ExpectedOutput(type_error)
+    fold AbstractFPred()
+    //:: ExpectedOutput(type_error)
+    unfold AbstractFPred()
+    //:: ExpectedOutput(type_error)
+    return unfolding AbstractFPred() in true
+}
+
+func mPred(s SomeStruct) bool {
+    //:: ExpectedOutput(type_error)
+    fold s.AbstractMPred()
+    //:: ExpectedOutput(type_error)
+    unfold s.AbstractMPred()
+    //:: ExpectedOutput(type_error)
+    return unfolding s.AbstractMPred() in true
+}
+
+func interfacePred(itf SomeInterface) bool {
+    // this should succeed
+    fold itf.InterfacePred()
+    // this should succeed
+    unfold itf.InterfacePred()
+    // this should succeed
+    return unfolding itf.InterfacePred() in true
+}
+
+func predTrue() {
+    // this should succeed
+    fold PredTrue!<!>()
+}
+
+func isChannel(channel chan int) {
+    //:: ExpectedOutput(type_error)
+    fold channel.IsChannel()
+}
+
+pred eq(x *int, y *int) {
+	x == y
+}
+
+func predExprs() bool {
+	x@ := 1
+	y@ := 2
+	// having a predicate constructor as a base is supported:
+	fold eq!<&x, _!>(&x)
+	fold eq!<_, &y!>(&y)
+	fold eq!<_, _!>(&x, &x)
+	fold eq!<&x, &x!>()
+	// predicate constructors in unfolding expressions is not supported:
+	//:: ExpectedOutput(type_error)
+	b := unfolding eq!<&x, &x!>() in true
+
+	predExpr := eq!<&x, &x!>;
+	//:: ExpectedOutput(type_error)
+    fold predExpr()
+    //:: ExpectedOutput(type_error)
+    unfold predExpr()
+    // there are two errors in the next statement (predicate expression instead of predicate constructor and unfolding a predicate expression)
+    // but our unit testing framework is happy with just a single expected output annotation:
+    //:: ExpectedOutput(type_error)
+    return unfolding predExpr() in true
+}


### PR DESCRIPTION
Strengthens foldability checks within Gobra to avoid situations in which Silicon would crash while unfolding an abstract predicate