### PR TITLE
Fixes 401 and 402

### DIFF
--- a/src/main/scala/viper/gobra/translator/implementations/components/ConditionsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/ConditionsImpl.scala
@@ -13,6 +13,7 @@ import viper.gobra.translator.Names
 import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.Conditions
 import viper.gobra.translator.util.FunctionGeneratorWithoutContext
+import viper.silver.plugin.standard.termination
 import viper.silver.verifier.ErrorReason
 import viper.silver.{ast => vpr}
 import viper.silver.verifier.{errors => vprerr}
@@ -30,15 +31,18 @@ class ConditionsImpl extends Conditions {
     * Generates:
     * function assertArg1(b: Boolean): Boolean
     *   requires b
+    *   decreases
     * { true }
     */
   private val assertFunction: vpr.Function = {
     val b = vpr.LocalVarDecl("b", vpr.Bool)()
+    // empty termination measure
+    val terminationMeasure = termination.DecreasesTuple(Seq.empty, None)()
     vpr.Function(
       name = Names.assertFunc,
       formalArgs = Seq(b),
       typ = vpr.Bool,
-      pres = Seq(b.localVar),
+      pres = Seq(b.localVar, terminationMeasure),
       posts = Seq.empty,
       body = Some(vpr.TrueLit()())
     )()
@@ -49,17 +53,20 @@ class ConditionsImpl extends Conditions {
     * Generates:
     * function assertArg2(b: Boolean, y: T): T
     *   requires b
+    *   decreases
     * { y }
     */
   private val typedAssertFunc = new FunctionGeneratorWithoutContext[vpr.Type] {
     override def genFunction(t: vpr.Type): vpr.Function = {
       val b = vpr.LocalVarDecl("b", vpr.Bool)()
       val y = vpr.LocalVarDecl("y", t)()
+      // empty termination measure
+      val terminationMeasure = termination.DecreasesTuple(Seq.empty, None)()
       vpr.Function(
         name = Names.typedAssertFunc(t),
         formalArgs = Seq(b, y),
         typ = t,
-        pres = Seq(b.localVar),
+        pres = Seq(b.localVar, terminationMeasure),
         posts = Seq.empty,
         body = Some(y.localVar)
       )()

--- a/src/test/resources/regressions/issues/000401.gobra
+++ b/src/test/resources/regressions/issues/000401.gobra
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type S struct {
+	m map[int]int
+}
+
+requires acc(s.m)
+decreases
+pure func f(s S) int {
+	return (s.m)[0]
+}

--- a/src/test/resources/regressions/issues/000402.gobra
+++ b/src/test/resources/regressions/issues/000402.gobra
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type S struct {
+	b []int
+}
+
+decreases
+pure func check(s S) bool {
+	return s.b == nil
+}


### PR DESCRIPTION
Adds termination measures to the viper functions generated from file `ConditionsImpl.scala` and adds a termination measure to the viper function `nilSlice` generated from the file `SliceEncoding.scala`.

Furthermore, I improved the documentation of functions in `SliceEncoding.scala` by adding `decreases` clauses where they were missing.

Closes #401 
Closes #402