### PR TITLE
Add "only files with header" mode to Gobra

### DIFF
--- a/src/main/resources/stubs/fmt/fmt.gobra
+++ b/src/main/resources/stubs/fmt/fmt.gobra
@@ -1,3 +1,8 @@
-// TODO: explain, add license
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// The purpose of this file is to allow programs to import this package
+// without Gobra complaining that the package is empty.
+// We do not support members defined in this package.
 
 package fmt

--- a/src/main/resources/stubs/fmt/fmt.gobra
+++ b/src/main/resources/stubs/fmt/fmt.gobra
@@ -1,0 +1,3 @@
+// TODO: explain, add license
+
+package fmt

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -25,9 +25,6 @@ import viper.silver.{ast => vpr}
 import scala.concurrent.{Await, Future, TimeoutException}
 
 // TODO:
-// 1. fix issues with empty packages when running in --onlyFilesWithHeader mode
-// 2. fix issues with more than one package name in the same folder (?) => maybe not a problem if we only parse files with header
-// 3. test with verifiedSCION
 // 4. clean-up, add tests, commit and open a PR with a motivating text
 
 object GoVerifier {
@@ -215,8 +212,8 @@ class Gobra extends GoVerifier with GoIdeVerifier {
 
   private def performParsing(pkgInfo: PackageInfo, config: Config): Either[Vector[VerifierError], PPackage] = {
     if (config.shouldParse) {
-      // TODO explain why needed?
       val sourcesToParse = config.packageInfoInputMap(pkgInfo).filter {
+        // only parses sources with header when running in this mode
         p => !config.onlyFilesWithHeader || Config.sourceHasHeader(p)
       }
       Parser.parse(sourcesToParse, pkgInfo)(config)

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -198,9 +198,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
       } else {
         // our current "merge" strategy for potentially different, duplicate, or even contradicting configurations is to concatenate them:
         val args = configs.flatMap(configString => configString.split(" ")).toList
-        // TODO
-        val hasHeader = args.contains("gobra")
-        val actualArgs = args.filter(_ != "gobra")
+        val actualArgs = args filter (_ != Config.headerTag)
         // skip include dir checks as the include should only be parsed and is not resolved yet based on the current directory
         val inFileConfig = new ScallopGobraConfig(actualArgs, isInputOptional = true, skipIncludeDirChecks = true).config
         // modify all relative includeDirs such that they are resolved relatively to the current file:

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -24,9 +24,6 @@ import viper.silver.{ast => vpr}
 
 import scala.concurrent.{Await, Future, TimeoutException}
 
-// TODO:
-// 4. clean-up, add tests, commit and open a PR with a motivating text
-
 object GoVerifier {
 
   val copyright = "(c) Copyright ETH Zurich 2012 - 2022"

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -66,7 +66,10 @@ case class Config(
                    int32bit: Boolean = false,
                    // the following option is currently not controllable via CLI as it is meaningless without a constantly
                    // running JVM. It is targeted in particular to Gobra Server and Gobra IDE
-                   cacheParser: Boolean = false
+                   cacheParser: Boolean = false,
+                   // TODO: explain, add headers to all files in stubs
+                   onlyFilesWithHeader: Boolean = false,
+                   filesWithHeader: Set[Path] = Set(), // TODO: maybe not needed if we just check whether sources have header
 ) {
 
   def merge(other: Config): Config = {
@@ -103,7 +106,9 @@ case class Config(
       shouldViperEncode = shouldViperEncode,
       checkOverflows = checkOverflows || other.checkOverflows,
       shouldVerify = shouldVerify,
-      int32bit = int32bit || other.int32bit
+      int32bit = int32bit || other.int32bit,
+      onlyFilesWithHeader = onlyFilesWithHeader || other.onlyFilesWithHeader,
+      filesWithHeader = filesWithHeader ++ other.filesWithHeader,
     )
   }
 
@@ -308,6 +313,13 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
   val int32Bit: ScallopOption[Boolean] = toggle(
     name = "int32",
     descrYes = "Run with 32-bit sized integers",
+    default = Some(false),
+    noshort = false
+  )
+
+  val onlyFilesWithHeader: ScallopOption[Boolean] = toggle(
+    name = "onlyFilesWithHeader",
+    descrYes = "When enabled, Gobra only looks at files that contain header comment '// ##(gobra)'",
     default = Some(false),
     noshort = false
   )
@@ -587,6 +599,8 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     checkOverflows = checkOverflows(),
     int32bit = int32Bit(),
     shouldVerify = shouldVerify,
-    shouldChop = shouldChop
+    shouldChop = shouldChop,
+    onlyFilesWithHeader = onlyFilesWithHeader(),
+    filesWithHeader = Set.empty
   )
 }

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -67,7 +67,10 @@ case class Config(
                    // the following option is currently not controllable via CLI as it is meaningless without a constantly
                    // running JVM. It is targeted in particular to Gobra Server and Gobra IDE
                    cacheParser: Boolean = false,
-                   // TODO: explain, add headers to all files in stubs
+                   // this option introduces a mode where Gobra only considers files with a specific annotation ("##(gobra)").
+                   // this is useful when verifying large packages where some files might use some unsupported feature of Gobra,
+                   // or when the goal is to gradually verify part of a package without having to provide an explicit list of the files
+                   // to verify.
                    onlyFilesWithHeader: Boolean = false,
 ) {
 

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -119,7 +119,9 @@ case class Config(
 }
 
 object Config {
-  val header = """##\(gobra\)""".r
+  // the header tag is assumed to be an invalid option to Gobra's cli
+  val headerTag = "gobra"
+  val header = """##\(%s\)""".format(headerTag).r
   def sourceHasHeader(s: Source): Boolean = header.findFirstIn(s.content).nonEmpty
 }
 

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -69,7 +69,6 @@ case class Config(
                    cacheParser: Boolean = false,
                    // TODO: explain, add headers to all files in stubs
                    onlyFilesWithHeader: Boolean = false,
-                   filesWithHeader: Set[Path] = Set(), // TODO: maybe not needed if we just check whether sources have header
 ) {
 
   def merge(other: Config): Config = {
@@ -108,7 +107,6 @@ case class Config(
       shouldVerify = shouldVerify,
       int32bit = int32bit || other.int32bit,
       onlyFilesWithHeader = onlyFilesWithHeader || other.onlyFilesWithHeader,
-      filesWithHeader = filesWithHeader ++ other.filesWithHeader,
     )
   }
 
@@ -118,6 +116,11 @@ case class Config(
     } else {
       TypeBounds(Int = TypeBounds.IntWith64Bit, UInt = TypeBounds.UIntWith64Bit)
     }
+}
+
+object Config {
+  val header = """##\(gobra\)""".r
+  def sourceHasHeader(s: Source): Boolean = header.findFirstIn(s.content).nonEmpty
 }
 
 class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = false, skipIncludeDirChecks: Boolean = false)
@@ -319,7 +322,7 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
 
   val onlyFilesWithHeader: ScallopOption[Boolean] = toggle(
     name = "onlyFilesWithHeader",
-    descrYes = "When enabled, Gobra only looks at files that contain header comment '// ##(gobra)'",
+    descrYes = s"When enabled, Gobra only looks at files that contain header comment '// ${Config.header}'",
     default = Some(false),
     noshort = false
   )
@@ -601,6 +604,5 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     shouldVerify = shouldVerify,
     shouldChop = shouldChop,
     onlyFilesWithHeader = onlyFilesWithHeader(),
-    filesWithHeader = Set.empty
   )
 }

--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -197,11 +197,14 @@ object PackageResolver {
     res filter { p => !onlyFilesWithHeaders || isResourceWithHeader(p) }
   }
 
-  // TODO: doc
+  /**
+    * Decides whether an input resource should be considered by Gobra when considering only files with headers.
+    */
   private def isResourceWithHeader(resource: InputResource): Boolean = {
     resource match {
-      // TODO: should be moved outside such that it does not complain about empty packages (i.e. after that check), however we should not apply this transformation to imported sources
-      case i: InputResource if i.builtin => true
+      case i: InputResource if i.builtin =>
+        // standard library methods defined in stubs are always considered by Gobra
+        true
       case i: InputResource => Config.sourceHasHeader(i.asSource())
     }
   }

--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -32,9 +32,6 @@ object PackageResolver {
   val fileUriScheme = "file"
   val jarUriScheme = "jar"
 
-  // TODO: get a way to avoid replicating this here
-  private val inFileConfigRegex = """##\((.*)\)""".r
-
   trait AbstractImport
   /** represents an implicit unqualified import that should resolve to the built-in package */
   case object BuiltInImport extends AbstractImport
@@ -205,11 +202,7 @@ object PackageResolver {
     sources filter {
       // TODO: should be moved outside such that it does not complain about empty packages (i.e. after that check), however we should not apply this transformation to imported sources
       case i: InputResource if i.builtin => true
-      case i: InputResource =>
-        val configs = for (m <- inFileConfigRegex.findAllMatchIn(i.asSource().content)) yield m.group(1)
-        val args = configs.flatMap(configString => configString.split(" ")).toList
-        // TODO: move this to a non hardcoded value
-        args.contains("gobra")
+      case i: InputResource => Config.sourceHasHeader(i.asSource())
     }
   }
 

--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -194,12 +194,12 @@ object PackageResolver {
       case resource if !res.contains(resource) => resource.close()
       case _ =>
     })
-    if (onlyFilesWithHeaders) getOnlySourcesWithHeader(res) else res
+    res filter { p => !onlyFilesWithHeaders || isResourceWithHeader(p) }
   }
 
   // TODO: doc
-  private def getOnlySourcesWithHeader(sources: Vector[InputResource]): Vector[InputResource] = {
-    sources filter {
+  private def isResourceWithHeader(resource: InputResource): Boolean = {
+    resource match {
       // TODO: should be moved outside such that it does not complain about empty packages (i.e. after that check), however we should not apply this transformation to imported sources
       case i: InputResource if i.builtin => true
       case i: InputResource => Config.sourceHasHeader(i.asSource())

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -226,7 +226,7 @@ object Parser {
 
       def replace(n: PImplicitQualifiedImport): Option[PExplicitQualifiedImport] = {
         val qualifier = for {
-          qualifierName <- PackageResolver.getQualifier(n, config.moduleName, config.includeDirs)
+          qualifierName <- PackageResolver.getQualifier(n, config.moduleName, config.includeDirs, config.onlyFilesWithHeader)
           // create a new PIdnDef node and set its positions according to the old node (PositionedRewriter ensures that
           // the same happens for the newly created PExplicitQualifiedImport)
           idnDef = PIdnDef(qualifierName)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -227,7 +227,6 @@ trait MemberResolution { this: TypeInfoImpl =>
     def parseAndTypeCheck(importTarget: AbstractImport): Either[Vector[VerifierError], ExternalTypeInfo] = {
       val pkgSources = PackageResolver.resolveSources(importTarget, config.moduleName, config.includeDirs, config.onlyFilesWithHeader).getOrElse(Vector())
       val res = for {
-        // TODO: Do checks to see if it should be skiped here
         nonEmptyPkgSources <- if (pkgSources.isEmpty)
           Left(Vector(NotFoundError(s"No source files for package '$importTarget' found")))
           else Right(pkgSources)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -225,8 +225,9 @@ trait MemberResolution { this: TypeInfoImpl =>
 
   def tryPackageLookup(importTarget: AbstractImport, id: PIdnUse, errNode: PNode): Option[(Entity, Vector[MemberPath])] = {
     def parseAndTypeCheck(importTarget: AbstractImport): Either[Vector[VerifierError], ExternalTypeInfo] = {
-      val pkgSources = PackageResolver.resolveSources(importTarget, config.moduleName, config.includeDirs).getOrElse(Vector())
+      val pkgSources = PackageResolver.resolveSources(importTarget, config.moduleName, config.includeDirs, config.onlyFilesWithHeader).getOrElse(Vector())
       val res = for {
+        // TODO: Do checks to see if it should be skiped here
         nonEmptyPkgSources <- if (pkgSources.isEmpty)
           Left(Vector(NotFoundError(s"No source files for package '$importTarget' found")))
           else Right(pkgSources)

--- a/src/test/resources/regressions/features/onlyHeaderFiles/onlyHeaders.gobra
+++ b/src/test/resources/regressions/features/onlyHeaderFiles/onlyHeaders.gobra
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package onlyHeaderFiles
+
+// ##(--onlyFilesWithHeader -I ./)
+// ##(gobra)
+
+import "pkg1"
+
+func f(n int) (res int) {
+    res = pkg1.f(n)
+    //:: ExpectedOutput(assertion_error)
+    assert false
+}

--- a/src/test/resources/regressions/features/onlyHeaderFiles/pkg1/correct_file.gobra
+++ b/src/test/resources/regressions/features/onlyHeaderFiles/pkg1/correct_file.gobra
@@ -1,0 +1,8 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// ##(gobra)
+
+package pkg1
+
+func f(int) int

--- a/src/test/resources/regressions/features/onlyHeaderFiles/pkg1/erroneous_file.gobra
+++ b/src/test/resources/regressions/features/onlyHeaderFiles/pkg1/erroneous_file.gobra
@@ -1,0 +1,8 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg1
+
+// Ill-formed file. Because it does not have the header,
+// it will not be considered by Gobra
+func f g h()


### PR DESCRIPTION
This PR adds the flag `--onlyFilesWithHeaders` to Gobra. The purpose of this flag is to instruct Gobra to only consider files that contain the annotation `// ##(gobra)`. This is useful for gradually adding Gobra annotations to the SCION repository, where the goal is to gradually introduce annotations to the code with a minimal impact on the non-annotated code. In particular, this PR allows the following goals:
- allow an annotated Go file to import a package whose files use features not supported by Gobra or that relies on unspecified packages.
- allow Gobra to target only a part of the files in a package without having to provide an explicit list of files to target.

There are currently some features of Gobra that pose additional challenges:
- Gobra rejects packages if there are files on the package path that have different package clauses. This is the case in SCION. A temporary fix (which works for my use case but might not be suitable in general) consists of not reading the package clause of files without the header.
- Every package imported in this mode must have at least one file "with header", otherwise Gobra complains that the package is empty.