### PR TITLE
More Consistent Viper ASTs

### DIFF
--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -1126,7 +1126,7 @@ case class PDomainFunction(id: PIdnDef,
                            result: PResult
                                  ) extends PGhostMisc with PScope with PCodeRoot with PDomainClause
 
-case class PDomainAxiom(exp: PExpression) extends PGhostMisc with PDomainClause
+case class PDomainAxiom(exp: PExpression) extends PGhostMisc with PScope with PCodeRoot with PDomainClause
 
 
 /**

--- a/src/main/scala/viper/gobra/ast/internal/transform/CGEdgesTerminationTransform.scala
+++ b/src/main/scala/viper/gobra/ast/internal/transform/CGEdgesTerminationTransform.scala
@@ -190,7 +190,7 @@ object CGEdgesTerminationTransform extends InternalTransform {
       case in.DefinedT(name, _) => in.DefinedTExpr(name)(src)
       case in.PointerT(t, _) => in.PointerTExpr(typeAsExpr(t)(src))(src)
       case in.TupleT(ts, _) => in.TupleTExpr(ts map(typeAsExpr(_)(src)))(src)
-      case in.StructT(_, fields: Vector[in.Field], _) =>
+      case in.StructT(fields: Vector[in.Field], _) =>
         in.StructTExpr(fields.map(field => (field.name, typeAsExpr(field.typ)(src), field.ghost)))(src)
       case _ => Violation.violation(s"no corresponding type expression matched: $t")
     }

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -2349,9 +2349,7 @@ object Desugar {
 
       case t: Type.StructT =>
         val inFields: Vector[in.Field] = structD(t, addrMod)(src)
-
-        val structName = nm.struct(t)
-        registerType(in.StructT(structName, inFields, addrMod))
+        registerType(in.StructT(inFields, addrMod))
 
       case Type.PredT(args) => in.PredT(args.map(typeD(_, Addressability.rValue)(src)), Addressability.rValue)
 
@@ -3076,15 +3074,6 @@ object Desugar {
       case _ => exprD(ctx)(triggerExp)
     }
 
-
-    //    private def origin(n: PNode): in.Origin = {
-//      val start = pom.positions.getStart(n).get
-//      val finish = pom.positions.getFinish(n).get
-//      val pos = pom.translate(start, finish)
-//      val code = pom.positions.substring(start, finish).get
-//      in.Origin(code, pos)
-//    }
-
     private def meta(n: PNode, context: TypeInfo = info): Source.Parser.Single = {
       val pom = context.getTypeInfo.tree.originalRoot.positions
       val start = pom.positions.getStart(n).get
@@ -3122,7 +3111,6 @@ object Desugar {
     private val METHODSPEC_PREFIX = "S"
     private val METHOD_PREFIX = "M"
     private val TYPE_PREFIX = "T"
-    private val STRUCT_PREFIX = "X"
     private val INTERFACE_PREFIX = "Y"
     private val DOMAIN_PREFIX = "D"
     private val LABEL_PREFIX = "L"
@@ -3196,17 +3184,6 @@ object Desugar {
     def inParam(idx: Int, s: PScope, context: ExternalTypeInfo): String = name(IN_PARAMETER_PREFIX)("P" + idx, s, context)
     def outParam(idx: Int, s: PScope, context: ExternalTypeInfo): String = name(OUT_PARAMETER_PREFIX)("P" + idx, s, context)
     def receiver(s: PScope, context: ExternalTypeInfo): String = name(RECEIVER_PREFIX)("R", s, context)
-
-    def struct(s: StructT): String = {
-      // we assume that structs are uniquely identified by the SourcePosition at which they were declared:
-      val pom = s.context.getTypeInfo.tree.originalRoot.positions
-      val start = pom.positions.getStart(s.decl).get
-      val finish = pom.positions.getFinish(s.decl).get
-      val pos = pom.translate(start, finish)
-      // replace characters that could be misinterpreted:
-      val structName = pos.toString.replace(".", "$")
-      s"$STRUCT_PREFIX$$$structName"
-    }
 
     def interface(s: InterfaceT): String = {
       if (s.isEmpty) {

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -439,7 +439,7 @@ object Desugar {
           )(src)
         } else if (rets.size == 1) { // multi assignment
           in.Seqn(Vector(
-            multiassD(returns.map(v => in.Assignee.Var(v)), rets.head)(src),
+            multiassD(returns.map(v => in.Assignee.Var(v)), rets.head, decl)(src),
             in.Return()(src)
           ))(src)
         } else {
@@ -582,7 +582,7 @@ object Desugar {
           )(src)
         } else if (rets.size == 1) { // multi assignment
           in.Seqn(Vector(
-            multiassD(returns.map(v => in.Assignee.Var(v)), rets.head)(src),
+            multiassD(returns.map(v => in.Assignee.Var(v)), rets.head, decl)(src),
             in.Return()(src)
           ))(src)
         } else {
@@ -790,7 +790,7 @@ object Desugar {
 
         idn match {
           case _: PWildcard =>
-            freshDeclaredExclusiveVar(t.withAddressability(Addressability.Exclusive))(src)
+            freshDeclaredExclusiveVar(t.withAddressability(Addressability.Exclusive), idn, info)(src)
 
           case _ =>
             val x = assignableVarD(ctx)(idn)
@@ -865,7 +865,7 @@ object Desugar {
                 for{le <- goL(left.head); re <- goE(right.head)} yield singleAss(le, re)(src)
               } else {
                 // copy results to temporary variables and then to assigned variables
-                val temps = left map (l => freshExclusiveVar(typeD(info.typ(l), Addressability.exclusiveVariable)(src))(src))
+                val temps = left map (l => freshExclusiveVar(typeD(info.typ(l), Addressability.exclusiveVariable)(src), stmt, info)(src))
                 val resToTemps = (temps zip right).map{ case (l, r) =>
                   for{re <- goE(r)} yield singleAss(in.Assignee.Var(l), re)(src)
                 }
@@ -878,7 +878,7 @@ object Desugar {
               }
             } else if (right.size == 1) {
               for{les <- sequence(left map goL); re  <- goE(right.head)}
-                yield multiassD(les, re)(src)
+                yield multiassD(les, re, stmt)(src)
             } else { violation("invalid assignment") }
 
           case PAssignmentWithOp(right, op, left) =>
@@ -918,7 +918,7 @@ object Desugar {
                     dL <- leftOfAssignmentD(l)(typeD(info.typ(l), Addressability.exclusiveVariable)(src))
                   } yield in.Assignee.Var(dL)
                 })
-              } yield multiassD(les, re)(src))
+              } yield multiassD(les, re, stmt)(src))
             } else { violation("invalid assignment") }
 
           case PVarDecl(typOpt, right, left, _) =>
@@ -940,7 +940,7 @@ object Desugar {
                     dL <- leftOfAssignmentD(l)(re.typ)
                   } yield in.Assignee.Var(dL)
                 })
-              } yield multiassD(les, re)(src))
+              } yield multiassD(les, re, stmt)(src))
             } else if (right.isEmpty && typOpt.nonEmpty) {
               val typ = typeD(info.symbType(typOpt.get), Addressability.exclusiveVariable)(src)
               val lelems = sequence(left.map{ l =>
@@ -965,7 +965,7 @@ object Desugar {
             for {
               dPre <- maybeStmtD(ctx)(pre)(src)
               dExp <- exprD(ctx)(exp)
-              exprVar <- freshDeclaredExclusiveVar(dExp.typ.withAddressability(Addressability.exclusiveVariable))(dExp.info)
+              exprVar <- freshDeclaredExclusiveVar(dExp.typ.withAddressability(Addressability.exclusiveVariable), stmt, info)(dExp.info)
               exprAss = singleAss(in.Assignee.Var(exprVar), dExp)(dExp.info)
               _ <- write(exprAss)
               clauses <- sequence(cases.map(c => switchCaseD(c, exprVar)(ctx)))
@@ -1041,7 +1041,7 @@ object Desugar {
             for {
               dPre <- maybeStmtD(ctx)(pre)(src)
               dExp <- exprD(ctx)(exp)
-              exprVar <- freshDeclaredExclusiveVar(dExp.typ.withAddressability(Addressability.exclusiveVariable))(dExp.info)
+              exprVar <- freshDeclaredExclusiveVar(dExp.typ.withAddressability(Addressability.exclusiveVariable), stmt, info)(dExp.info)
               exprAss = singleAss(in.Assignee.Var(exprVar), dExp)(dExp.info)
               _ <- write(exprAss)
               clauses <- sequence(cases.map(c => typeSwitchCaseD(c, exprVar, binder)(ctx)))
@@ -1126,15 +1126,15 @@ object Desugar {
       } yield (acceptCond, stmt)
     }
 
-    def multiassD(lefts: Vector[in.Assignee], right: in.Expr)(src: Source.Parser.Info): in.Stmt = {
+    def multiassD(lefts: Vector[in.Assignee], right: in.Expr, astCtx: PNode)(src: Source.Parser.Info): in.Stmt = {
 
       right match {
         case in.Tuple(args) if args.size == lefts.size =>
           in.Seqn(lefts.zip(args) map { case (l, r) => singleAss(l, r)(src)})(src)
 
         case n: in.TypeAssertion if lefts.size == 2 =>
-          val resTarget = freshExclusiveVar(lefts(0).op.typ.withAddressability(Addressability.exclusiveVariable))(src)
-          val successTarget = freshExclusiveVar(lefts(1).op.typ.withAddressability(Addressability.exclusiveVariable))(src)
+          val resTarget = freshExclusiveVar(lefts(0).op.typ.withAddressability(Addressability.exclusiveVariable), astCtx, info)(src)
+          val successTarget = freshExclusiveVar(lefts(1).op.typ.withAddressability(Addressability.exclusiveVariable), astCtx, info)(src)
           in.Block(
             Vector(resTarget, successTarget),
             Vector( // declare for the fresh variables is not necessary because they are put into a block
@@ -1145,8 +1145,8 @@ object Desugar {
           )(src)
 
         case n: in.Receive if lefts.size == 2 =>
-          val resTarget = freshExclusiveVar(lefts(0).op.typ.withAddressability(Addressability.exclusiveVariable))(src)
-          val successTarget = freshExclusiveVar(in.BoolT(Addressability.exclusiveVariable))(src)
+          val resTarget = freshExclusiveVar(lefts(0).op.typ.withAddressability(Addressability.exclusiveVariable), astCtx, info)(src)
+          val successTarget = freshExclusiveVar(in.BoolT(Addressability.exclusiveVariable), astCtx, info)(src)
           val recvChannelProxy = n.recvChannel
           val recvGivenPermProxy = n.recvGivenPerm
           val recvGotPermProxy = n.recvGotPerm
@@ -1161,8 +1161,8 @@ object Desugar {
           )(src)
 
         case l@ in.IndexedExp(base, _, _) if base.typ.isInstanceOf[in.MapT] && lefts.size == 2 =>
-          val resTarget = freshExclusiveVar(lefts(0).op.typ.withAddressability(Addressability.exclusiveVariable))(src)
-          val successTarget = freshExclusiveVar(in.BoolT(Addressability.exclusiveVariable))(src)
+          val resTarget = freshExclusiveVar(lefts(0).op.typ.withAddressability(Addressability.exclusiveVariable), astCtx, info)(src)
+          val successTarget = freshExclusiveVar(in.BoolT(Addressability.exclusiveVariable), astCtx, info)(src)
           in.Block(
             Vector(resTarget, successTarget),
             Vector(
@@ -1191,7 +1191,7 @@ object Desugar {
       } yield in.FieldRef(base, f)(src)
     }
 
-    def functionCallD(ctx: FunctionContext)(p: ap.FunctionCall)(src: Meta): Writer[in.Expr] = {
+    def functionCallD(ctx: FunctionContext)(p: ap.FunctionCall, expr: PInvoke)(src: Meta): Writer[in.Expr] = {
       def getBuiltInFuncType(f: ap.BuiltInFunctionKind): FunctionT = {
         val abstractType = info.typ(f.symb.tag)
         val argsForTyping = f match {
@@ -1297,13 +1297,13 @@ object Desugar {
           val resT = typeD(ft.result, Addressability.callResult)(src)
           val targets = resT match {
             case in.VoidT => Vector()
-            case _ => Vector(freshExclusiveVar(resT)(src))
+            case _ => Vector(freshExclusiveVar(resT, expr, info)(src))
           }
           (resT, targets)
         case base: ap.Symbolic => base.symb match {
           case fsym: st.WithResult =>
             val resT = typeD(fsym.context.typ(fsym.result), Addressability.callResult)(src)
-            val targets = fsym.result.outs map (o => freshExclusiveVar(typeD(fsym.context.symbType(o.typ), Addressability.exclusiveVariable)(src))(src))
+            val targets = fsym.result.outs map (o => freshExclusiveVar(typeD(fsym.context.symbType(o.typ), Addressability.exclusiveVariable)(src), expr, info)(src))
             (resT, targets)
           case c => Violation.violation(s"This case should be unreachable, but got $c")
         }
@@ -1460,8 +1460,8 @@ object Desugar {
           indexedExprD(p.base, p.index)(ctx)(src) map in.Assignee.Index
         case Some(ap.BlankIdentifier(decl)) =>
           for {
-            expr <- exprD(ctx)(decl)
-            v <- freshDeclaredExclusiveVar(expr.typ)(src)
+            dExpr <- exprD(ctx)(decl)
+            v <- freshDeclaredExclusiveVar(dExpr.typ, expr, info)(src)
           } yield in.Assignee.Var(v)
         case p => Violation.violation(s"unexpected ast pattern $p")
       }
@@ -1539,7 +1539,7 @@ object Desugar {
             case c: PCompositeLit =>
               for {
                 c <- compositeLitD(ctx)(c)
-                v <- freshDeclaredExclusiveVar(in.PointerT(c.typ.withAddressability(Addressability.Shared), Addressability.reference))(src)
+                v <- freshDeclaredExclusiveVar(in.PointerT(c.typ.withAddressability(Addressability.Shared), Addressability.reference), expr, info)(src)
                 _ <- write(in.New(v, c)(src))
               } yield v
 
@@ -1701,7 +1701,7 @@ object Desugar {
 
           case b: PBlankIdentifier =>
             val typ = typeD(info.typ(b), Addressability.exclusiveVariable)(src)
-            freshDeclaredExclusiveVar(typ)(src)
+            freshDeclaredExclusiveVar(typ, expr, info)(src)
 
           case PReceive(op) =>
             for {
@@ -1718,7 +1718,7 @@ object Desugar {
             val resT = typeD(info.symbType(t), Addressability.Exclusive)(src)
 
             for {
-              target <- freshDeclaredExclusiveVar(resT)(src)
+              target <- freshDeclaredExclusiveVar(resT, expr, info)(src)
               argsD <- sequence(args map go)
               arg0 = argsD.lift(0)
               arg1 = argsD.lift(1)
@@ -1741,7 +1741,7 @@ object Desugar {
             val allocatedType = typeD(info.symbType(t), Addressability.Exclusive)(src)
             val targetT = in.PointerT(allocatedType.withAddressability(Addressability.Shared), Addressability.reference)
             for {
-              target <- freshDeclaredExclusiveVar(targetT)(src)
+              target <- freshDeclaredExclusiveVar(targetT, expr, info)(src)
               zero = in.DfltVal(allocatedType)(src)
               _ <- write(in.New(target, zero)(src))
             } yield target
@@ -1819,10 +1819,10 @@ object Desugar {
       }
     }
 
-    def invokeD(ctx: FunctionContext)(expr: PExpression): Writer[in.Expr] = {
+    def invokeD(ctx: FunctionContext)(expr: PInvoke): Writer[in.Expr] = {
       val src: Meta = meta(expr)
       info.resolve(expr) match {
-        case Some(p: ap.FunctionCall) => functionCallD(ctx)(p)(src)
+        case Some(p: ap.FunctionCall) => functionCallD(ctx)(p, expr)(src)
         case Some(ap.Conversion(typ, arg)) =>
           val typType = info.symbType(typ)
           val argType = info.typ(arg)
@@ -1831,7 +1831,7 @@ object Desugar {
             case (SliceT(IntT(TypeBounds.Byte)), StringT) =>
               val resT = typeD(SliceT(IntT(TypeBounds.Byte)), Addressability.Exclusive)(src)
               for {
-                target <- freshDeclaredExclusiveVar(resT)(src)
+                target <- freshDeclaredExclusiveVar(resT, expr, info)(src)
                 dArg <- exprD(ctx)(arg)
                 conv: in.EffectfulConversion = in.EffectfulConversion(target, resT, dArg)(src)
                 _ <- write(conv)
@@ -2429,14 +2429,14 @@ object Desugar {
       }
     }
 
-    def freshExclusiveVar(typ: in.Type)(info: Source.Parser.Info): in.LocalVar = {
+    def freshExclusiveVar(typ: in.Type, scope: PNode, ctx: ExternalTypeInfo)(info: Source.Parser.Info): in.LocalVar = {
       require(typ.addressability == Addressability.exclusiveVariable)
-      in.LocalVar(nm.fresh, typ)(info)
+      in.LocalVar(nm.fresh(scope, ctx), typ)(info)
     }
 
-    def freshDeclaredExclusiveVar(typ: in.Type)(info: Source.Parser.Info): Writer[in.LocalVar] = {
+    def freshDeclaredExclusiveVar(typ: in.Type, scope: PNode, ctx: ExternalTypeInfo)(info: Source.Parser.Info): Writer[in.LocalVar] = {
       require(typ.addressability == Addressability.exclusiveVariable)
-      val res = in.LocalVar(nm.fresh, typ)(info)
+      val res = in.LocalVar(nm.fresh(scope, ctx), typ)(info)
       declare(res).map(_ => res)
     }
 
@@ -2479,7 +2479,7 @@ object Desugar {
           noGhost match {
             case PNamedParameter(id, typ) =>
               val param = in.Parameter.In(idName(id, context), typeD(context.symbType(typ), Addressability.inParameter)(src))(src)
-              val local = Some(localAlias(localVarContextFreeD(id, context)))
+              val local = Some(localAlias(localVarContextFreeD(id, context), id, context))
               (param, local)
 
             case PUnnamedParameter(typ) =>
@@ -2500,7 +2500,7 @@ object Desugar {
           noGhost match {
             case PNamedParameter(id, typ) =>
               val param = in.Parameter.Out(idName(id, context), typeD(context.symbType(typ), Addressability.outParameter)(src))(src)
-              val local = Some(localAlias(localVarContextFreeD(id, context)))
+              val local = Some(localAlias(localVarContextFreeD(id, context), id, context))
               (param, local)
 
             case PUnnamedParameter(typ) =>
@@ -2517,7 +2517,7 @@ object Desugar {
       p match {
         case PNamedReceiver(id, typ, _) =>
           val param = in.Parameter.In(idName(id, context), typeD(context.symbType(typ), Addressability.receiver)(src))(src)
-          val local = Some(localAlias(localVarContextFreeD(id, context)))
+          val local = Some(localAlias(localVarContextFreeD(id, context), id, context))
           (param, local)
 
         case PUnnamedReceiver(typ) =>
@@ -2527,8 +2527,8 @@ object Desugar {
       }
     }
 
-    def localAlias(internal: in.LocalVar): in.LocalVar = internal match {
-      case in.LocalVar(id, typ) => in.LocalVar(nm.alias(id), typ)(internal.info)
+    def localAlias(internal: in.LocalVar, scope: PNode, ctx: ExternalTypeInfo): in.LocalVar = internal match {
+      case in.LocalVar(id, typ) => in.LocalVar(nm.alias(id, scope, ctx), typ)(internal.info)
     }
 
     def structD(struct: StructT, addrMod: Addressability)(src: Meta): Vector[in.Field] =
@@ -3129,22 +3129,30 @@ object Desugar {
     private val GLOBAL_PREFIX = "G"
     private val BUILTIN_PREFIX = "B"
 
-    private var counter = 0
+    /** the counter to generate fresh names depending on the current code root for which a fresh name should be generated */
+    private var nonceCounter: Map[PCodeRoot, Int] = Map.empty
 
-    private var scopeCounter = 0
+    /**
+      * there is a separate counter per code root in order that scope, identifiers, etc. of an unchanged function
+      * are consistently named across verification runs (i.e. independent of modifications to other function)
+      */
+    private var scopeCounter: Map[PCodeRoot, Int] = Map.empty
     private var scopeMap: Map[PScope, Int] = Map.empty
 
-    private def maybeRegister(s: PScope): Unit = {
+    private def maybeRegister(s: PScope, ctx: ExternalTypeInfo): Unit = {
       if (!(scopeMap contains s)) {
-        scopeMap += (s -> scopeCounter)
-        scopeCounter += 1
+        val codeRoot = ctx.codeRoot(s)
+        val value = scopeCounter.getOrElse(codeRoot, 0)
+
+        scopeMap += (s -> value)
+        scopeCounter += (codeRoot -> (value + 1))
       }
     }
 
     val implicitThis: String = Names.implicitThis
 
     private def name(postfix: String)(n: String, s: PScope, context: ExternalTypeInfo): String = {
-      maybeRegister(s)
+      maybeRegister(s, context)
       // n has occur first in order that function inverse properly works
       s"${n}_${context.pkgName}_$postfix${scopeMap(s)}" // deterministic
     }
@@ -3165,29 +3173,7 @@ object Desugar {
       case PMethodReceiveName(typ)    => nameWithoutScope(s"$METHOD_PREFIX${typ.name}")(n, context)
       case PMethodReceivePointer(typ) => nameWithoutScope(s"P$METHOD_PREFIX${typ.name}")(n, context)
     }
-    private def stringifyType(typ: in.Type): String = typ match {
-      case _: in.BoolT => "Bool"
-      case _: in.StringT => "String"
-      case in.IntT(_, kind) => s"Int${kind.name}"
-      case in.VoidT => ""
-      case _: in.PermissionT => "Permission"
-      case in.SortT => "Sort"
-      case in.ArrayT(len, elemT, _) => s"Array$len${stringifyType(elemT)}"
-      case in.SliceT(elemT, _) => s"Slice${stringifyType(elemT)}"
-      case in.SequenceT(elemT, _) => s"Sequence${stringifyType(elemT)}"
-      case in.SetT(elemT, _) => s"Set${stringifyType(elemT)}"
-      case in.MultisetT(elemT, _) => s"Multiset${stringifyType(elemT)}"
-      case in.OptionT(elemT, _) => s"Option${stringifyType(elemT)}"
-      case in.DefinedT(name, _) => s"Defined$name"
-      case in.PointerT(t, _) => s"Pointer${stringifyType(t)}"
-      // we use a dollar sign to mark the beginning and end of the type list to avoid that `Tuple(Tuple(X), Y)` and `Tuple(Tuple(X, Y))` map to the same name:
-      case in.TupleT(ts, _) => s"Tuple$$${ts.map(stringifyType).mkString("")}$$"
-      case in.PredT(ts, _) => s"Pred$$${ts.map(stringifyType).mkString("")}$$"
-      case in.StructT(name, fields, _) => s"Struct$name$$${fields.map(_.typ).map(stringifyType).mkString("")}$$"
-      case in.InterfaceT(name, _) => s"Interface$name"
-      case in.ChannelT(elemT, _) => s"Channel${stringifyType(elemT)}"
-      case t => Violation.violation(s"cannot stringify type $t")
-    }
+    private def stringifyType(typ: in.Type): String = Names.serializeType(typ)
     def builtInMember(tag: BuiltInMemberTag, dependantTypes: Vector[in.Type]): String = {
       val typeString = dependantTypes.map(stringifyType).mkString("_")
       s"${tag.identifier}_$BUILTIN_PREFIX$FUNCTION_PREFIX$typeString"
@@ -3195,11 +3181,15 @@ object Desugar {
 
     def inverse(n: String): String = n.substring(0, n.length - FIELD_PREFIX.length)
 
-    def alias(n: String): String = s"${n}_$COPY_PREFIX$fresh"
+    def alias(n: String, scope: PNode, ctx: ExternalTypeInfo): String = s"${n}_$COPY_PREFIX${fresh(scope, ctx)}"
 
-    def fresh: String = {
-      val f = FRESH_PREFIX + counter
-      counter += 1
+    /** returns a fresh string that is guaranteed to be unique in the root scope of `scope` (i.e. in the enclosing code root or domain in which `scope` occurs) */
+    def fresh(scope: PNode, ctx: ExternalTypeInfo): String = {
+      val codeRoot = ctx.codeRoot(scope)
+      val value = nonceCounter.getOrElse(codeRoot, 0)
+
+      val f = FRESH_PREFIX + value
+      nonceCounter += (codeRoot -> (value + 1))
       f
     }
 

--- a/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
+++ b/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.frontend.info
 
-import viper.gobra.ast.frontend.{PEmbeddedDecl, PExpression, PFieldDecl, PIdnNode, PIdnUse, PKeyedElement, PMPredicateDecl, PMPredicateSig, PMember, PMethodDecl, PMethodSig, PMisc, PNode, PParameter, PPkgDef, PScope, PType}
+import viper.gobra.ast.frontend.{PCodeRoot, PEmbeddedDecl, PExpression, PFieldDecl, PIdnNode, PIdnUse, PKeyedElement, PMPredicateDecl, PMPredicateSig, PMember, PMethodDecl, PMethodSig, PMisc, PNode, PParameter, PPkgDef, PScope, PType}
 import viper.gobra.frontend.info.base.BuiltInMemberTag.BuiltInMemberTag
 import viper.gobra.frontend.info.base.Type.{AbstractType, InterfaceT, StructT, Type}
 import viper.gobra.frontend.info.base.SymbolTable.{Embbed, Field, MPredicateImpl, MPredicateSpec, MethodImpl, MethodSpec, Regular, TypeMember}
@@ -87,4 +87,7 @@ trait ExternalTypeInfo {
 
   /** returns all implementation proofs found in the current package */
   def localImplementationProofs: Vector[(Type, InterfaceT, Vector[String], Vector[String])]
+
+  /** returns the code root for a given node; can only be called on nodes that are enclosed in a code root */
+  def codeRoot(n: PNode): PCodeRoot with PScope
 }

--- a/src/main/scala/viper/gobra/frontend/info/TypeInfo.scala
+++ b/src/main/scala/viper/gobra/frontend/info/TypeInfo.scala
@@ -21,8 +21,6 @@ trait TypeInfo extends ExternalTypeInfo {
   def addressability(expr: PExpression): Addressability
   def addressableVar(id: PIdnNode): Addressability
 
-  def codeRoot(n: PNode): PScope
-
   def tree: Tree[PNode, PPackage]
 
   def regular(n: PIdnNode): Regular

--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -79,7 +79,7 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context,
 
   override def scope(n: PIdnNode): PScope = enclosingIdScope(n)
 
-  override def codeRoot(n: PNode): PScope = enclosingCodeRoot(n)
+  override def codeRoot(n: PNode): PCodeRoot with PScope = enclosingCodeRoot(n)
 
   override def regular(n: PIdnNode): SymbolTable.Regular = entity(n) match {
     case r: Regular => r

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.frontend.info.implementation.typing.ghost
 
-import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error, noMessages}
+import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error}
 import viper.gobra.ast.frontend.{AstPattern => ap}
 import viper.gobra.ast.frontend._
 import viper.gobra.frontend.info.base.{SymbolTable => st}

--- a/src/main/scala/viper/gobra/reporting/DefaultMessageBackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/DefaultMessageBackTranslator.scala
@@ -20,8 +20,8 @@ class DefaultMessageBackTranslator(backTrackInfo: BackTrackInfo, config: Config)
   private def defaultTranslate: PartialFunction[Message, GobraMessage] = {
     case m: OverallSuccessMessage => GobraOverallSuccessMessage(m.verifier)
     case m: OverallFailureMessage => GobraOverallFailureMessage(m.verifier, translate(m.result))
-    case m@ EntitySuccessMessage(verifier, Source(info), _, _) => GobraEntitySuccessMessage(verifier, m.concerning, info)
-    case m@ EntityFailureMessage(verifier, Source(info), _, result, _) => GobraEntityFailureMessage(verifier, m.concerning, info, translate(result))
+    case m@ EntitySuccessMessage(verifier, Source(info), _, cached) => GobraEntitySuccessMessage(verifier, m.concerning, info, cached)
+    case m@ EntityFailureMessage(verifier, Source(info), _, result, cached) => GobraEntityFailureMessage(verifier, m.concerning, info, translate(result), cached)
   }
 
   private def translate(result: VerificationResult): VerifierResult =

--- a/src/main/scala/viper/gobra/reporting/Message.scala
+++ b/src/main/scala/viper/gobra/reporting/Message.scala
@@ -34,38 +34,41 @@ case class GobraOverallSuccessMessage(verifier: String) extends GobraVerificatio
   val result: VerifierResult = Success
 
   override def toString: String = s"overall_success_message(" +
-    s"verifier=${verifier})"
+    s"verifier=$verifier)"
 }
 
 case class GobraOverallFailureMessage(verifier: String, result: VerifierResult) extends GobraVerificationResultMessage {
   override val name: String = s"overall_failure_message"
 
   override def toString: String = s"overall_failure_message(" +
-    s"verifier=${verifier}, " +
+    s"verifier=$verifier, " +
     s"failure=${result.toString})"
 }
 
 sealed trait GobraEntityResultMessage extends GobraVerificationResultMessage {
   val entity: vpr.Member
   val concerning: Source.Verifier.Info
+  val cached: Boolean
 }
 
-case class GobraEntitySuccessMessage(verifier: String, entity: vpr.Member, concerning: Source.Verifier.Info) extends GobraEntityResultMessage {
+case class GobraEntitySuccessMessage(verifier: String, entity: vpr.Member, concerning: Source.Verifier.Info, cached: Boolean) extends GobraEntityResultMessage {
   override val name: String = s"entity_success_message"
   val result: VerifierResult = Success
 
   override def toString: String = s"entity_success_message(" +
-    s"verifier=${verifier}, " +
-    s"concerning=${concerning.toString})"
+    s"verifier=$verifier, " +
+    s"concerning=${concerning.toString}, " +
+    s"cached=${cached.toString})"
 }
 
-case class GobraEntityFailureMessage(verifier: String, entity: vpr.Member, concerning: Source.Verifier.Info, result: VerifierResult) extends GobraEntityResultMessage {
+case class GobraEntityFailureMessage(verifier: String, entity: vpr.Member, concerning: Source.Verifier.Info, result: VerifierResult, cached: Boolean) extends GobraEntityResultMessage {
   override val name: String = s"entity_failure_message"
 
   override def toString: String = s"entity_failure_message(" +
-    s"verifier=${verifier}, " +
+    s"verifier=$verifier, " +
     s"concerning=${concerning.toString}, " +
-    s"failure=${result.toString})"
+    s"failure=${result.toString}, " +
+    s"cached=${cached.toString})"
 }
 
 case class ChoppedProgressMessage(idx: Int, of: Int) extends GobraMessage {
@@ -77,7 +80,7 @@ case class PreprocessedInputMessage(input: String, preprocessedContent: () => St
   override val name: String = s"preprocessed_input_message"
 
   override def toString: String = s"preprocessed_input_message(" +
-    s"file=${input}, " +
+    s"file=$input, " +
     s"content=${preprocessedContent()})"
 }
 
@@ -85,7 +88,7 @@ case class ParsedInputMessage(input: String, ast: () => PProgram) extends GobraM
   override val name: String = s"parsed_input_message"
 
   override def toString: String = s"parsed_input_message(" +
-    s"file=${input}, " +
+    s"file=$input, " +
     s"ast=${ast().formatted})"
 }
 
@@ -93,7 +96,7 @@ case class ParserErrorMessage(input: Path, result: Vector[ParserError]) extends 
   override val name: String = s"parser_error_message"
 
   override def toString: String = s"parser_error_message(" +
-    s"file=${input}), " +
+    s"file=$input), " +
     s"errors=${result.map(_.toString).mkString(",")})"
 }
 
@@ -103,21 +106,21 @@ sealed trait TypeCheckMessage extends GobraMessage {
   val ast: () => PPackage
 
   override def toString: String = s"type_check_message(" +
-    s"files=${inputs})"
+    s"files=$inputs)"
 }
 
 case class TypeCheckSuccessMessage(inputs: Vector[String], ast: () => PPackage, erasedGhostCode: () => String, goifiedGhostCode: () => String) extends TypeCheckMessage {
   override val name: String = s"type_check_success_message"
 
   override def toString: String = s"type_check_success_message(" +
-    s"files=${inputs})"
+    s"files=$inputs)"
 }
 
 case class TypeCheckFailureMessage(inputs: Vector[String], packageName: PPkg, ast: () => PPackage, result: Vector[VerifierError]) extends TypeCheckMessage {
   override val name: String = s"type_check_failure_message"
 
   override def toString: String = s"type_check_failure_message(" +
-    s"files=${inputs}, " +
+    s"files=$inputs, " +
     s"package=$packageName, " +
     s"failures=${result.map(_.toString).mkString(",")})"
 }
@@ -126,7 +129,7 @@ case class TypeCheckDebugMessage(inputs: Vector[String], ast: () => PPackage, de
   override val name: String = s"type_check_debug_message"
 
   override def toString: String = s"type_check_debug_message(" +
-    s"files=${inputs}), " +
+    s"files=$inputs, " +
     s"debugInfo=${debugTypeInfo()})"
 }
 
@@ -134,7 +137,7 @@ case class DesugaredMessage(inputs: Vector[String], internal: () => in.Program) 
   override val name: String = s"desugared_message"
 
   override def toString: String = s"desugared_message(" +
-    s"files=${inputs}, " +
+    s"files=$inputs, " +
     s"internal=${internal().formatted})"
 }
 
@@ -142,7 +145,7 @@ case class AppliedInternalTransformsMessage(inputs: Vector[String], internal: ()
   override val name: String = s"transform_message"
 
   override def toString: String = s"transform_message(" +
-    s"files=${inputs}, " +
+    s"files=$inputs, " +
     s"internal=${internal().formatted})"
 }
 
@@ -150,7 +153,7 @@ case class GeneratedViperMessage(inputs: Vector[String], vprAst: () => vpr.Progr
   override val name: String = s"generated_viper_message"
 
   override def toString: String = s"generated_viper_message(" +
-    s"files=${inputs}, " +
+    s"files=$inputs, " +
     s"vprFormated=$vprAstFormatted)"
 
   lazy val vprAstFormatted: String = silver.ast.pretty.FastPrettyPrinter.pretty(vprAst())
@@ -160,7 +163,7 @@ case class ChoppedViperMessage(inputs: Vector[String], idx: Int, vprAst: () => v
   override val name: String = s"chopped_viper_message"
 
   override def toString: String = s"chopped_viper_message(" +
-    s"file=${inputs}, " +
+    s"file=$inputs, " +
     s"vprFormated=$vprAstFormatted)"
 
   lazy val vprAstFormatted: String = silver.ast.pretty.FastPrettyPrinter.pretty(vprAst())
@@ -181,6 +184,6 @@ abstract class SimpleMessage(val text: String) extends GobraMessage {
 }
 
 case class CopyrightReport(override val text: String) extends SimpleMessage(text) {
-  override def toString: String = s"copyright_report(text=${text.toString})"
+  override def toString: String = s"copyright_report(text=$text)"
   override val name: String = s"copyright_report"
 }

--- a/src/main/scala/viper/gobra/translator/Names.scala
+++ b/src/main/scala/viper/gobra/translator/Names.scala
@@ -44,7 +44,7 @@ object Names {
     // we use a dollar sign to mark the beginning and end of the type list to avoid that `Tuple(Tuple(X), Y)` and `Tuple(Tuple(X, Y))` map to the same name:
     case in.TupleT(ts, _) => s"Tuple$$${ts.map(serializeType).mkString("")}$$"
     case in.PredT(ts, _) => s"Pred$$${ts.map(serializeType).mkString("")}$$"
-    case in.StructT(name, fields, _) => s"Struct$name${serializeFields(fields)}"
+    case in.StructT(fields, _) => s"Struct${serializeFields(fields)}"
     case in.InterfaceT(name, _) => s"Interface$name"
     case in.ChannelT(elemT, _) => s"Channel${serializeType(elemT)}"
     case t => Violation.violation(s"cannot stringify type $t")

--- a/src/main/scala/viper/gobra/translator/Names.scala
+++ b/src/main/scala/viper/gobra/translator/Names.scala
@@ -14,7 +14,7 @@ import viper.silver.{ast => vpr}
 object Names {
   def returnLabel: String = "returnLabel"
 
-  def freshName(ctx: Context): String = s"fn$$$$${ctx.getAndIncrementFreshCounter}"
+  def freshName(ctx: Context): String = s"fn$$$$${ctx.getAndIncrementFreshVariableCounter}"
 
   /* sanitizes type name to a valid Viper name */
   def serializeType(t: vpr.Type): String = {

--- a/src/main/scala/viper/gobra/translator/Names.scala
+++ b/src/main/scala/viper/gobra/translator/Names.scala
@@ -8,14 +8,14 @@ package viper.gobra.translator
 
 import viper.gobra.ast.{internal => in}
 import viper.gobra.theory.Addressability
-import viper.gobra.translator.interfaces.Context
 import viper.gobra.util.Violation
 import viper.silver.{ast => vpr}
 
 object Names {
-  def returnLabel: String = "returnLabel"
+  // fresh name prefix
+  def freshNamePrefix: String = "fn$$"
 
-  def freshName(ctx: Context): String = s"fn$$$$${ctx.getAndIncrementFreshVariableCounter}"
+  def returnLabel: String = "returnLabel"
 
   /* sanitizes type name to a valid Viper name */
   def serializeType(t: vpr.Type): String = {
@@ -61,7 +61,6 @@ object Names {
     // we use a dollar sign to mark the beginning and end of the type list to avoid that `Tuple(Tuple(X), Y)` and `Tuple(Tuple(X, Y))` map to the same name:
     s"$$$serializedFields$$"
   }
-
 
   // assert
   def assertFunc: String = "assertArg1"

--- a/src/main/scala/viper/gobra/translator/encodings/EmbeddingComponent.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/EmbeddingComponent.scala
@@ -8,7 +8,7 @@ package viper.gobra.translator.encodings
 
 import viper.gobra.translator.interfaces.translator.Generator
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.silver.{ast => vpr}
 
 trait EmbeddingParameter {
@@ -36,8 +36,8 @@ object EmbeddingComponent {
 
   class Impl[P <: EmbeddingParameter](p: (vpr.Exp, P) => Context => vpr.Exp, t: P => Context => vpr.Type) extends EmbeddingComponent[P] {
 
-    override def finalize(col: Collector): Unit = {
-      generatedMember foreach col.addMember
+    override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+      generatedMember foreach addMemberFn
     }
 
     /** Returns the embedded type E. */

--- a/src/main/scala/viper/gobra/translator/encodings/EmbeddingComponent.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/EmbeddingComponent.scala
@@ -11,11 +11,15 @@ import viper.gobra.translator.Names
 import viper.gobra.translator.interfaces.{Collector, Context}
 import viper.silver.{ast => vpr}
 
+trait EmbeddingParameter {
+  def serialize: String
+}
+
 /**
   * Creates an embedded type E that is made up of all elements of 't' that satisfy 'p',
   * where 't' and 'p' are parametrized by an instance of P.
   */
-trait EmbeddingComponent[P] extends Generator {
+trait EmbeddingComponent[P <: EmbeddingParameter] extends Generator {
 
   /** Returns the embedded type E. */
   def typ(id: P)(ctx: Context): vpr.Type
@@ -30,7 +34,7 @@ trait EmbeddingComponent[P] extends Generator {
 
 object EmbeddingComponent {
 
-  class Impl[P](p: (vpr.Exp, P) => Context => vpr.Exp, t: P => Context => vpr.Type) extends EmbeddingComponent[P] {
+  class Impl[P <: EmbeddingParameter](p: (vpr.Exp, P) => Context => vpr.Exp, t: P => Context => vpr.Type) extends EmbeddingComponent[P] {
 
     override def finalize(col: Collector): Unit = {
       generatedMember foreach col.addMember
@@ -70,45 +74,51 @@ object EmbeddingComponent {
 
     /**
       * Generates domain, box function, and unbox function:
+      * note that the function names of box and unbox depends not just on P but also the embedded type E (represented by `NT` below)
       *
       * domain N{}
       *
-      * function boxN(x: T): N
+      * function boxNT(x: T): N
       *   requires p(x)
       *   ensures  unbox(result) == x
       *
-      * function unboxN(y: N): T
+      * function unboxNT(y: N): T
       *   ensures p(result) && boxN(result) == y
       *
       * */
     private def genTriple(id: P)(ctx: Context): Unit = {
       val domain = vpr.Domain(
-        name = s"${Names.embeddingDomain}${Names.freshName}",
+        name = s"${Names.embeddingDomain}_${id.serialize}",
         functions = Seq.empty,
         axioms = Seq.empty,
         typVars = Seq.empty
       )()
 
+      /** embedded type */
+      val T = t(id)(ctx)
       val N = vpr.DomainType(domain = domain, typVarsMap = Map.empty)
-      val x = vpr.LocalVarDecl("x", t(id)(ctx))()
+      val x = vpr.LocalVarDecl("x", T)()
       val y = vpr.LocalVarDecl("y", N)()
+
+      val boxName = s"${Names.embeddingBoxFunc}_${N.domainName}_${Names.serializeType(T)}"
+      val unboxName = s"${Names.embeddingUnboxFunc}_${N.domainName}_${Names.serializeType(T)}"
 
       def boxApp(arg: vpr.Exp): vpr.FuncApp = {
         vpr.FuncApp(
-          funcname = s"${Names.embeddingBoxFunc}_${N.domainName}",
+          funcname = boxName,
           args = Seq(arg)
         )(vpr.NoPosition, vpr.NoInfo, typ = x.typ, vpr.NoTrafos)
       }
 
       def unboxApp(arg: vpr.Exp): vpr.FuncApp = {
         vpr.FuncApp(
-          funcname = s"${Names.embeddingUnboxFunc}_${N.domainName}",
+          funcname = unboxName,
           args = Seq(arg)
         )(vpr.NoPosition, vpr.NoInfo, typ = x.typ, vpr.NoTrafos)
       }
 
       val box = vpr.Function(
-        name = s"${Names.embeddingBoxFunc}_${N.domainName}",
+        name = boxName,
         formalArgs = Seq(x),
         typ = N,
         pres = Seq(p(x.localVar, id)(ctx)),
@@ -116,18 +126,14 @@ object EmbeddingComponent {
         body = None
       )()
 
-      val unbox = {
-        val resT = t(id)(ctx)
-
-        vpr.Function(
-          name = s"${Names.embeddingUnboxFunc}_${N.domainName}",
-          formalArgs = Seq(y),
-          typ = resT,
-          pres = Seq.empty,
-          posts = Seq(p(vpr.Result(resT)(), id)(ctx), vpr.EqCmp(boxApp(vpr.Result(resT)()), y.localVar)()),
-          body = None
-        )()
-      }
+      val unbox = vpr.Function(
+        name = unboxName,
+        formalArgs = Seq(y),
+        typ = T,
+        pres = Seq.empty,
+        posts = Seq(p(vpr.Result(T)(), id)(ctx), vpr.EqCmp(boxApp(vpr.Result(T)()), y.localVar)()),
+        body = None
+      )()
 
       generatedMember ::= domain
       genDomainMap += (id -> domain)
@@ -136,9 +142,5 @@ object EmbeddingComponent {
       generatedMember ::= unbox
       genUnboxFuncMap += (id -> unbox)
     }
-}
-
-
-
-
+  }
 }

--- a/src/main/scala/viper/gobra/translator/encodings/FloatEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/FloatEncoding.scala
@@ -9,7 +9,7 @@ package viper.gobra.translator.encodings
 import org.bitbucket.inkytonik.kiama.==>
 import viper.gobra.ast.{internal => in}
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.CodeLevel.unit
 import viper.gobra.translator.util.ViperWriter.CodeWriter
 import viper.silver.{ast => vpr}
@@ -80,20 +80,20 @@ class FloatEncoding extends LeafTypeEncoding {
     }
   }
 
-  override def finalize(col: Collector): Unit = {
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
     if (isUsed32) {
-      col.addMember(addFloat32)
-      col.addMember(subFloat32)
-      col.addMember(mulFloat32)
-      col.addMember(divFloat32)
-      col.addMember(fromIntTo32)
+      addMemberFn(addFloat32)
+      addMemberFn(subFloat32)
+      addMemberFn(mulFloat32)
+      addMemberFn(divFloat32)
+      addMemberFn(fromIntTo32)
     }
     if (isUsed64) {
-      col.addMember(addFloat64)
-      col.addMember(subFloat64)
-      col.addMember(mulFloat64)
-      col.addMember(divFloat64)
-      col.addMember(fromIntTo64)
+      addMemberFn(addFloat64)
+      addMemberFn(subFloat64)
+      addMemberFn(mulFloat64)
+      addMemberFn(divFloat64)
+      addMemberFn(fromIntTo64)
     }
   }
   private var isUsed32: Boolean = false

--- a/src/main/scala/viper/gobra/translator/encodings/IntEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/IntEncoding.scala
@@ -12,7 +12,7 @@ import viper.gobra.reporting.BackTranslator.RichErrorMessage
 import viper.gobra.reporting.{ShiftPreconditionError, Source}
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.CodeWriter
 import viper.silver.verifier.{errors => err}
 import viper.silver.{ast => vpr}
@@ -84,14 +84,14 @@ class IntEncoding extends LeafTypeEncoding {
     }
   }
 
-  override def finalize(col: Collector): Unit = {
-    if(isUsedBitAnd) { col.addMember(bitwiseAnd) }
-    if(isUsedBitOr) { col.addMember(bitwiseOr) }
-    if(isUsedBitXor) { col.addMember(bitwiseXor) }
-    if(isUsedBitClear) { col.addMember(bitClear) }
-    if(isUsedLeftShift) { col.addMember(shiftLeft) }
-    if(isUsedRightShift) { col.addMember(shiftRight) }
-    if(isUsedBitNeg) { col.addMember(bitwiseNegation) }
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    if(isUsedBitAnd) { addMemberFn(bitwiseAnd) }
+    if(isUsedBitOr) { addMemberFn(bitwiseOr) }
+    if(isUsedBitXor) { addMemberFn(bitwiseXor) }
+    if(isUsedBitClear) { addMemberFn(bitClear) }
+    if(isUsedLeftShift) { addMemberFn(shiftLeft) }
+    if(isUsedRightShift) { addMemberFn(shiftRight) }
+    if(isUsedBitNeg) { addMemberFn(bitwiseNegation) }
   }
 
   /* Bitwise Operations */

--- a/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
@@ -102,7 +102,7 @@ class StringEncoding extends LeafTypeEncoding {
         val (pos, info, errT) = conv.vprMeta
 
         val sliceT = in.SliceT(in.IntT(Addressability.sliceElement, TypeBounds.Byte), Addressability.outParameter)
-        val slice = in.LocalVar(Names.freshName, sliceT)(conv.info)
+        val slice = in.LocalVar(Names.freshName(ctx), sliceT)(conv.info)
         val vprSlice = ctx.typeEncoding.variable(ctx)(slice)
         val qtfVar = in.BoundVar("i", in.IntT(Addressability.boundVariable))(conv.info)
         val post = in.SepForall(

--- a/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
@@ -13,7 +13,7 @@ import viper.gobra.reporting.Source
 import viper.gobra.theory.Addressability
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.FunctionGenerator
 import viper.gobra.translator.util.ViperWriter.CodeLevel._
 import viper.gobra.translator.util.ViperWriter.CodeWriter
@@ -125,11 +125,11 @@ class StringEncoding extends LeafTypeEncoding {
     }
   }
 
-  override def finalize(col: Collector): Unit = {
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
     if (isUsed) {
-      col.addMember(genDomain())
-      col.addMember(strSlice)
-      byteSliceToStrFuncGenerator.finalize(col)
+      addMemberFn(genDomain())
+      addMemberFn(strSlice)
+      byteSliceToStrFuncGenerator.finalize(addMemberFn)
     }
   }
   private var isUsed: Boolean = false

--- a/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
@@ -102,7 +102,7 @@ class StringEncoding extends LeafTypeEncoding {
         val (pos, info, errT) = conv.vprMeta
 
         val sliceT = in.SliceT(in.IntT(Addressability.sliceElement, TypeBounds.Byte), Addressability.outParameter)
-        val slice = in.LocalVar(Names.freshName(ctx), sliceT)(conv.info)
+        val slice = in.LocalVar(ctx.freshNames.next(), sliceT)(conv.info)
         val vprSlice = ctx.typeEncoding.variable(ctx)(slice)
         val qtfVar = in.BoundVar("i", in.IntT(Addressability.boundVariable))(conv.info)
         val post = in.SepForall(

--- a/src/main/scala/viper/gobra/translator/encodings/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/TypeEncoding.scala
@@ -10,7 +10,6 @@ import org.bitbucket.inkytonik.kiama.==>
 import viper.gobra.ast.internal.theory.Comparability
 import viper.gobra.ast.{internal => in}
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
-import viper.gobra.translator.Names
 import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.{CodeWriter, MemberWriter}
 import viper.gobra.translator.interfaces.translator.Generator
@@ -211,7 +210,7 @@ trait TypeEncoding extends Generator {
   def statement(ctx: Context): in.Stmt ==> CodeWriter[vpr.Stmt] = {
     case newStmt@in.New(target, expr) if typ(ctx).isDefinedAt(expr.typ) =>
       val (pos, info, errT) = newStmt.vprMeta
-      val z = in.LocalVar(Names.freshName(ctx), target.typ.withAddressability(Exclusive))(newStmt.info)
+      val z = in.LocalVar(ctx.freshNames.next(), target.typ.withAddressability(Exclusive))(newStmt.info)
       val zDeref = in.Deref(z)(newStmt.info)
       seqn(
         for {

--- a/src/main/scala/viper/gobra/translator/encodings/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/TypeEncoding.scala
@@ -211,7 +211,7 @@ trait TypeEncoding extends Generator {
   def statement(ctx: Context): in.Stmt ==> CodeWriter[vpr.Stmt] = {
     case newStmt@in.New(target, expr) if typ(ctx).isDefinedAt(expr.typ) =>
       val (pos, info, errT) = newStmt.vprMeta
-      val z = in.LocalVar(Names.freshName, target.typ.withAddressability(Exclusive))(newStmt.info)
+      val z = in.LocalVar(Names.freshName(ctx), target.typ.withAddressability(Exclusive))(newStmt.info)
       val zDeref = in.Deref(z)(newStmt.info)
       seqn(
         for {

--- a/src/main/scala/viper/gobra/translator/encodings/arrays/ArrayEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/arrays/ArrayEncoding.scala
@@ -381,7 +381,7 @@ class ArrayEncoding extends TypeEncoding with SharedArrayEmbedding {
 
     val (pos, info, errT) = src.vprMeta
 
-    val idx = in.BoundVar(Names.freshName(ctx), in.IntT(Exclusive))(src.info)
+    val idx = in.BoundVar(ctx.freshNames.next(), in.IntT(Exclusive))(src.info)
     val vIdx = ctx.typeEncoding.variable(ctx)(idx)
 
     for {
@@ -404,7 +404,7 @@ class ArrayEncoding extends TypeEncoding with SharedArrayEmbedding {
         val (pos, info, errT) = e.vprMeta
         for {
           vS <- ctx.expr.translate(e)(ctx)
-          x = in.LocalVar(Names.freshName(ctx), e.typ)(e.info)
+          x = in.LocalVar(ctx.freshNames.next(), e.typ)(e.info)
           vX = variable(ctx)(x)
           _ <- local(vX)
           _ <- bind(vX.localVar, vS)
@@ -415,7 +415,7 @@ class ArrayEncoding extends TypeEncoding with SharedArrayEmbedding {
         val (pos, info, errT) = e.vprMeta
         for {
           vS <- ctx.typeEncoding.reference(ctx)(loc)
-          x = in.LocalVar(Names.freshName(ctx), e.typ)(e.info)
+          x = in.LocalVar(ctx.freshNames.next(), e.typ)(e.info)
           vX = variable(ctx)(x)
           _ <- local(vX)
           _ <- bind(vX.localVar, vS)

--- a/src/main/scala/viper/gobra/translator/encodings/arrays/ExclusiveArrayComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/arrays/ExclusiveArrayComponentImpl.scala
@@ -7,7 +7,7 @@
 package viper.gobra.translator.encodings.arrays
 
 import viper.gobra.translator.encodings.EmbeddingComponent
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.ast.{internal => in}
 import viper.silver.{ast => vpr}
 import ArrayEncoding.ComponentParameter
@@ -15,8 +15,8 @@ import viper.gobra.translator.encodings
 
 class ExclusiveArrayComponentImpl extends ExclusiveArrayComponent {
 
-  override def finalize(col: Collector): Unit = {
-    emb.finalize(col)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    emb.finalize(addMemberFn)
   }
 
   /** Embeds Sequences of fixed length as specified by ComponentParameter. */

--- a/src/main/scala/viper/gobra/translator/encodings/arrays/ExclusiveArrayComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/arrays/ExclusiveArrayComponentImpl.scala
@@ -21,8 +21,8 @@ class ExclusiveArrayComponentImpl extends ExclusiveArrayComponent {
 
   /** Embeds Sequences of fixed length as specified by ComponentParameter. */
   private val emb: EmbeddingComponent[ComponentParameter] = new encodings.EmbeddingComponent.Impl[ComponentParameter](
-    p = (e: vpr.Exp, id: ComponentParameter) => (_: Context) => vpr.EqCmp(vpr.SeqLength(e)(), vpr.IntLit(id._1)())(),
-    t = (id: ComponentParameter) => (ctx: Context) => vpr.SeqType(ctx.typeEncoding.typ(ctx)(id._2))
+    p = (e: vpr.Exp, id: ComponentParameter) => (_: Context) => vpr.EqCmp(vpr.SeqLength(e)(), vpr.IntLit(id.len)())(),
+    t = (id: ComponentParameter) => (ctx: Context) => vpr.SeqType(ctx.typeEncoding.typ(ctx)(id.elemT))
   )
 
   /** Returns type of exclusive-array domain. */
@@ -32,7 +32,7 @@ class ExclusiveArrayComponentImpl extends ExclusiveArrayComponent {
   override def create(args: Vector[vpr.Exp], t: ComponentParameter)(src: in.Node)(ctx: Context): vpr.Exp = {
     val (pos, info, errT) = src.vprMeta
     if (args.isEmpty) {
-      emb.box(vpr.EmptySeq(ctx.typeEncoding.typ(ctx)(t._2))(pos, info, errT), t)(pos, info, errT)(ctx) // box(Seq(args))
+      emb.box(vpr.EmptySeq(ctx.typeEncoding.typ(ctx)(t.elemT))(pos, info, errT), t)(pos, info, errT)(ctx) // box(Seq(args))
     } else {
       emb.box(vpr.ExplicitSeq(args)(pos, info, errT), t)(pos, info, errT)(ctx) // box(Seq(args))
     }

--- a/src/main/scala/viper/gobra/translator/encodings/arrays/SharedArrayComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/arrays/SharedArrayComponentImpl.scala
@@ -29,15 +29,15 @@ class SharedArrayComponentImpl extends SharedArrayComponent {
     * function arrayNil(): Array[ [T@] ]
     *   ensures len(result) == 1 && Forall idx :: {array_get(result, idx)} array_get(result, idx) == [dflt(T@)]
     * */
-  private val arrayNilFunc: FunctionGenerator[ComponentParameter] = new FunctionGenerator[(BigInt, in.Type)]{
+  private val arrayNilFunc: FunctionGenerator[ComponentParameter] = new FunctionGenerator[ComponentParameter]{
 
-    def genFunction(t: (BigInt, in.Type))(ctx: Context): vpr.Function = {
-      val vResType = ctx.array.typ(ctx.typeEncoding.typ(ctx)(t._2))
-      val src = in.DfltVal(in.ArrayT(t._1, t._2, Shared))(Source.Parser.Internal)
+    def genFunction(t: ComponentParameter)(ctx: Context): vpr.Function = {
+      val vResType = ctx.array.typ(ctx.typeEncoding.typ(ctx)(t.elemT))
+      val src = in.DfltVal(t.arrayT(Shared))(Source.Parser.Internal)
       val idx = in.BoundVar("idx", in.IntT(Exclusive))(src.info)
       val vIdx = ctx.typeEncoding.variable(ctx)(idx)
       val resAccess = ctx.array.loc(vpr.Result(vResType)(), vIdx.localVar)()
-      val idxEq = vpr.EqCmp(resAccess, pure(ctx.expr.translate(in.DfltVal(t._2)(src.info))(ctx))(ctx).res)()
+      val idxEq = vpr.EqCmp(resAccess, pure(ctx.expr.translate(in.DfltVal(t.elemT)(src.info))(ctx))(ctx).res)()
       val forall = vpr.Forall(
         Seq(vIdx),
         Seq(vpr.Trigger(Seq(resAccess))()),
@@ -45,7 +45,7 @@ class SharedArrayComponentImpl extends SharedArrayComponent {
       )()
 
       vpr.Function(
-        name = s"${Names.arrayDefaultFunc}_${Names.freshName}",
+        name = s"${Names.arrayNilFunc}_${t.serialize}",
         formalArgs = Seq.empty,
         typ = vResType,
         pres = Seq.empty,
@@ -59,10 +59,10 @@ class SharedArrayComponentImpl extends SharedArrayComponent {
   private val emb: EmbeddingComponent[ComponentParameter] = new encodings.EmbeddingComponent.Impl[ComponentParameter](
     p = (e: vpr.Exp, id: ComponentParameter) => (ctx: Context) =>
       vpr.Or( // len(a) == n || a == arrayNil
-        vpr.EqCmp(ctx.array.len(e)(), vpr.IntLit(id._1)())(),
+        vpr.EqCmp(ctx.array.len(e)(), vpr.IntLit(id.len)())(),
         vpr.EqCmp(e, arrayNilFunc(Vector.empty, id)()(ctx))()
       )(),
-    t = (id: ComponentParameter) => (ctx: Context) => ctx.array.typ(ctx.typeEncoding.typ(ctx)(id._2))
+    t = (id: ComponentParameter) => (ctx: Context) => ctx.array.typ(ctx.typeEncoding.typ(ctx)(id.elemT))
   )
 
   /** Returns type of exclusive-array domain. */

--- a/src/main/scala/viper/gobra/translator/encodings/arrays/SharedArrayComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/arrays/SharedArrayComponentImpl.scala
@@ -7,7 +7,7 @@
 package viper.gobra.translator.encodings.arrays
 
 import viper.gobra.translator.encodings.EmbeddingComponent
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.ast.{internal => in}
 import viper.silver.{ast => vpr}
 import ArrayEncoding.ComponentParameter
@@ -19,9 +19,9 @@ import viper.gobra.translator.util.ViperWriter.CodeLevel.pure
 
 class SharedArrayComponentImpl extends SharedArrayComponent {
 
-  override def finalize(col: Collector): Unit = {
-    emb.finalize(col)
-    arrayNilFunc.finalize(col)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    emb.finalize(addMemberFn)
+    arrayNilFunc.finalize(addMemberFn)
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/encodings/channels/ChannelEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/channels/ChannelEncoding.scala
@@ -58,7 +58,7 @@ class ChannelEncoding extends LeafTypeEncoding {
 
       case exp@in.Receive(channel :: ctx.Channel(typeParam), recvChannel, recvGivenPerm, recvGotPerm) =>
         val (pos, info, errT) = exp.vprMeta
-        val res = in.LocalVar(Names.freshName, typeParam.withAddressability(Addressability.Exclusive))(exp.info)
+        val res = in.LocalVar(Names.freshName(ctx), typeParam.withAddressability(Addressability.Exclusive))(exp.info)
         val vprRes = ctx.typeEncoding.variable(ctx)(res)
         val recvChannelPred = in.Accessible.Predicate(in.MPredicateAccess(channel, recvChannel, Vector())(exp.info))
         for {
@@ -133,7 +133,7 @@ class ChannelEncoding extends LeafTypeEncoding {
     default(super.statement(ctx)){
       case makeStmt@in.MakeChannel(target, in.ChannelT(typeParam, _), optBufferSizeArg, isChannelPred, bufferSizeMProxy) =>
         val (pos, info, errT) = makeStmt.vprMeta
-        val a = in.LocalVar(Names.freshName, in.ChannelT(typeParam.withAddressability(Addressability.channelElement), Addressability.Exclusive))(makeStmt.info)
+        val a = in.LocalVar(Names.freshName(ctx), in.ChannelT(typeParam.withAddressability(Addressability.channelElement), Addressability.Exclusive))(makeStmt.info)
         val vprA = ctx.typeEncoding.variable(ctx)(a)
         val bufferSizeArg = optBufferSizeArg.getOrElse(in.IntLit(0)(makeStmt.info)) // create an unbuffered channel by default
         seqn(
@@ -196,9 +196,9 @@ class ChannelEncoding extends LeafTypeEncoding {
 
       case stmt@in.SafeReceive(resTarget, successTarget, channel :: ctx.Channel(typeParam), recvChannel, recvGivenPerm, recvGotPerm, closed) =>
         val (pos, info, errT) = stmt.vprMeta
-        val res = in.LocalVar(Names.freshName, typeParam.withAddressability(Addressability.Exclusive))(stmt.info)
+        val res = in.LocalVar(Names.freshName(ctx), typeParam.withAddressability(Addressability.Exclusive))(stmt.info)
         val vprRes = ctx.typeEncoding.variable(ctx)(res)
-        val ok = in.LocalVar(Names.freshName, in.BoolT(Addressability.Exclusive))(stmt.info)
+        val ok = in.LocalVar(Names.freshName(ctx), in.BoolT(Addressability.Exclusive))(stmt.info)
         val vprOk = ctx.typeEncoding.variable(ctx)(ok)
         val recvChannelPred = in.Accessible.Predicate(in.MPredicateAccess(channel, recvChannel, Vector())(stmt.info))
         seqn(

--- a/src/main/scala/viper/gobra/translator/encodings/channels/ChannelEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/channels/ChannelEncoding.scala
@@ -11,7 +11,6 @@ import viper.gobra.ast.{internal => in}
 import viper.gobra.reporting.{ChannelMakePreconditionError, ChannelReceiveError, ChannelSendError, InsufficientPermissionFromTagError, Source}
 import viper.gobra.theory.Addressability
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
-import viper.gobra.translator.Names
 import viper.gobra.translator.encodings.LeafTypeEncoding
 import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.CodeWriter
@@ -58,7 +57,7 @@ class ChannelEncoding extends LeafTypeEncoding {
 
       case exp@in.Receive(channel :: ctx.Channel(typeParam), recvChannel, recvGivenPerm, recvGotPerm) =>
         val (pos, info, errT) = exp.vprMeta
-        val res = in.LocalVar(Names.freshName(ctx), typeParam.withAddressability(Addressability.Exclusive))(exp.info)
+        val res = in.LocalVar(ctx.freshNames.next(), typeParam.withAddressability(Addressability.Exclusive))(exp.info)
         val vprRes = ctx.typeEncoding.variable(ctx)(res)
         val recvChannelPred = in.Accessible.Predicate(in.MPredicateAccess(channel, recvChannel, Vector())(exp.info))
         for {
@@ -133,7 +132,7 @@ class ChannelEncoding extends LeafTypeEncoding {
     default(super.statement(ctx)){
       case makeStmt@in.MakeChannel(target, in.ChannelT(typeParam, _), optBufferSizeArg, isChannelPred, bufferSizeMProxy) =>
         val (pos, info, errT) = makeStmt.vprMeta
-        val a = in.LocalVar(Names.freshName(ctx), in.ChannelT(typeParam.withAddressability(Addressability.channelElement), Addressability.Exclusive))(makeStmt.info)
+        val a = in.LocalVar(ctx.freshNames.next(), in.ChannelT(typeParam.withAddressability(Addressability.channelElement), Addressability.Exclusive))(makeStmt.info)
         val vprA = ctx.typeEncoding.variable(ctx)(a)
         val bufferSizeArg = optBufferSizeArg.getOrElse(in.IntLit(0)(makeStmt.info)) // create an unbuffered channel by default
         seqn(
@@ -196,9 +195,9 @@ class ChannelEncoding extends LeafTypeEncoding {
 
       case stmt@in.SafeReceive(resTarget, successTarget, channel :: ctx.Channel(typeParam), recvChannel, recvGivenPerm, recvGotPerm, closed) =>
         val (pos, info, errT) = stmt.vprMeta
-        val res = in.LocalVar(Names.freshName(ctx), typeParam.withAddressability(Addressability.Exclusive))(stmt.info)
+        val res = in.LocalVar(ctx.freshNames.next(), typeParam.withAddressability(Addressability.Exclusive))(stmt.info)
         val vprRes = ctx.typeEncoding.variable(ctx)(res)
-        val ok = in.LocalVar(Names.freshName(ctx), in.BoolT(Addressability.Exclusive))(stmt.info)
+        val ok = in.LocalVar(ctx.freshNames.next(), in.BoolT(Addressability.Exclusive))(stmt.info)
         val vprOk = ctx.typeEncoding.variable(ctx)(ok)
         val recvChannelPred = in.Accessible.Predicate(in.MPredicateAccess(channel, recvChannel, Vector())(stmt.info))
         seqn(

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
@@ -11,7 +11,7 @@ import viper.gobra.ast.internal.Expr
 import viper.gobra.translator.encodings.TypeEncoding
 import viper.gobra.util.Violation
 import viper.gobra.ast.{internal => in}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.{CodeWriter, MemberWriter}
 import viper.silver.ast.Exp
 import viper.silver.{ast => vpr}
@@ -27,7 +27,7 @@ class FinalTypeEncoding(te: TypeEncoding) extends TypeEncoding {
     case n => Violation.violation(s"Node $n (${n.getClass}) did not match with any implemented case of $name. ")
   }
 
-  override def finalize(col: Collector): Unit = te.finalize(col)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = te.finalize(addMemberFn)
   override def typ(ctx: Context): in.Type ==> vpr.Type = te.typ(ctx) orElse expectedMatch("typ")
   override def variable(ctx: Context): in.BodyVar ==> vpr.LocalVarDecl = te.variable(ctx) orElse expectedMatch("variable")
   override def globalVar(ctx: Context): in.GlobalVar ==> CodeWriter[vpr.Exp] = te.globalVar(ctx) orElse expectedMatch("globalVar")

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncodingCombiner.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncodingCombiner.scala
@@ -10,7 +10,7 @@ import viper.gobra.translator.encodings.TypeEncoding
 import org.bitbucket.inkytonik.kiama.==>
 import viper.gobra.ast.internal.Expr
 import viper.gobra.ast.{internal => in}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.{CodeWriter, MemberWriter}
 import viper.silver.ast.Exp
 import viper.silver.{ast => vpr}
@@ -28,7 +28,7 @@ abstract class TypeEncodingCombiner(encodings: Vector[TypeEncoding]) extends Typ
   protected[combinators] def combiner[X, Y](get: TypeEncoding => (X ==> Y)): X ==> Y
 
 
-  override def finalize(col: Collector): Unit = encodings.foreach(_.finalize(col))
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = encodings.foreach(_.finalize(addMemberFn))
   override def typ(ctx: Context): in.Type ==> vpr.Type = combiner(_.typ(ctx))
   override def variable(ctx: Context): in.BodyVar ==> vpr.LocalVarDecl = combiner(_.variable(ctx))
   override def globalVar(ctx: Context): in.GlobalVar ==> CodeWriter[vpr.Exp] = combiner(_.globalVar(ctx))

--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
@@ -14,7 +14,7 @@ import viper.gobra.reporting.{ComparisonError, ComparisonOnIncomparableInterface
 import viper.gobra.theory.Addressability
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.FunctionGenerator
 import viper.gobra.translator.util.ViperWriter.CodeWriter
 import viper.gobra.util.{Algorithms, Violation}
@@ -50,13 +50,13 @@ class InterfaceEncoding extends LeafTypeEncoding {
 
   private var genMembers: List[vpr.Member] = List.empty
 
-  override def finalize(col: Collector): Unit = {
-    poly.finalize(col)
-    types.finalize(col)
-    toInterfaceFunc.finalize(col)
-    genMembers foreach col.addMember
-    typeOfWithSubtypeFactFuncMap.values foreach col.addMember
-    genPredicates foreach col.addMember
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    poly.finalize(addMemberFn)
+    types.finalize(addMemberFn)
+    toInterfaceFunc.finalize(addMemberFn)
+    genMembers foreach addMemberFn
+    typeOfWithSubtypeFactFuncMap.values foreach addMemberFn
+    genPredicates foreach addMemberFn
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/PolymorphValueComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/PolymorphValueComponentImpl.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.translator.encodings.interfaces
 
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.silver.{ast => vpr}
 import viper.gobra.ast.{internal => in}
 import viper.gobra.translator.Names
@@ -206,7 +206,7 @@ class PolymorphValueComponentImpl(handle: PolymorphValueInterfaceHandle) extends
   }
   private var isUsed: Boolean = false
 
-  override def finalize(col: Collector): Unit = if (isUsed) { genDomain.foreach(col.addMember) }
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = if (isUsed) { genDomain.foreach(addMemberFn) }
 
   /** Returns whether 'typ' has finite cardinality. */
   private def finiteCardinality(typ: in.Type)(ctx: in.DefinedT => in.Type): Boolean = {

--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/TypeComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/TypeComponentImpl.scala
@@ -10,7 +10,7 @@ import viper.gobra.ast.internal.theory.{Comparability, TypeHead}
 import viper.gobra.ast.internal.theory.TypeHead._
 import viper.gobra.ast.{internal => in}
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperUtil
 import viper.gobra.util.TypeBounds
 import viper.silver.{ast => vpr}
@@ -366,8 +366,8 @@ class TypeComponentImpl extends TypeComponent {
     )()
   }
 
-  override def finalize(collector: Collector): Unit = {
-    collector.addMember(genDomain)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    addMemberFn(genDomain)
   }
 
 }

--- a/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
@@ -93,7 +93,7 @@ class MapEncoding extends LeafTypeEncoding {
 
       case (lit: in.MapLit) :: ctx.Map(keys, values) =>
         val (pos, info, errT) = lit.vprMeta
-        val res = in.LocalVar(Names.freshName, lit.typ.withAddressability(Exclusive))(lit.info)
+        val res = in.LocalVar(Names.freshName(ctx), lit.typ.withAddressability(Exclusive))(lit.info)
         val vRes = ctx.typeEncoding.variable(ctx)(res)
 
         for {
@@ -198,7 +198,7 @@ class MapEncoding extends LeafTypeEncoding {
                 MapMakePreconditionError(info)
             } else unit(())
 
-            mapVar = in.LocalVar(Names.freshName, t.withAddressability(Exclusive))(makeStmt.info)
+            mapVar = in.LocalVar(Names.freshName(ctx), t.withAddressability(Exclusive))(makeStmt.info)
             mapVarVpr = ctx.typeEncoding.variable(ctx)(mapVar)
             _ <- local(mapVarVpr)
 
@@ -211,9 +211,9 @@ class MapEncoding extends LeafTypeEncoding {
 
       case l@ in.SafeMapLookup(resTarget, successTarget, indexedExp@ in.IndexedExp(_, _, _)) =>
         val (pos, info, errT) = l.vprMeta
-        val res = in.LocalVar(Names.freshName, indexedExp.typ.withAddressability(Addressability.Exclusive))(l.info)
+        val res = in.LocalVar(Names.freshName(ctx), indexedExp.typ.withAddressability(Addressability.Exclusive))(l.info)
         val vprRes = ctx.typeEncoding.variable(ctx)(res)
-        val ok = in.LocalVar(Names.freshName, in.BoolT(Addressability.Exclusive))(l.info)
+        val ok = in.LocalVar(Names.freshName(ctx), in.BoolT(Addressability.Exclusive))(l.info)
         val vprOk = ctx.typeEncoding.variable(ctx)(ok)
 
         seqn(
@@ -258,7 +258,7 @@ class MapEncoding extends LeafTypeEncoding {
     default(super.assignment(ctx)){
       case (in.Assignee(in.IndexedExp(m :: ctx.Map(keys, values), idx, _)), rhs, src) =>
         val (pos, info, errT) = src.vprMeta
-        val res = in.LocalVar(Names.freshName, in.IntT(Exclusive))(m.info)
+        val res = in.LocalVar(Names.freshName(ctx), in.IntT(Exclusive))(m.info)
         val vRes = ctx.typeEncoding.variable(ctx)(res)
         seqn(
           for {

--- a/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
@@ -93,7 +93,7 @@ class MapEncoding extends LeafTypeEncoding {
 
       case (lit: in.MapLit) :: ctx.Map(keys, values) =>
         val (pos, info, errT) = lit.vprMeta
-        val res = in.LocalVar(Names.freshName(ctx), lit.typ.withAddressability(Exclusive))(lit.info)
+        val res = in.LocalVar(ctx.freshNames.next(), lit.typ.withAddressability(Exclusive))(lit.info)
         val vRes = ctx.typeEncoding.variable(ctx)(res)
 
         for {
@@ -198,7 +198,7 @@ class MapEncoding extends LeafTypeEncoding {
                 MapMakePreconditionError(info)
             } else unit(())
 
-            mapVar = in.LocalVar(Names.freshName(ctx), t.withAddressability(Exclusive))(makeStmt.info)
+            mapVar = in.LocalVar(ctx.freshNames.next(), t.withAddressability(Exclusive))(makeStmt.info)
             mapVarVpr = ctx.typeEncoding.variable(ctx)(mapVar)
             _ <- local(mapVarVpr)
 
@@ -211,9 +211,9 @@ class MapEncoding extends LeafTypeEncoding {
 
       case l@ in.SafeMapLookup(resTarget, successTarget, indexedExp@ in.IndexedExp(_, _, _)) =>
         val (pos, info, errT) = l.vprMeta
-        val res = in.LocalVar(Names.freshName(ctx), indexedExp.typ.withAddressability(Addressability.Exclusive))(l.info)
+        val res = in.LocalVar(ctx.freshNames.next(), indexedExp.typ.withAddressability(Addressability.Exclusive))(l.info)
         val vprRes = ctx.typeEncoding.variable(ctx)(res)
-        val ok = in.LocalVar(Names.freshName(ctx), in.BoolT(Addressability.Exclusive))(l.info)
+        val ok = in.LocalVar(ctx.freshNames.next(), in.BoolT(Addressability.Exclusive))(l.info)
         val vprOk = ctx.typeEncoding.variable(ctx)(ok)
 
         seqn(
@@ -258,7 +258,7 @@ class MapEncoding extends LeafTypeEncoding {
     default(super.assignment(ctx)){
       case (in.Assignee(in.IndexedExp(m :: ctx.Map(keys, values), idx, _)), rhs, src) =>
         val (pos, info, errT) = src.vprMeta
-        val res = in.LocalVar(Names.freshName(ctx), in.IntT(Exclusive))(m.info)
+        val res = in.LocalVar(ctx.freshNames.next(), in.IntT(Exclusive))(m.info)
         val vRes = ctx.typeEncoding.variable(ctx)(res)
         seqn(
           for {

--- a/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
@@ -15,7 +15,7 @@ import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.Names
 import viper.gobra.translator.encodings.LeafTypeEncoding
 import viper.gobra.translator.encodings.maps.MapEncoding.{checkKeyComparability, comparabilityErrorT, repeatedKeyErrorT}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.CodeLevel._
 import viper.gobra.translator.util.ViperWriter.CodeWriter
 import viper.gobra.util.Violation
@@ -303,10 +303,10 @@ class MapEncoding extends LeafTypeEncoding {
     }
   }
 
-  override def finalize(col: Collector): Unit = {
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
     if (isUsed) {
-      col.addMember(genDomain())
-      col.addMember(underlyingMapField)
+      addMemberFn(genDomain())
+      addMemberFn(underlyingMapField)
     }
   }
 

--- a/src/main/scala/viper/gobra/translator/encodings/preds/DefuncComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/preds/DefuncComponentImpl.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.translator.encodings.preds
 
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.ast.{internal => in}
 import viper.gobra.translator.Names
 import viper.silver.{ast => vpr}
@@ -131,9 +131,9 @@ class DefuncComponentImpl extends DefuncComponent {
   }
 
 
-  override def finalize(col: Collector): Unit = {
-    encounteredTokens foreach (S => col.addMember(genDomain(S)))
-    encounteredTokens foreach (S => genEval(S) foreach col.addMember)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    encounteredTokens foreach (S => addMemberFn(genDomain(S)))
+    encounteredTokens foreach (S => genEval(S) foreach addMemberFn)
   }
 
   /** Returns the default value of the predicate type with arguments 'ts' */

--- a/src/main/scala/viper/gobra/translator/encodings/preds/PredEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/preds/PredEncoding.scala
@@ -12,7 +12,7 @@ import viper.gobra.ast.{internal => in}
 import viper.gobra.reporting.BackTranslator.RichErrorMessage
 import viper.gobra.reporting.{DefaultErrorBackTranslator, FoldError, Source, UnfoldError}
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.CodeWriter
 import viper.silver.{ast => vpr}
 import viper.silver.verifier.{errors => vprerr}
@@ -24,8 +24,8 @@ class PredEncoding extends LeafTypeEncoding {
 
   private val defunc: DefuncComponent = new DefuncComponentImpl
 
-  override def finalize(col: Collector): Unit = {
-    defunc.finalize(col)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    defunc.finalize(addMemberFn)
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/encodings/sequences/SequenceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/sequences/SequenceEncoding.scala
@@ -258,7 +258,7 @@ class SequenceEncoding extends LeafTypeEncoding {
       )()
 
       vpr.Function(
-        name = s"${Names.emptySequenceFunc}_${Names.freshName}",
+        name = s"${Names.emptySequenceFunc}_${Names.serializeType(t)}",
         formalArgs = Vector(nDecl),
         typ = vResultType,
         pres = Vector(pre1),

--- a/src/main/scala/viper/gobra/translator/encodings/sequences/SequenceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/sequences/SequenceEncoding.scala
@@ -12,7 +12,7 @@ import viper.gobra.ast.{internal => in}
 import viper.gobra.reporting.Source
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.FunctionGenerator
 import viper.gobra.translator.util.ViperWriter.CodeWriter
 import viper.gobra.util.Violation
@@ -23,8 +23,8 @@ class SequenceEncoding extends LeafTypeEncoding {
   import viper.gobra.translator.util.ViperWriter.CodeLevel._
   import viper.gobra.translator.util.TypePatterns._
 
-  override def finalize(col: Collector): Unit = {
-    emptySeqFunc.finalize(col)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    emptySeqFunc.finalize(addMemberFn)
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
@@ -15,7 +15,7 @@ import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.Names
 import viper.gobra.translator.encodings.LeafTypeEncoding
 import viper.gobra.translator.encodings.arrays.SharedArrayEmbedding
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.FunctionGenerator
 import viper.gobra.translator.util.ViperWriter.CodeWriter
 import viper.gobra.util.Violation
@@ -29,13 +29,13 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
   import viper.gobra.translator.util.ViperWriter.CodeLevel._
   import viper.gobra.translator.util.{ViperUtil => vu}
 
-  override def finalize(col : Collector) : Unit = {
-    constructGenerator.finalize(col)
-    fullSliceFromArrayGenerator.finalize(col)
-    fullSliceFromSliceGenerator.finalize(col)
-    sliceFromArrayGenerator.finalize(col)
-    sliceFromSliceGenerator.finalize(col)
-    nilSliceGenerator.finalize(col)
+  override def finalize(addMemberFn: vpr.Member => Unit) : Unit = {
+    constructGenerator.finalize(addMemberFn)
+    fullSliceFromArrayGenerator.finalize(addMemberFn)
+    fullSliceFromSliceGenerator.finalize(addMemberFn)
+    sliceFromArrayGenerator.finalize(addMemberFn)
+    sliceFromSliceGenerator.finalize(addMemberFn)
+    nilSliceGenerator.finalize(addMemberFn)
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
@@ -105,7 +105,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
 
       case (lit : in.SliceLit) :: ctx.Slice(_) =>
         val litA = lit.asArrayLit
-        val tmp = in.LocalVar(Names.freshName(ctx), litA.typ.withAddressability(Addressability.pointerBase))(lit.info)
+        val tmp = in.LocalVar(ctx.freshNames.next(), litA.typ.withAddressability(Addressability.pointerBase))(lit.info)
         val tmpT = ctx.typeEncoding.variable(ctx)(tmp)
         val underlyingTyp = underlyingType(lit.typ)(ctx)
         for {
@@ -137,7 +137,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       case makeStmt@in.MakeSlice(target, in.SliceT(typeParam, _), lenArg, optCapArg) =>
         val (pos, info, errT) = makeStmt.vprMeta
         val sliceT = in.SliceT(typeParam.withAddressability(Shared), Addressability.Exclusive)
-        val slice = in.LocalVar(Names.freshName(ctx), sliceT)(makeStmt.info)
+        val slice = in.LocalVar(ctx.freshNames.next(), sliceT)(makeStmt.info)
         val vprSlice = ctx.typeEncoding.variable(ctx)(slice)
         seqn(
           for {
@@ -223,7 +223,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
 
     val (pos, info, errT) = src.vprMeta
 
-    val idx = in.BoundVar(Names.freshName(ctx), in.IntT(Exclusive))(src.info)
+    val idx = in.BoundVar(ctx.freshNames.next(), in.IntT(Exclusive))(src.info)
     val vIdx = ctx.typeEncoding.variable(ctx)(idx)
 
     for {

--- a/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
@@ -105,7 +105,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
 
       case (lit : in.SliceLit) :: ctx.Slice(_) =>
         val litA = lit.asArrayLit
-        val tmp = in.LocalVar(Names.freshName, litA.typ.withAddressability(Addressability.pointerBase))(lit.info)
+        val tmp = in.LocalVar(Names.freshName(ctx), litA.typ.withAddressability(Addressability.pointerBase))(lit.info)
         val tmpT = ctx.typeEncoding.variable(ctx)(tmp)
         val underlyingTyp = underlyingType(lit.typ)(ctx)
         for {
@@ -137,7 +137,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       case makeStmt@in.MakeSlice(target, in.SliceT(typeParam, _), lenArg, optCapArg) =>
         val (pos, info, errT) = makeStmt.vprMeta
         val sliceT = in.SliceT(typeParam.withAddressability(Shared), Addressability.Exclusive)
-        val slice = in.LocalVar(Names.freshName, sliceT)(makeStmt.info)
+        val slice = in.LocalVar(Names.freshName(ctx), sliceT)(makeStmt.info)
         val vprSlice = ctx.typeEncoding.variable(ctx)(slice)
         seqn(
           for {
@@ -223,7 +223,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
 
     val (pos, info, errT) = src.vprMeta
 
-    val idx = in.BoundVar(Names.freshName, in.IntT(Exclusive))(src.info)
+    val idx = in.BoundVar(Names.freshName(ctx), in.IntT(Exclusive))(src.info)
     val vIdx = ctx.typeEncoding.variable(ctx)(idx)
 
     for {
@@ -325,7 +325,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       val post4 = vpr.EqCmp(ctx.slice.cap(result)(), capDecl.localVar)()
 
       vpr.Function(
-        s"${Names.sliceConstruct}_${Names.freshName}",
+        s"${Names.sliceConstruct}_${Names.serializeType(typ)}",
         Seq(aDecl, offsetDecl, lenDecl, capDecl),
         ctx.slice.typ(typ),
         Seq(pre1, pre2, pre3, pre4),
@@ -385,7 +385,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       )(ctx)()
 
       vpr.Function(
-        s"${Names.fullSliceFromArray}_${Names.freshName}",
+        s"${Names.fullSliceFromArray}_${Names.serializeType(typ)}",
         Seq(aDecl, iDecl, jDecl, kDecl),
         ctx.slice.typ(typ),
         Seq(pre1, pre2, pre3, pre4, pre5),
@@ -446,7 +446,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       )(ctx)()
 
       vpr.Function(
-        s"${Names.fullSliceFromSlice}_${Names.freshName}",
+        s"${Names.fullSliceFromSlice}_${Names.serializeType(typ)}",
         Seq(sDecl, iDecl, jDecl, kDecl),
         ctx.slice.typ(typ),
         Seq(pre1, pre2, pre3, pre4, pre5),
@@ -503,7 +503,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       )(ctx)()
 
       vpr.Function(
-        s"${Names.sliceFromArray}_${Names.freshName}",
+        s"${Names.sliceFromArray}_${Names.serializeType(typ)}",
         Seq(aDecl, iDecl, jDecl),
         ctx.slice.typ(typ),
         Seq(pre1, pre2, pre3),
@@ -561,7 +561,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       )(ctx)()
 
       vpr.Function(
-        s"${Names.sliceFromSlice}_${Names.freshName}",
+        s"${Names.sliceFromSlice}_${Names.serializeType(typ)}",
         Seq(sDecl, iDecl, jDecl),
         ctx.slice.typ(typ),
         Seq(pre1, pre2, pre3, pre4),
@@ -618,7 +618,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       )(ctx)()
 
       vpr.Function(
-        s"${Names.sliceDefaultFunc}_${Names.freshName}",
+        s"${Names.sliceDefaultFunc}_${Names.serializeType(typ)}",
         Seq(),
         sliceTypT,
         Seq(pre1),

--- a/src/main/scala/viper/gobra/translator/encodings/structs/SharedStructComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/structs/SharedStructComponentImpl.scala
@@ -7,7 +7,7 @@
 package viper.gobra.translator.encodings.structs
 
 import viper.gobra.ast.{internal => in}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.silver.{ast => vpr}
 import StructEncoding.ComponentParameter
 import viper.gobra.translator.Names
@@ -18,7 +18,7 @@ import viper.gobra.translator.Names
   * */
 class SharedStructComponentImpl extends SharedStructComponent {
 
-  override def finalize(col: Collector): Unit = genDomains.foreach(col.addMember)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = genDomains foreach addMemberFn
 
   private var genDomains: List[vpr.Domain] = List.empty
   private var genArities: Set[Int] = Set.empty

--- a/src/main/scala/viper/gobra/translator/encodings/structs/StructEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/structs/StructEncoding.scala
@@ -248,7 +248,7 @@ class StructEncoding extends TypeEncoding {
     */
   private val shDfltFunc: FunctionGenerator[Vector[in.Field]] = new FunctionGenerator[Vector[in.Field]] {
     override def genFunction(fs: Vector[in.Field])(ctx: Context): vpr.Function = {
-      val resType = in.StructT("the name does not matter", fs, Shared)
+      val resType = in.StructT(fs, Shared)
       val vResType = typ(ctx)(resType)
       val src = in.DfltVal(resType)(Source.Parser.Internal)
       val resDummy = in.LocalVar("res", resType)(src.info)

--- a/src/main/scala/viper/gobra/translator/implementations/CollectorImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/CollectorImpl.scala
@@ -19,13 +19,11 @@ class CollectorImpl extends Collector {
   protected var _methods: List[vpr.Method]  = List.empty
   protected var _extensions: List[vpr.ExtensionMember] = List.empty
 
-  /** invokes finalize on each generator */
-  override def finalize(generators: Vector[Generator]): Unit = {
-    for (generator <- generators) {
-      if(!_visitedGenerators.contains(generator)) {
-        _visitedGenerators += generator
-        generator.finalize(addMember)
-      }
+  /** invokes finalize on the generator */
+  override def finalize(generator: Generator): Unit = {
+    if(!_visitedGenerators.contains(generator)) {
+      _visitedGenerators += generator
+      generator.finalize(addMember)
     }
   }
 

--- a/src/main/scala/viper/gobra/translator/implementations/CollectorImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/CollectorImpl.scala
@@ -7,15 +7,27 @@
 package viper.gobra.translator.implementations
 
 import viper.gobra.translator.interfaces.Collector
+import viper.gobra.translator.interfaces.translator.Generator
 import viper.silver.{ast => vpr}
 
 class CollectorImpl extends Collector {
+  protected var _visitedGenerators: Set[Generator] = Set.empty
   protected var _domains: List[vpr.Domain] = List.empty
   protected var _fields: List[vpr.Field] = List.empty
   protected var _predicates: List[vpr.Predicate] = List.empty
   protected var _functions: List[vpr.Function] = List.empty
   protected var _methods: List[vpr.Method]  = List.empty
   protected var _extensions: List[vpr.ExtensionMember] = List.empty
+
+  /** invokes finalize on each generator */
+  override def finalize(generators: Vector[Generator]): Unit = {
+    generators foreach { generator =>
+      if(!_visitedGenerators.contains(generator)) {
+        _visitedGenerators += generator
+        generator.finalize(this)
+      }
+    }
+  }
 
   override def addMember(m: vpr.Member): Unit = m match {
     case d: vpr.Domain => _domains ::= d

--- a/src/main/scala/viper/gobra/translator/implementations/CollectorImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/CollectorImpl.scala
@@ -21,15 +21,15 @@ class CollectorImpl extends Collector {
 
   /** invokes finalize on each generator */
   override def finalize(generators: Vector[Generator]): Unit = {
-    generators foreach { generator =>
+    for (generator <- generators) {
       if(!_visitedGenerators.contains(generator)) {
         _visitedGenerators += generator
-        generator.finalize(this)
+        generator.finalize(addMember)
       }
     }
   }
 
-  override def addMember(m: vpr.Member): Unit = m match {
+  private def addMember(m: vpr.Member): Unit = m match {
     case d: vpr.Domain => _domains ::= d
     case f: vpr.Field => _fields ::= f
     case p: vpr.Predicate => _predicates ::= p

--- a/src/main/scala/viper/gobra/translator/implementations/ContextImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/ContextImpl.scala
@@ -36,7 +36,8 @@ case class ContextImpl(
                         predicate: Predicates,
                         builtInMembers: BuiltInMembers,
                         stmt: Statements,
-                        table: LookupTable
+                        table: LookupTable,
+                        initialFreshCounterValue: Int = 0
                       ) extends Context {
 
   def this(conf: TranslatorConfig, table: LookupTable) = {
@@ -91,6 +92,7 @@ case class ContextImpl(
                    predicateN: Predicates = predicate,
                    builtInMembersN: BuiltInMembers = builtInMembers,
                    stmtN: Statements = stmt,
+                   initialFreshCounterValueN: Int = freshCounter
                  ): Context = copy(
     fieldN,
     arrayN,
@@ -113,8 +115,18 @@ case class ContextImpl(
     pureMethodN,
     predicateN,
     builtInMembersN,
-    stmtN
+    stmtN,
+    initialFreshCounterValue = initialFreshCounterValueN
   )
 
   override def addVars(vars: LocalVarDecl*): Context = this
+
+
+  private var freshCounter: Int = initialFreshCounterValue
+  override def getFreshCounter: Int = freshCounter
+  override def getAndIncrementFreshCounter: Int = {
+    val value = freshCounter
+    freshCounter += 1
+    value
+  }
 }

--- a/src/main/scala/viper/gobra/translator/implementations/ContextImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/ContextImpl.scala
@@ -7,6 +7,7 @@
 package viper.gobra.translator.implementations
 
 import viper.gobra.ast.internal.LookupTable
+import viper.gobra.translator.Names
 import viper.gobra.translator.encodings.TypeEncoding
 import viper.gobra.translator.interfaces.{Context, TranslatorConfig}
 import viper.gobra.translator.interfaces.translator._
@@ -92,7 +93,7 @@ case class ContextImpl(
                    predicateN: Predicates = predicate,
                    builtInMembersN: BuiltInMembers = builtInMembers,
                    stmtN: Statements = stmt,
-                   initialFreshCounterValueN: Int = getFreshVariableCounter
+                   initialFreshCounterValueN: Int = internalFreshNames.getValue
                  ): Context = copy(
     fieldN,
     arrayN,
@@ -121,12 +122,16 @@ case class ContextImpl(
 
   override def addVars(vars: LocalVarDecl*): Context = this
 
+  override val internalFreshNames: FreshNameIteratorImpl = FreshNameIteratorImpl(initialFreshCounterValue)
 
-  private var freshVariableCounter: Int = initialFreshCounterValue
-  override def getFreshVariableCounter: Int = freshVariableCounter
-  override def getAndIncrementFreshVariableCounter: Int = {
-    val value = freshVariableCounter
-    freshVariableCounter += 1
-    value
+  case class FreshNameIteratorImpl(private val initialValue: Int) extends FreshNameIterator {
+    private var currentValue: Int = initialValue
+    override def hasNext: Boolean = true
+    override def next(): String = {
+      val value = currentValue
+      currentValue += 1
+      s"${Names.freshNamePrefix}$value"
+    }
+    override def getValue: Int = currentValue
   }
 }

--- a/src/main/scala/viper/gobra/translator/implementations/ContextImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/ContextImpl.scala
@@ -92,7 +92,7 @@ case class ContextImpl(
                    predicateN: Predicates = predicate,
                    builtInMembersN: BuiltInMembers = builtInMembers,
                    stmtN: Statements = stmt,
-                   initialFreshCounterValueN: Int = freshCounter
+                   initialFreshCounterValueN: Int = getFreshVariableCounter
                  ): Context = copy(
     fieldN,
     arrayN,
@@ -122,11 +122,11 @@ case class ContextImpl(
   override def addVars(vars: LocalVarDecl*): Context = this
 
 
-  private var freshCounter: Int = initialFreshCounterValue
-  override def getFreshCounter: Int = freshCounter
-  override def getAndIncrementFreshCounter: Int = {
-    val value = freshCounter
-    freshCounter += 1
+  private var freshVariableCounter: Int = initialFreshCounterValue
+  override def getFreshVariableCounter: Int = freshVariableCounter
+  override def getAndIncrementFreshVariableCounter: Int = {
+    val value = freshVariableCounter
+    freshVariableCounter += 1
     value
   }
 }

--- a/src/main/scala/viper/gobra/translator/implementations/components/ArraysImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/ArraysImpl.scala
@@ -7,7 +7,6 @@
 package viper.gobra.translator.implementations.components
 
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.Arrays
 import viper.silver.{ast => vpr}
 
@@ -115,7 +114,7 @@ class ArraysImpl extends Arrays {
     vpr.DomainFuncApp(lenFunc, Seq(a), a.typ.asInstanceOf[vpr.DomainType].typVarsMap)(pos, info, errT)
   }
 
-  override def finalize(col : Collector) : Unit = {
-    if (generateDomain) col.addMember(domain)
+  override def finalize(addMemberFn: vpr.Member => Unit) : Unit = {
+    if (generateDomain) addMemberFn(domain)
   }
 }

--- a/src/main/scala/viper/gobra/translator/implementations/components/ConditionsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/ConditionsImpl.scala
@@ -10,7 +10,6 @@ import viper.gobra.reporting.BackTranslator.{ErrorTransformer, RichErrorMessage}
 import viper.gobra.reporting.Source.Verifier
 import viper.gobra.reporting.{Source, VerificationError}
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.Conditions
 import viper.gobra.translator.util.FunctionGeneratorWithoutContext
 import viper.silver.plugin.standard.termination
@@ -20,11 +19,11 @@ import viper.silver.verifier.{errors => vprerr}
 
 class ConditionsImpl extends Conditions {
 
-  override def finalize(col: Collector): Unit = {
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
     if (isAssertFuncUsed) {
-      col.addMember(assertFunction)
+      addMemberFn(assertFunction)
     }
-    typedAssertFunc.finalize(col)
+    typedAssertFunc.finalize(addMemberFn)
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/implementations/components/EqualityImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/EqualityImpl.scala
@@ -8,14 +8,13 @@ package viper.gobra.translator.implementations.components
 
 import viper.gobra.translator.interfaces.components.Equality
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.Collector
 import viper.silver.{ast => vpr}
 
 class EqualityImpl extends Equality {
 
-  override def finalize(col: Collector): Unit = {
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
     if (isUsed) {
-      col.addMember(equalityDomain)
+      addMemberFn(equalityDomain)
     }
   }
 

--- a/src/main/scala/viper/gobra/translator/implementations/components/FieldsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/FieldsImpl.scala
@@ -8,14 +8,14 @@ package viper.gobra.translator.implementations.components
 
 import viper.gobra.ast.{internal => in}
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.interfaces.components.Fields
 import viper.gobra.translator.util.PrimitiveGenerator
 import viper.silver.{ast => vpr}
 
 class FieldsImpl extends Fields {
 
-  override def finalize(col: Collector): Unit = _fieldGenerator.finalize(col)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = _fieldGenerator.finalize(addMemberFn)
 
   private val _fieldGenerator: PrimitiveGenerator.PrimitiveGenerator[vpr.Type, vpr.Field] =
     PrimitiveGenerator.simpleGenerator(

--- a/src/main/scala/viper/gobra/translator/implementations/components/FixpointImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/FixpointImpl.scala
@@ -8,7 +8,7 @@ package viper.gobra.translator.implementations.components
 
 import viper.gobra.ast.internal.GlobalConst
 import viper.gobra.ast.{internal => in}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.interfaces.components.Fixpoint
 import viper.silver.ast.{Exp, Type, TypeVar}
 import viper.silver.{ast => vpr}
@@ -16,10 +16,10 @@ import viper.silver.{ast => vpr}
 class FixpointImpl extends Fixpoint {
 
   /**
-    * Finalizes translation. May add to collector.
+    * Finalizes translation. `addMemberFn` is called with any member that is part of the encoding.
     */
-  override def finalize(col: Collector): Unit = {
-    generatedDomains foreach col.addMember
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    generatedDomains foreach addMemberFn
   }
 
   override def create(gc: in.GlobalConstDecl)(ctx: Context): Unit = {

--- a/src/main/scala/viper/gobra/translator/implementations/components/OptionImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/OptionImpl.scala
@@ -6,7 +6,6 @@
 
 package viper.gobra.translator.implementations.components
 
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.Options
 import viper.silver.{ast => vpr}
 
@@ -242,7 +241,7 @@ class OptionImpl extends Options {
     vpr.DomainType(domain, Map(typeVar -> t))
   }
 
-  override def finalize(col : Collector) : Unit = {
-    if (generateDomain) col.addMember(domain)
+  override def finalize(addMemberFn: vpr.Member => Unit) : Unit = {
+    if (generateDomain) addMemberFn(domain)
   }
 }

--- a/src/main/scala/viper/gobra/translator/implementations/components/OptionToSeqImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/OptionToSeqImpl.scala
@@ -6,7 +6,6 @@
 
 package viper.gobra.translator.implementations.components
 
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.{OptionToSeq, Options}
 import viper.silver.ast.{DomainFuncApp, ErrorTrafo, Exp, Info, Position}
 import viper.silver.{ast => vpr}
@@ -84,7 +83,7 @@ class OptionToSeqImpl(options : Options) extends OptionToSeq {
     )(pos, info, errT)
   }
 
-  override def finalize(col : Collector) : Unit = {
-    if (generateDomain) col.addMember(domain)
+  override def finalize(addMemberFn: vpr.Member => Unit) : Unit = {
+    if (generateDomain) addMemberFn(domain)
   }
 }

--- a/src/main/scala/viper/gobra/translator/implementations/components/SeqMultiplicityImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/SeqMultiplicityImpl.scala
@@ -6,7 +6,6 @@
 
 package viper.gobra.translator.implementations.components
 
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.SeqMultiplicity
 import viper.silver.{ast => vpr}
 
@@ -196,10 +195,10 @@ class SeqMultiplicityImpl extends SeqMultiplicity {
   )()
 
   /**
-    * Finalises translation. May add to collector.
+    * Finalizes translation. `addMemberFn` is called with any member that is part of the encoding.
     */
-  override def finalize(col : Collector) : Unit = {
-    if (generateDomain) col.addMember(domain)
+  override def finalize(addMemberFn: vpr.Member => Unit) : Unit = {
+    if (generateDomain) addMemberFn(domain)
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/implementations/components/SeqToMultisetImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/SeqToMultisetImpl.scala
@@ -6,7 +6,6 @@
 
 package viper.gobra.translator.implementations.components
 
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.{SeqMultiplicity, SeqToMultiset}
 import viper.gobra.util.Violation
 import viper.silver.{ast => vpr}
@@ -153,10 +152,10 @@ class SeqToMultisetImpl(val seqMultiplicity : SeqMultiplicity) extends SeqToMult
   )()
 
   /**
-    * Finalises translation. May add to collector.
+    * Finalizes translation. `addMemberFn` is called with any member that is part of the encoding.
     */
-  override def finalize(col : Collector) : Unit = {
-    if (generateDomain) col.addMember(domain)
+  override def finalize(addMemberFn: vpr.Member => Unit) : Unit = {
+    if (generateDomain) addMemberFn(domain)
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/implementations/components/SeqToSetImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/SeqToSetImpl.scala
@@ -6,7 +6,6 @@
 
 package viper.gobra.translator.implementations.components
 
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.SeqToSet
 import viper.gobra.util.Violation
 import viper.silver.{ast => vpr}
@@ -158,10 +157,10 @@ class SeqToSetImpl extends SeqToSet {
   )()
 
   /**
-    * Finalises translation. May add to collector.
+    * Finalizes translation. `addMemberFn` is called with any member that is part of the encoding.
     */
-  override def finalize(col : Collector) : Unit = {
-    if (generateDomain) col.addMember(domain)
+  override def finalize(addMemberFn: vpr.Member => Unit) : Unit = {
+    if (generateDomain) addMemberFn(domain)
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/implementations/components/SlicesImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/SlicesImpl.scala
@@ -6,7 +6,6 @@
 
 package viper.gobra.translator.implementations.components
 
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.{Arrays, Slices}
 import viper.silver.{ast => vpr}
 
@@ -363,10 +362,10 @@ class SlicesImpl(val arrays : Arrays) extends Slices {
     vpr.DomainType(domain, Map(typeVar -> t))
   }
 
-  override def finalize(col : Collector) : Unit = {
+  override def finalize(addMemberFn: vpr.Member => Unit) : Unit = {
     if (generateDomain) {
-      col.addMember(domain)
-      col.addMember(sadd_func)
+      addMemberFn(domain)
+      addMemberFn(sadd_func)
     }
   }
 }

--- a/src/main/scala/viper/gobra/translator/implementations/components/TuplesImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/TuplesImpl.scala
@@ -6,6 +6,7 @@
 
 package viper.gobra.translator.implementations.components
 
+import viper.gobra.translator.Names
 import viper.gobra.translator.interfaces.components.Tuples
 import viper.silver.{ast => vpr}
 
@@ -66,7 +67,7 @@ class TuplesImpl extends Tuples {
   private val getters: mutable.Map[(Int,Int), vpr.DomainFunc] = mutable.Map.empty
 
   private def addNTuplesDomain(arity: Int): Unit = {
-    val domainName = s"Tuple$arity"
+    val domainName = s"${Names.tupleDomain}$arity"
 
     val typeVars = 0.until(arity) map (ix => vpr.TypeVar(s"T$ix"))
     val decls = 0.until(arity) map (ix => vpr.LocalVarDecl(s"t$ix", typeVars(ix))())
@@ -127,10 +128,12 @@ class TuplesImpl extends Tuples {
       )(domainName = domainName)
     }
 
+    // there are not quantified variables for tuples of 0 arity. Thus, do not generate any axioms in this case:
+    val axioms = if (arity == 0) Seq.empty else Seq(getOverTupleAxiom, tupleOverGetAxiom)
     val domain = vpr.Domain(
       domainName,
       tupleFunc +: getFuncs,
-      Seq(getOverTupleAxiom, tupleOverGetAxiom),
+      axioms,
       typeVars
     )()
 

--- a/src/main/scala/viper/gobra/translator/implementations/components/TuplesImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/TuplesImpl.scala
@@ -6,7 +6,6 @@
 
 package viper.gobra.translator.implementations.components
 
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.Tuples
 import viper.silver.{ast => vpr}
 
@@ -15,10 +14,10 @@ import scala.collection.mutable
 class TuplesImpl extends Tuples {
 
   /**
-    * Finalizes translation. May add to collector.
+    * Finalizes translation. `addMemberFn` is called with any member that is part of the encoding.
     */
-  override def finalize(col: Collector): Unit = {
-    generatedDomains foreach col.addMember
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    generatedDomains foreach addMemberFn
   }
 
   override def typ(args: Vector[vpr.Type]): vpr.DomainType = {

--- a/src/main/scala/viper/gobra/translator/implementations/components/UnknownValuesImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/components/UnknownValuesImpl.scala
@@ -7,13 +7,12 @@
 package viper.gobra.translator.implementations.components
 
 import viper.gobra.translator.Names
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.components.UnknownValues
 import viper.silver.{ast => vpr}
 
 class UnknownValuesImpl extends UnknownValues {
 
-  override def finalize(col: Collector): Unit = {
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
     if (genFunctions.nonEmpty) {
       val domain = vpr.Domain(
         name = domainName,
@@ -22,7 +21,7 @@ class UnknownValuesImpl extends UnknownValues {
         axioms = Seq.empty
       )()
 
-      col.addMember(domain)
+      addMemberFn(domain)
     }
   }
 

--- a/src/main/scala/viper/gobra/translator/implementations/translator/AssertionsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/AssertionsImpl.scala
@@ -11,7 +11,7 @@ import viper.silver.verifier.{errors => vprerr}
 import viper.gobra.reporting.BackTranslator.ErrorTransformer
 import viper.gobra.reporting.BackTranslator.RichErrorMessage
 import viper.gobra.reporting.{DefaultErrorBackTranslator, LoopInvariantNotWellFormedError, MethodContractNotWellFormedError, Source}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.interfaces.translator.Assertions
 import viper.gobra.translator.util.ViperWriter.{CodeWriter, MemberWriter}
 import viper.gobra.util.Violation
@@ -23,7 +23,7 @@ class AssertionsImpl extends Assertions {
   import viper.gobra.translator.util.ViperWriter.CodeLevel._
   import viper.gobra.translator.util.ViperWriter.{MemberLevel => MemL}
 
-  override def finalize(col: Collector): Unit = ()
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = ()
 
   override def translate(ass: in.Assertion)(ctx: Context): CodeWriter[vpr.Exp] = {
 

--- a/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
@@ -96,7 +96,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
     */
   private def getOrGenerateMethod(tag: BuiltInMethodTag, recv: in.Type, args: Vector[in.Type])(src: Source.Parser.Info)(ctx: Context): in.MethodProxy = {
     def create(): in.BuiltInMethod = {
-      val proxy = in.MethodProxy(tag.identifier, freshNameForTag(tag))(src)
+      val proxy = in.MethodProxy(tag.identifier, freshNameForTag(tag)(ctx))(src)
       in.BuiltInMethod(recv, tag, proxy, args)(src)
     }
     val method = getOrGenerate(tag, Vector(recv), create)(ctx)
@@ -109,7 +109,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
   @unused
   private def getOrGenerateFunction(tag: BuiltInFunctionTag, args: Vector[in.Type])(src: Source.Parser.Info)(ctx: Context): in.FunctionProxy = {
     def create(): in.BuiltInFunction = {
-      val proxy = in.FunctionProxy(freshNameForTag(tag))(src)
+      val proxy = in.FunctionProxy(freshNameForTag(tag)(ctx))(src)
       in.BuiltInFunction(tag, proxy, args)(src)
     }
     val function = getOrGenerate(tag, args, create)(ctx)
@@ -121,7 +121,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
     */
   private def getOrGenerateFPredicate(tag: BuiltInFPredicateTag, args: Vector[in.Type])(src: Source.Parser.Info)(ctx: Context): in.FPredicateProxy = {
     def create(): in.BuiltInFPredicate = {
-      val proxy = in.FPredicateProxy(freshNameForTag(tag))(src)
+      val proxy = in.FPredicateProxy(freshNameForTag(tag)(ctx))(src)
       in.BuiltInFPredicate(tag, proxy, args)(src)
     }
     val predicate = getOrGenerate(tag, args, create)(ctx)
@@ -134,7 +134,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
 
   private def getOrGenerateMPredicate(tag: BuiltInMPredicateTag, recv: in.Type, args: Vector[in.Type])(src: Source.Parser.Info)(ctx: Context): in.MPredicateProxy = {
     def create(): in.BuiltInMPredicate = {
-      val proxy = in.MPredicateProxy(tag.identifier, freshNameForTag(tag))(src)
+      val proxy = in.MPredicateProxy(tag.identifier, freshNameForTag(tag)(ctx))(src)
       in.BuiltInMPredicate(recv, tag, proxy, args)(src)
     }
     val predicate = getOrGenerate(tag, Vector(recv), create)(ctx)
@@ -180,8 +180,8 @@ class BuiltInMembersImpl extends BuiltInMembers {
     })(ctx)
 
 
-  private def freshNameForTag(tag: BuiltInMemberTag): String =
-    s"${Names.builtInMember}_${tag.identifier}_${Names.freshName}"
+  private def freshNameForTag(tag: BuiltInMemberTag)(ctx: Context): String =
+    s"${Names.builtInMember}_${tag.identifier}_${Names.freshName(ctx)}"
 
 
   //

--- a/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
@@ -13,10 +13,11 @@ import viper.gobra.reporting.Source
 import viper.gobra.theory.Addressability
 import viper.gobra.translator.Names
 import viper.gobra.translator.interfaces.translator.BuiltInMembers
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.PrimitiveGenerator
 import viper.gobra.util.Computation
 import viper.gobra.util.Violation.violation
+import viper.silver.{ast => vpr}
 
 import scala.annotation.unused
 import scala.language.postfixOps
@@ -30,11 +31,11 @@ class BuiltInMembersImpl extends BuiltInMembers {
   // the implementation uses 4 distinct generators (instead of a single one) such that the exposed
   // methods (i.e. method, function, fpredicate, and mpredicate) can return the translated 'regular' member.
 
-  override def finalize(col: Collector): Unit = {
-    methodGenerator.finalize(col)
-    functionGenerator.finalize(col)
-    fPredicateGenerator.finalize(col)
-    mPredicateGenerator.finalize(col)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    methodGenerator.finalize(addMemberFn)
+    functionGenerator.finalize(addMemberFn)
+    fPredicateGenerator.finalize(addMemberFn)
+    mPredicateGenerator.finalize(addMemberFn)
   }
 
   private def member(x: in.BuiltInMember)(ctx: Context): in.Member =

--- a/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
@@ -182,7 +182,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
 
 
   private def freshNameForTag(tag: BuiltInMemberTag)(ctx: Context): String =
-    s"${Names.builtInMember}_${tag.identifier}_${Names.freshName(ctx)}"
+    s"${Names.builtInMember}_${tag.identifier}_${ctx.freshNames.next()}"
 
 
   //

--- a/src/main/scala/viper/gobra/translator/implementations/translator/ExpressionsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/ExpressionsImpl.scala
@@ -7,7 +7,7 @@
 package viper.gobra.translator.implementations.translator
 
 import viper.gobra.ast.{internal => in}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.interfaces.translator.Expressions
 import viper.gobra.translator.util.ViperWriter.CodeWriter
 import viper.gobra.util.Violation
@@ -17,7 +17,7 @@ class ExpressionsImpl extends Expressions {
 
   import viper.gobra.translator.util.ViperWriter.CodeLevel._
 
-  override def finalize(col: Collector): Unit = {}
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {}
 
   override def translate(x: in.Expr)(ctx: Context): CodeWriter[vpr.Exp] = {
 

--- a/src/main/scala/viper/gobra/translator/implementations/translator/MethodsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/MethodsImpl.scala
@@ -9,7 +9,7 @@ package viper.gobra.translator.implementations.translator
 import viper.gobra.ast.{internal => in}
 import viper.gobra.translator.Names
 import viper.gobra.translator.interfaces.translator.Methods
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.{ViperUtil => vu}
 import viper.silver.ast.Method
 import viper.silver.{ast => vpr}
@@ -19,7 +19,7 @@ class MethodsImpl extends Methods {
   import viper.gobra.translator.util.ViperWriter.{CodeLevel => cl, _}
   import MemberLevel._
 
-  override def finalize(col: Collector): Unit = ()
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = ()
 
   override def method(x: in.Method)(ctx: Context): MemberWriter[Method] = {
     val (pos, info, errT) = x.vprMeta

--- a/src/main/scala/viper/gobra/translator/implementations/translator/PredicatesImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/PredicatesImpl.scala
@@ -10,7 +10,7 @@ import org.bitbucket.inkytonik.kiama.==>
 import viper.gobra.ast.{internal => in}
 import viper.gobra.reporting.Source
 import viper.gobra.translator.interfaces.translator.Predicates
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.{ViperUtil => vu}
 import viper.silver.{ast => vpr}
 import viper.silver.plugin.standard.predicateinstance
@@ -21,9 +21,9 @@ class PredicatesImpl extends Predicates {
   import MemberLevel._
 
   /**
-    * Finalizes translation. May add to collector.
+    * Finalizes translation. `addMemberFn` is called with any member that is part of the encoding.
     */
-  override def finalize(col: Collector): Unit = ()
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = ()
 
   override def mpredicate(pred: in.MPredicate)(ctx: Context): MemberWriter[vpr.Predicate] = {
 

--- a/src/main/scala/viper/gobra/translator/implementations/translator/ProgramsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/ProgramsImpl.scala
@@ -30,8 +30,7 @@ class ProgramsImpl extends Programs {
       /** we use a separate context for each member in order to reset the fresh counter */
       val ctx = (mainCtx := (initialFreshCounterValueN = 0))
       val typeEncodingOpt = ctx.typeEncoding.member(ctx).lift(member)
-      val memberWriter = if (typeEncodingOpt.isDefined) typeEncodingOpt.get
-      else {
+      val memberWriter = typeEncodingOpt.getOrElse {
         member match {
           case f: in.Function => ctx.method.function(f)(ctx).map(Vector(_))
           case m: in.Method => ctx.method.method(m)(ctx).map(Vector(_))

--- a/src/main/scala/viper/gobra/translator/implementations/translator/ProgramsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/ProgramsImpl.scala
@@ -52,8 +52,8 @@ class ProgramsImpl extends Programs {
 
     val progW = for {
       membersWithCtxs <- sequence(program.members map goM)
-      ctxs = membersWithCtxs map { case (_, ctx) => ctx }
-      members = membersWithCtxs flatMap { case (m, _) => m }
+      (memberss, ctxs) = membersWithCtxs.unzip
+      members = memberss.flatten
 
       col = {
         val c = new CollectorImpl()

--- a/src/main/scala/viper/gobra/translator/implementations/translator/ProgramsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/ProgramsImpl.scala
@@ -10,7 +10,7 @@ import viper.gobra.ast.{internal => in}
 import viper.gobra.backend.BackendVerifier
 import viper.gobra.reporting.BackTranslator.BackTrackInfo
 import viper.gobra.translator.implementations.{CollectorImpl, ContextImpl}
-import viper.gobra.translator.interfaces.TranslatorConfig
+import viper.gobra.translator.interfaces.{Context, TranslatorConfig}
 import viper.gobra.translator.interfaces.translator.Programs
 import viper.gobra.translator.util.ViperWriter.MemberWriter
 import viper.gobra.util.Violation
@@ -24,11 +24,13 @@ class ProgramsImpl extends Programs {
 
     val (pos, info, errT) = program.vprMeta
 
-    val ctx = new ContextImpl(conf, program.table)
+    val mainCtx = new ContextImpl(conf, program.table)
 
-    def goM(member: in.Member): MemberWriter[Vector[vpr.Member]] = {
+    def goM(member: in.Member): MemberWriter[(Vector[vpr.Member], Context)] = {
+      /** we use a separate context for each member in order to reset the fresh counter */
+      val ctx = (mainCtx := (initialFreshCounterValueN = 0))
       val typeEncodingOpt = ctx.typeEncoding.member(ctx).lift(member)
-      if (typeEncodingOpt.isDefined) typeEncodingOpt.get
+      val memberWriter = if (typeEncodingOpt.isDefined) typeEncodingOpt.get
       else {
         member match {
           case f: in.Function => ctx.method.function(f)(ctx).map(Vector(_))
@@ -45,15 +47,17 @@ class ProgramsImpl extends Programs {
           case p => Violation.violation(s"found unsupported member: $p")
         }
       }
+      memberWriter.map(m => (m, ctx))
     }
 
     val progW = for {
-      memberss <- sequence(program.members map goM)
-      members = memberss.flatten
+      membersWithCtxs <- sequence(program.members map goM)
+      ctxs = membersWithCtxs map { case (_, ctx) => ctx }
+      members = membersWithCtxs flatMap { case (m, _) => m }
 
       col = {
         val c = new CollectorImpl()
-        ctx.finalize(c)
+        ctxs.foreach(ctx => ctx.finalize(c))
         c
       }
 

--- a/src/main/scala/viper/gobra/translator/implementations/translator/PureMethodsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/PureMethodsImpl.scala
@@ -8,7 +8,7 @@ package viper.gobra.translator.implementations.translator
 
 import viper.gobra.ast.{internal => in}
 import viper.gobra.translator.interfaces.translator.PureMethods
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.silver.{ast => vpr}
 
 class PureMethodsImpl extends PureMethods {
@@ -17,9 +17,9 @@ class PureMethodsImpl extends PureMethods {
   import MemberLevel._
 
   /**
-    * Finalizes translation. May add to collector.
+    * Finalizes translation. `addMemberFn` is called with any member that is part of the encoding.
     */
-  override def finalize(col: Collector): Unit = ()
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = ()
 
   override def pureMethod(meth: in.PureMethod)(ctx: Context): MemberWriter[vpr.Function] = {
     require(meth.results.size == 1)

--- a/src/main/scala/viper/gobra/translator/implementations/translator/StatementsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/StatementsImpl.scala
@@ -120,7 +120,7 @@ class StatementsImpl extends Statements {
           // vTargets can be field-accesses, but a MethodCall in Viper requires variables as targets.
           // Therefore, we introduce auxiliary variables and
           // add an assignment from the auxiliary variables to the actual targets
-          (vUsedTargets, auxTargetsWithAssignment) = vTargets.map(viperTarget).unzip
+          (vUsedTargets, auxTargetsWithAssignment) = vTargets.map(viperTarget(_)(ctx)).unzip
           (auxTargetDecls, backAssignments) = auxTargetsWithAssignment.flatten.unzip
           _ <- local(auxTargetDecls: _*)
           _ <- write(vpr.MethodCall(func.name, vArgss, vUsedTargets)(pos, info, errT))
@@ -135,7 +135,7 @@ class StatementsImpl extends Statements {
           // vTargets can be field-accesses, but a MethodCall in Viper requires variables as targets.
           // Therefore, we introduce auxiliary variables and
           // add an assignment from the auxiliary variables to the actual targets
-          (vUsedTargets, auxTargetsWithAssignment) = vTargets.map(viperTarget).unzip
+          (vUsedTargets, auxTargetsWithAssignment) = vTargets.map(viperTarget(_)(ctx)).unzip
           (auxTargetDecls, backAssignments) = auxTargetsWithAssignment.flatten.unzip
           _ <- local(auxTargetDecls: _*)
           _ <- write(vpr.MethodCall(meth.uniqueName, vRecv +: vArgss, vUsedTargets)(pos, info, errT))
@@ -172,11 +172,11 @@ class StatementsImpl extends Statements {
     result(vprStmt) map (s => stmtComment(x, s))
   }
 
-  private def viperTarget(x: vpr.Exp): (vpr.LocalVar, Option[(vpr.LocalVarDecl, vpr.AbstractAssign)]) = {
+  private def viperTarget(x: vpr.Exp)(ctx: Context): (vpr.LocalVar, Option[(vpr.LocalVarDecl, vpr.AbstractAssign)]) = {
     x match {
       case x: vpr.LocalVar => (x, None)
       case _ =>
-        val decl = vpr.LocalVarDecl(Names.freshName, x.typ)(x.pos, x.info, x.errT)
+        val decl = vpr.LocalVarDecl(Names.freshName(ctx), x.typ)(x.pos, x.info, x.errT)
         val ass  = vu.valueAssign(x, decl.localVar)(x.pos, x.info, x.errT)
         (decl.localVar, Some((decl, ass)))
     }

--- a/src/main/scala/viper/gobra/translator/implementations/translator/StatementsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/StatementsImpl.scala
@@ -176,7 +176,7 @@ class StatementsImpl extends Statements {
     x match {
       case x: vpr.LocalVar => (x, None)
       case _ =>
-        val decl = vpr.LocalVarDecl(Names.freshName(ctx), x.typ)(x.pos, x.info, x.errT)
+        val decl = vpr.LocalVarDecl(ctx.freshNames.next(), x.typ)(x.pos, x.info, x.errT)
         val ass  = vu.valueAssign(x, decl.localVar)(x.pos, x.info, x.errT)
         (decl.localVar, Some((decl, ass)))
     }

--- a/src/main/scala/viper/gobra/translator/implementations/translator/StatementsImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/StatementsImpl.scala
@@ -10,7 +10,7 @@ import viper.gobra.ast.{internal => in}
 import viper.gobra.reporting.{GoCallPreconditionReason, PreconditionError, Source}
 import viper.gobra.translator.Names
 import viper.gobra.translator.interfaces.translator.Statements
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.CodeWriter
 import viper.gobra.translator.util.{Comments, ViperUtil => vu}
 import viper.gobra.util.Violation
@@ -25,7 +25,7 @@ class StatementsImpl extends Statements {
 
   import viper.gobra.translator.util.ViperWriter.CodeLevel._
 
-  override def finalize(col: Collector): Unit = ()
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = ()
 
   /** Clients can assume that the returned writer does not contain local variable definitions or written statements. */
   override def translate(x: in.Stmt)(ctx: Context): CodeWriter[vpr.Stmt] = {

--- a/src/main/scala/viper/gobra/translator/implementations/translator/TerminationMeasuresImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/TerminationMeasuresImpl.scala
@@ -8,7 +8,7 @@ package viper.gobra.translator.implementations.translator
 
 import viper.gobra.ast.internal.TerminationMeasure
 import viper.gobra.ast.{internal => in}
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.interfaces.translator.TerminationMeasures
 import viper.gobra.translator.util.ViperWriter.MemberLevel.pure
 import viper.gobra.translator.util.ViperWriter.{CodeWriter, MemberWriter, CodeLevel => cl}
@@ -19,7 +19,7 @@ import viper.silver.{ast => vpr}
 
 class TerminationMeasuresImpl extends TerminationMeasures {
 
-  override def finalize(col: Collector): Unit = ()
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = ()
 
   override def translate(measure: TerminationMeasure)(ctx: Context): CodeWriter[Exp] = {
     val (pos, info, errT) = measure.vprMeta

--- a/src/main/scala/viper/gobra/translator/interfaces/Collector.scala
+++ b/src/main/scala/viper/gobra/translator/interfaces/Collector.scala
@@ -9,8 +9,8 @@ import viper.gobra.translator.interfaces.translator.Generator
 import viper.silver.{ast => vpr}
 
 trait Collector {
-  /** invokes finalize on each generator */
-  def finalize(generators: Vector[Generator]): Unit
+  /** invokes finalize on the generator */
+  def finalize(generator: Generator): Unit
 
   def domains: Seq[vpr.Domain]
   def fields: Seq[vpr.Field]

--- a/src/main/scala/viper/gobra/translator/interfaces/Collector.scala
+++ b/src/main/scala/viper/gobra/translator/interfaces/Collector.scala
@@ -12,8 +12,6 @@ trait Collector {
   /** invokes finalize on each generator */
   def finalize(generators: Vector[Generator]): Unit
 
-  def addMember(m: vpr.Member): Unit
-
   def domains: Seq[vpr.Domain]
   def fields: Seq[vpr.Field]
   def predicate: Seq[vpr.Predicate]

--- a/src/main/scala/viper/gobra/translator/interfaces/Collector.scala
+++ b/src/main/scala/viper/gobra/translator/interfaces/Collector.scala
@@ -5,9 +5,13 @@
 // Copyright (c) 2011-2020 ETH Zurich.
 
 package viper.gobra.translator.interfaces
+import viper.gobra.translator.interfaces.translator.Generator
 import viper.silver.{ast => vpr}
 
 trait Collector {
+  /** invokes finalize on each generator */
+  def finalize(generators: Vector[Generator]): Unit
+
   def addMember(m: vpr.Member): Unit
 
   def domains: Seq[vpr.Domain]

--- a/src/main/scala/viper/gobra/translator/interfaces/Context.scala
+++ b/src/main/scala/viper/gobra/translator/interfaces/Context.scala
@@ -105,34 +105,31 @@ trait Context {
 
 
   def finalize(col : Collector): Unit = {
-    val generators = Vector(
-      // components
-      field,
-      array,
-      seqToSet,
-      seqToMultiset,
-      seqMultiplicity,
-      option,
-      optionToSeq,
-      slice,
-      fixpoint,
-      tuple,
-      equality,
-      condition,
-      unknownValue,
+    // components
+    col.finalize(field)
+    col.finalize(array)
+    col.finalize(seqToSet)
+    col.finalize(seqToMultiset)
+    col.finalize(seqMultiplicity)
+    col.finalize(option)
+    col.finalize(optionToSeq)
+    col.finalize(slice)
+    col.finalize(fixpoint)
+    col.finalize(tuple)
+    col.finalize(equality)
+    col.finalize(condition)
+    col.finalize(unknownValue)
 
-      // translators
-      typeEncoding,
-      ass,
-      measures,
-      expr,
-      method,
-      pureMethod,
-      predicate,
-      builtInMembers,
-      stmt
-    )
-    col.finalize(generators)
+    // translators
+    col.finalize(typeEncoding)
+    col.finalize(ass)
+    col.finalize(measures)
+    col.finalize(expr)
+    col.finalize(method)
+    col.finalize(pureMethod)
+    col.finalize(predicate)
+    col.finalize(builtInMembers)
+    col.finalize(stmt)
   }
 
   trait FreshNameIterator extends Iterator[String] {

--- a/src/main/scala/viper/gobra/translator/interfaces/Context.scala
+++ b/src/main/scala/viper/gobra/translator/interfaces/Context.scala
@@ -70,6 +70,10 @@ trait Context {
 
   def addVars(vars: vpr.LocalVarDecl*): Context
 
+  // fresh variable counter
+  protected def getFreshCounter: Int
+  def getAndIncrementFreshCounter: Int
+
   /** copy constructor */
   def :=(
           fieldN: Fields = field,
@@ -93,35 +97,39 @@ trait Context {
           pureMethodN: PureMethods = pureMethod,
           predicateN: Predicates = predicate,
           builtInMembersN: BuiltInMembers = builtInMembers,
-          stmtN: Statements = stmt
+          stmtN: Statements = stmt,
+          initialFreshCounterValueN: Int = getFreshCounter
          ): Context
 
 
   def finalize(col : Collector): Unit = {
-    // components
-    field.finalize(col)
-    array.finalize(col)
-    seqToSet.finalize(col)
-    seqToMultiset.finalize(col)
-    seqMultiplicity.finalize(col)
-    option.finalize(col)
-    optionToSeq.finalize(col)
-    slice.finalize(col)
-    fixpoint.finalize(col)
-    tuple.finalize(col)
-    equality.finalize(col)
-    condition.finalize(col)
-    unknownValue.finalize(col)
+    val generators = Vector(
+      // components
+      field,
+      array,
+      seqToSet,
+      seqToMultiset,
+      seqMultiplicity,
+      option,
+      optionToSeq,
+      slice,
+      fixpoint,
+      tuple,
+      equality,
+      condition,
+      unknownValue,
 
-    // translators
-    typeEncoding.finalize(col)
-    ass.finalize(col)
-    measures.finalize(col)
-    expr.finalize(col)
-    method.finalize(col)
-    pureMethod.finalize(col)
-    predicate.finalize(col)
-    builtInMembers.finalize(col)
-    stmt.finalize(col)
+      // translators
+      typeEncoding,
+      ass,
+      measures,
+      expr,
+      method,
+      pureMethod,
+      predicate,
+      builtInMembers,
+      stmt
+    )
+    col.finalize(generators)
   }
 }

--- a/src/main/scala/viper/gobra/translator/interfaces/Context.scala
+++ b/src/main/scala/viper/gobra/translator/interfaces/Context.scala
@@ -71,8 +71,10 @@ trait Context {
   def addVars(vars: vpr.LocalVarDecl*): Context
 
   // fresh variable counter
-  protected def getFreshVariableCounter: Int
-  def getAndIncrementFreshVariableCounter: Int
+  /** publicly exposed infinite iterator providing fresh names */
+  def freshNames: Iterator[String] = internalFreshNames
+  /** internal fresh name iterator that additionally provides a getter function for its counter value */
+  protected def internalFreshNames: FreshNameIterator
 
   /** copy constructor */
   def :=(
@@ -98,7 +100,7 @@ trait Context {
           predicateN: Predicates = predicate,
           builtInMembersN: BuiltInMembers = builtInMembers,
           stmtN: Statements = stmt,
-          initialFreshCounterValueN: Int = getFreshVariableCounter
+          initialFreshCounterValueN: Int = internalFreshNames.getValue
          ): Context
 
 
@@ -131,5 +133,9 @@ trait Context {
       stmt
     )
     col.finalize(generators)
+  }
+
+  trait FreshNameIterator extends Iterator[String] {
+    def getValue: Int
   }
 }

--- a/src/main/scala/viper/gobra/translator/interfaces/Context.scala
+++ b/src/main/scala/viper/gobra/translator/interfaces/Context.scala
@@ -71,8 +71,8 @@ trait Context {
   def addVars(vars: vpr.LocalVarDecl*): Context
 
   // fresh variable counter
-  protected def getFreshCounter: Int
-  def getAndIncrementFreshCounter: Int
+  protected def getFreshVariableCounter: Int
+  def getAndIncrementFreshVariableCounter: Int
 
   /** copy constructor */
   def :=(
@@ -98,7 +98,7 @@ trait Context {
           predicateN: Predicates = predicate,
           builtInMembersN: BuiltInMembers = builtInMembers,
           stmtN: Statements = stmt,
-          initialFreshCounterValueN: Int = getFreshCounter
+          initialFreshCounterValueN: Int = getFreshVariableCounter
          ): Context
 
 

--- a/src/main/scala/viper/gobra/translator/interfaces/translator/Generator.scala
+++ b/src/main/scala/viper/gobra/translator/interfaces/translator/Generator.scala
@@ -6,16 +6,17 @@
 
 package viper.gobra.translator.interfaces.translator
 
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
+import viper.silver.{ast => vpr}
 
 import scala.annotation.unused
 
 trait Generator {
 
   /**
-    * Finalizes translation. May add to collector.
+    * Finalizes translation. `addMemberFn` is called with any member that is part of the encoding.
     */
-  def finalize(@unused col: Collector): Unit = {}
+  def finalize(@unused addMemberFn: vpr.Member => Unit): Unit = {}
 
   def chain[R](fs: Vector[Context => (R, Context)])(ctx: Context): (Vector[R], Context) = {
     fs.foldLeft((Vector.empty[R], ctx)){ case ((rs, c), rf) =>

--- a/src/main/scala/viper/gobra/translator/util/DomainGenerator.scala
+++ b/src/main/scala/viper/gobra/translator/util/DomainGenerator.scala
@@ -6,13 +6,13 @@
 
 package viper.gobra.translator.util
 
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.interfaces.translator.Generator
 import viper.silver.{ast => vpr}
 
 trait DomainGenerator[T] extends Generator {
 
-  override def finalize(col: Collector): Unit = generatedMember.foreach(col.addMember(_))
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = generatedMember foreach addMemberFn
 
   private var generatedMember: List[vpr.Domain] = List.empty
   private var genMap: Map[T, vpr.Domain] = Map.empty

--- a/src/main/scala/viper/gobra/translator/util/FunctionGenerator.scala
+++ b/src/main/scala/viper/gobra/translator/util/FunctionGenerator.scala
@@ -6,13 +6,13 @@
 
 package viper.gobra.translator.util
 
-import viper.gobra.translator.interfaces.{Collector, Context}
+import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.interfaces.translator.Generator
 import viper.silver.{ast => vpr}
 
 trait FunctionGenerator[T] extends Generator {
 
-  override def finalize(col: Collector): Unit = generatedMember.foreach(col.addMember(_))
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = generatedMember foreach addMemberFn
 
   private var generatedMember: List[vpr.Function] = List.empty
   private var genMap: Map[T, vpr.Function] = Map.empty
@@ -36,7 +36,7 @@ trait FunctionGenerator[T] extends Generator {
 
 trait FunctionGeneratorWithoutContext[T] extends Generator {
 
-  override def finalize(col: Collector): Unit = generatedMember.foreach(col.addMember(_))
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = generatedMember foreach addMemberFn
 
   private var generatedMember: List[vpr.Function] = List.empty
   private var genMap: Map[T, vpr.Function] = Map.empty

--- a/src/main/scala/viper/gobra/translator/util/PrimitiveGenerator.scala
+++ b/src/main/scala/viper/gobra/translator/util/PrimitiveGenerator.scala
@@ -6,7 +6,6 @@
 
 package viper.gobra.translator.util
 
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.translator.Generator
 import viper.gobra.util.Computation
 import viper.silver.{ast => vpr}
@@ -24,7 +23,7 @@ object PrimitiveGenerator {
 
     override def gen(v: A): (R, Vector[vpr.Member]) = cachedGen(v)
 
-    override def finalize(col: Collector): Unit = generatedMember foreach col.addMember
+    override def finalize(addMemberFn: vpr.Member => Unit): Unit = generatedMember foreach addMemberFn
 
     override def apply(v: A): R = {
       val (r, ss) = gen(v)

--- a/src/main/scala/viper/gobra/translator/util/Registrator.scala
+++ b/src/main/scala/viper/gobra/translator/util/Registrator.scala
@@ -6,7 +6,6 @@
 
 package viper.gobra.translator.util
 
-import viper.gobra.translator.interfaces.Collector
 import viper.gobra.translator.interfaces.translator.Generator
 import viper.silver.{ast => vpr}
 
@@ -15,10 +14,10 @@ class Registrator[T <: vpr.Member] extends Generator {
   private var gens: Set[T] = Set.empty
 
   /**
-    * Finalizes translation. May add to collector.
+    * Finalizes translation. `addMemberFn` is called with any member that is part of the encoding.
     */
-  override def finalize(col: Collector): Unit = {
-    gens.foreach(col.addMember)
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
+    gens.foreach(addMemberFn)
     clean()
   }
 

--- a/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
+++ b/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
@@ -12,7 +12,6 @@ import viper.silver.{ast => vpr}
 import viper.gobra.ast.{internal => in}
 import viper.gobra.reporting.{DefaultErrorBackTranslator, Source, VerificationError}
 import viper.gobra.translator.util.{ViperUtil => vu}
-import viper.gobra.translator.Names
 import viper.gobra.translator.interfaces.Context
 import viper.gobra.translator.util.ViperWriter.MemberKindCompanion.{ErrorT, ReasonT}
 import viper.gobra.util.Violation
@@ -424,7 +423,7 @@ object ViperWriter {
 
     /* Can be used in expressions. */
     def copyResult(r: vpr.Exp)(ctx: Context): CodeWriter[vpr.LocalVar] = {
-      val z = vpr.LocalVar(Names.freshName(ctx), r.typ)(r.pos, r.info, r.errT)
+      val z = vpr.LocalVar(ctx.freshNames.next(), r.typ)(r.pos, r.info, r.errT)
       for {
         _ <- local(vu.toVarDecl(z))
         _ <- bind(z, r)

--- a/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
+++ b/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
@@ -423,8 +423,8 @@ object ViperWriter {
       create(reaTs.toVector.map(ReasonT), ())
 
     /* Can be used in expressions. */
-    def copyResult(r: vpr.Exp): CodeWriter[vpr.LocalVar] = {
-      val z = vpr.LocalVar(Names.freshName, r.typ)(r.pos, r.info, r.errT)
+    def copyResult(r: vpr.Exp)(ctx: Context): CodeWriter[vpr.LocalVar] = {
+      val z = vpr.LocalVar(Names.freshName(ctx), r.typ)(r.pos, r.info, r.errT)
       for {
         _ <- local(vu.toVarDecl(z))
         _ <- bind(z, r)


### PR DESCRIPTION
This PR further improves on #17 by providing some guarantees even when slightly changing the input program. The overall idea is that whitespace changes do not affect the encoding at all or changes within a particular Gobra member only affect the encoding of that particular member.
In practice, this amounts to avoiding global counters to create fresh names. This PR localizes counter for fresh names in the Desugarer and Encoding to the current code root / member.
Furthermore, struct names are dropped from the internal representation. However, the naming of interfaces and domains is not addressed by this PR (see #406).

I have not added any tests for this feature because we would need to compare ASTs before and after performing some modifications. However, I have diffed the generated Viper files to check that shifting around a Gobra function does not change the encoding. The ordering of domain functions seems to not be stable but I don't think this affects cacheing by ViperServer in any way.

There is one design decision I would like to mention here: I've changed the translator to create a context per member. Each context shares the same generators but resets the fresh name counter to 0. There are 2 different ways how all generated members could be collected at the end: (1) assume that all contexts share the same generators and that all possibly generated members are stored in them. Thus, `finalize` could/should only be called on the `mainCtx`. (2) Alternatively and currently implemented, each member returns the context with which it was encoded and `finalize` is called on each context. This approach makes less assumptions on where it is necessary/sufficient to collect Viper members but requires that each generator is visited only once. To do so, the collector has been adapted to keep track of the generators it visits. This however requires that `finalize` is not directly called on each context but only indirectly via the collector.
