### PR TITLE
Contextual Unbounded Struct Check

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/UnderlyingType.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/UnderlyingType.scala
@@ -20,13 +20,18 @@ trait UnderlyingType { this: TypeInfoImpl =>
       case t => t
     }
 
-  lazy val underlyingTypeP: PType => Option[PType] = {
-    def inCtx(c: ExternalTypeInfo, rhs: PType): Option[PType] = c match {
-      case c: UnderlyingType => c.underlyingTypeP(rhs)
+  lazy val underlyingTypeP: PType => Option[PType] = t => {
+    underlyingTypeWithCtxP(t).map(_._1)
+  }
+
+  /** returns the underlying type with the context in which it occurs */
+  lazy val underlyingTypeWithCtxP: PType => Option[(PType, UnderlyingType)] = {
+    def inCtx(c: ExternalTypeInfo, rhs: PType): Option[(PType, UnderlyingType)] = c match {
+      case c: UnderlyingType => c.underlyingTypeWithCtxP(rhs)
       case _ => None
     }
 
-    attr[PType, Option[PType]] {
+    attr[PType, Option[(PType, UnderlyingType)]] {
       case PNamedOperand(t) => entity(t) match {
         case st.NamedType(decl, _, ctx) => inCtx(ctx, decl.right)
         case st.TypeAlias(decl, _, ctx) => inCtx(ctx, decl.right)
@@ -37,7 +42,7 @@ trait UnderlyingType { this: TypeInfoImpl =>
         case st.TypeAlias(decl, _, ctx) => inCtx(ctx, decl.right)
         case _ => None // type not defined
       }
-      case t => Some(t)
+      case t => Some((t, this))
     }
   }
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/TypeTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/TypeTyping.scala
@@ -7,11 +7,13 @@
 package viper.gobra.frontend.info.implementation.typing
 
 import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error, noMessages}
+
 import scala.collection.immutable.ListMap
 import viper.gobra.ast.frontend._
 import viper.gobra.ast.frontend.{AstPattern => ap}
 import viper.gobra.frontend.info.base.Type.{StructT, _}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
+import viper.gobra.frontend.info.implementation.property.UnderlyingType
 
 trait TypeTyping extends BaseTyping { this: TypeInfoImpl =>
 
@@ -168,20 +170,40 @@ trait TypeTyping extends BaseTyping { this: TypeInfoImpl =>
     * or other cyclic structures.
     */
   def cyclicStructDef(struct: PStructType, name: Option[PIdnDef] = None) : Boolean = {
-    // `visitedTypes` keeps track of the types that were already discovered and checked,
-    // used for detecting cyclic definition chains
-    def isCyclic: (PStructType, Set[String]) => Boolean = (struct, visitedTypes) => {
-      val fieldTypes = struct.fields.map(_.typ) ++ struct.embedded.map(_.typ.typ)
-
-      fieldTypes exists {
-        case s: PStructType => isCyclic(s, visitedTypes)
-        case n: PNamedType if visitedTypes.contains(n.name) => true
-        case n: PNamedType if underlyingTypeP(n).exists(_.isInstanceOf[PStructType]) =>
-          isCyclic(underlyingTypeP(n).get.asInstanceOf[PStructType], visitedTypes + n.name)
-        case _ => false
-      }
+    // this function is indirectly cached because `underlyingTypeWithCtxP` is cached.
+    def isUnderlyingStructType(n: PNamedType, ctx: UnderlyingType): Option[(PStructType, UnderlyingType)] = ctx.underlyingTypeWithCtxP(n) match {
+      case Some((structT: PStructType, structCtx)) => Some(structT, structCtx)
+      case _ => None
     }
 
-    isCyclic(struct, name.map(_.name).toSet)
+    // `visitedTypes` keeps track of the types that were already discovered and checked,
+    // used for detecting cyclic definition chains
+    // `ctx` of type UnderlyingType represents in current context in which a lookup should happen
+    // ExternalTypeInfo is not used as we need access to `underlyingTypeWithCtxP`, which is not exposed by the interface.
+    def isCyclic: (PStructType, Set[String], UnderlyingType) => Boolean = (struct, visitedTypes, ctx) => {
+      // the goal is to detect whether a struct type has infinity size and cause a corresponding error before
+      // running into non-termination issues in Gobra.
+      // Cycles in the field types are one possible source for infinite size of the resulting struct.
+      // Another source are fields of (fixed-size) array type with the same element type as the struct.
+      // Note however that pointers (and thus e.g. slices) are enough to break these cycles and thus a field with
+      // pointer type to the current struct can be permitted and still results in a finite struct size.
+      val fieldTypes = struct.fields.map(_.typ) ++ struct.embedded.map(_.typ.typ)
+      fieldTypes exists {
+        case s: PStructType => isCyclic(s, visitedTypes, this)
+        case n: PNamedType if visitedTypes.contains(n.name) => true
+        case n: PNamedType if isUnderlyingStructType(n, ctx).isDefined =>
+          val (structT, structCtx) = isUnderlyingStructType(n, ctx).get
+          isCyclic(structT, visitedTypes + n.name, structCtx)
+        case PArrayType(_, elemT: PNamedType) if visitedTypes.contains(elemT.name) => true
+        case PArrayType(_, elemT: PNamedType) if isUnderlyingStructType(elemT, ctx).isDefined =>
+          val (structT, structCtx) = isUnderlyingStructType(elemT, ctx).get
+          isCyclic(structT, visitedTypes + elemT.name, structCtx)
+        // PDot (for qualifiedly imported types) does not need to be handled because cycles are prevented by non-cyclic imports
+        case _ => false
+      }
+
+    }
+
+    isCyclic(struct, name.map(_.name).toSet, this)
   }
 }

--- a/src/test/resources/regressions/features/structs/cyclic-struct-def-check.gobra
+++ b/src/test/resources/regressions/features/structs/cyclic-struct-def-check.gobra
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// ##(-I ./)
+
+import . "cyclic-struct-def-check"
+
+// note that this test case does not check whether Gobra detects a cyclic struct definition
+// instead, this test case makes sure that the right type checker context is used when performing this check.
+
+type ClientState struct {
+    someStruct SomeStruct
+}

--- a/src/test/resources/regressions/features/structs/cyclic-struct-def-check/pkg.gobra
+++ b/src/test/resources/regressions/features/structs/cyclic-struct-def-check/pkg.gobra
@@ -1,0 +1,10 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type SomeStruct struct {
+    nested NestedStruct
+}
+
+type NestedStruct struct {}

--- a/src/test/resources/regressions/features/structs/cyclic-struct-def-check2.gobra
+++ b/src/test/resources/regressions/features/structs/cyclic-struct-def-check2.gobra
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// ##(-I ./)
+
+import pkg "cyclic-struct-def-check"
+
+// this test case is very similar to `cyclic-struct-def-check.gobra` except that it uses a qualified import
+
+type ClientState struct {
+    someStruct pkg.SomeStruct
+}


### PR DESCRIPTION
Currently, Gobra checks for unbounded structs by following the underlying type of its struct fields and thus checking for potential cycles. However, the context in which the underlying types are declared is not considered, meaning that a not in tree exception occurs for the `cyclic-struct-def-check.gobra` test case.
This PR fixes this behavior by extending the `underlyingTypeP` function to provide not only the type but also its context. For compatibility reasons, this function is called `underlyingTypeWithCtxP`