### PR TITLE
Fix some errors in the reporting & the StatsCollector

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -67,10 +67,7 @@ trait GoVerifier extends StrictLogging {
         statsCollector.writeJsonReportToFile(statsFile)
 
         // Report timeouts that were not previously reported
-        val timeoutErrors = statsCollector.getTimeoutErrorsForNonFinishedTasks
-        if(timeoutErrors.nonEmpty) {
-          timeoutErrors.foreach(err => logger.error(err.formattedMessage))
-        }
+        statsCollector.getTimeoutErrorsForNonFinishedTasks.foreach(err => logger.error(err.formattedMessage))
       }
     })
 

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -49,6 +49,10 @@ case class DiamondError(message: String) extends VerifierError {
   val id = "diamond_error"
 }
 
+case class TimeoutError(message: String) extends  VerifierError {
+  val position: Option[SourcePosition] = None
+  val id = "timeout_error"
+}
 
 sealed trait VerificationError extends VerifierError {
 


### PR DESCRIPTION
## Changes:

* Report time out of viper members when a package verification timed out directly instead of at the end of the Gobra run
* Exit with a non-zero code when a package timed out
* Treat viper members only as verified when a result for a version of it with a body occurred (chopper may cause results for versions without a body)
* Some refactoring