### PR TITLE
Input File Filtering

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -6,9 +6,12 @@
 
 package viper.gobra
 
+import ch.qos.logback.classic.Logger
+
 import java.nio.file.Paths
 import java.util.concurrent.ExecutionException
 import com.typesafe.scalalogging.StrictLogging
+import org.slf4j.LoggerFactory
 import viper.gobra.ast.frontend.PPackage
 import viper.gobra.ast.internal.Program
 import viper.gobra.ast.internal.transform.{CGEdgesTerminationTransform, OverflowChecksTransform}
@@ -145,6 +148,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     val task = Future {
       for {
         finalConfig <- getAndMergeInFileConfig(config, pkgInfo)
+        _ = setLogLevel(finalConfig)
         parsedPackage <- performParsing(pkgInfo, finalConfig)
         typeInfo <- performTypeChecking(parsedPackage, finalConfig)
         program <- performDesugaring(parsedPackage, typeInfo, finalConfig)
@@ -221,6 +225,12 @@ class Gobra extends GoVerifier with GoIdeVerifier {
       }
       Right(mergedConfig)
     }
+  }
+
+  private def setLogLevel(config: Config): Unit = {
+    LoggerFactory.getLogger(GoVerifier.rootLogger)
+      .asInstanceOf[Logger]
+      .setLevel(config.logLevel)
   }
 
   private def performParsing(pkgInfo: PackageInfo, config: Config): Either[Vector[VerifierError], PPackage] = {

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -225,10 +225,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
 
   private def performParsing(pkgInfo: PackageInfo, config: Config): Either[Vector[VerifierError], PPackage] = {
     if (config.shouldParse) {
-      val sourcesToParse = config.packageInfoInputMap(pkgInfo).filter {
-        // only parses sources with header when running in this mode
-        p => !config.onlyFilesWithHeader || Config.sourceHasHeader(p)
-      }
+      val sourcesToParse = config.packageInfoInputMap(pkgInfo)
       Parser.parse(sourcesToParse, pkgInfo)(config)
     } else {
       Left(Vector())

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -143,8 +143,8 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     implicit val _executor: GobraExecutionContext = executor
 
     val task = Future {
-      val finalConfig = getAndMergeInFileConfig(config, pkgInfo)
       for {
+        finalConfig <- getAndMergeInFileConfig(config, pkgInfo)
         parsedPackage <- performParsing(pkgInfo, finalConfig)
         typeInfo <- performTypeChecking(parsedPackage, finalConfig)
         program <- performDesugaring(parsedPackage, typeInfo, finalConfig)
@@ -194,27 +194,33 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     * These in-file command options get combined for all files and passed to ScallopGobraConfig.
     * The current config merged with the newly created config is then returned
     */
-  def getAndMergeInFileConfig(config: Config, pkgInfo: PackageInfo): Config = {
-    val inFileConfigs = config.packageInfoInputMap(pkgInfo).flatMap(input => {
+  def getAndMergeInFileConfig(config: Config, pkgInfo: PackageInfo): Either[Vector[VerifierError], Config] = {
+    val inFileEitherConfigs = config.packageInfoInputMap(pkgInfo).map(input => {
       val content = input.content
       val configs = for (m <- inFileConfigRegex.findAllMatchIn(content)) yield m.group(1)
       if (configs.isEmpty) {
-        None
+        Right(None)
       } else {
         // our current "merge" strategy for potentially different, duplicate, or even contradicting configurations is to concatenate them:
         val args = configs.flatMap(configString => configString.split(" ")).toList
         // skip include dir checks as the include should only be parsed and is not resolved yet based on the current directory
-        val inFileConfig = new ScallopGobraConfig(args, isInputOptional = true, skipIncludeDirChecks = true).config
-        // modify all relative includeDirs such that they are resolved relatively to the current file:
-        val resolvedConfig = inFileConfig.copy(includeDirs = inFileConfig.includeDirs.map(
-          // it's important to convert includeDir to a string first as `path` might be a ZipPath and `includeDir` might not
-          includeDir => Paths.get(input.name).getParent.resolve(includeDir.toString)))
-        Some(resolvedConfig)
+        for {
+          inFileConfig <- new ScallopGobraConfig(args, isInputOptional = true, skipIncludeDirChecks = true).config
+          resolvedConfig = inFileConfig.copy(includeDirs = inFileConfig.includeDirs.map(
+            // it's important to convert includeDir to a string first as `path` might be a ZipPath and `includeDir` might not
+            includeDir => Paths.get(input.name).getParent.resolve(includeDir.toString)))
+        } yield Some(resolvedConfig)
       }
     })
-
-    // start with original config `config` and merge in every in file config:
-    inFileConfigs.foldLeft(config){ case (oldConfig, fileConfig) => oldConfig.merge(fileConfig) }
+    val (errors, inFileConfigs) = inFileEitherConfigs.partitionMap(identity)
+    if (errors.nonEmpty) Left(errors.map(ConfigError))
+    else {
+      // start with original config `config` and merge in every in file config:
+      val mergedConfig = inFileConfigs.flatten.foldLeft(config) {
+        case (oldConfig, fileConfig) => oldConfig.merge(fileConfig)
+      }
+      Right(mergedConfig)
+    }
   }
 
   private def performParsing(pkgInfo: PackageInfo, config: Config): Either[Vector[VerifierError], PPackage] = {
@@ -295,12 +301,17 @@ object GobraRunner extends GobraFrontend with StrictLogging {
     try {
       val scallopGobraConfig = new ScallopGobraConfig(args.toSeq)
       val config = scallopGobraConfig.config
-      // Print copyright report
-      config.reporter report CopyrightReport(s"${GoVerifier.name} ${GoVerifier.version}\n${GoVerifier.copyright}")
-
-      exitCode = verifier.verifyAllPackages(config)(executor) match {
-        case VerifierResult.Failure(_) => 1
-        case _ => 0
+      exitCode = config match {
+        case Left(validationError) =>
+          logger.error(validationError)
+          1
+        case Right(config) =>
+          // Print copyright report
+          config.reporter report CopyrightReport(s"${GoVerifier.name} ${GoVerifier.version}\n${GoVerifier.copyright}")
+          verifier.verifyAllPackages(config)(executor) match {
+            case VerifierResult.Failure(_) => 1
+            case _ => 0
+          }
       }
     } catch {
       case e: UglyErrorMessage =>

--- a/src/main/scala/viper/gobra/backend/ViperBackends.scala
+++ b/src/main/scala/viper/gobra/backend/ViperBackends.scala
@@ -67,7 +67,7 @@ object ViperBackends {
       server.getOrElse({
         var serverConfig = List("--logLevel", config.logLevel.levelStr)
         if(config.cacheFile.isDefined) {
-          serverConfig = serverConfig.appendedAll(List("--cacheFile", config.cacheFile.get))
+          serverConfig = serverConfig.appendedAll(List("--cacheFile", config.cacheFile.get.toString))
         }
 
         val createdServer = new ViperCoreServer(new ViperConfig(serverConfig))(executionContext)

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -18,7 +18,7 @@ import viper.gobra.GoVerifier
 import viper.gobra.frontend.PackageResolver.FileResource
 import viper.gobra.frontend.Source.getPackageInfo
 import viper.gobra.reporting.{FileWriterReporter, GobraReporter, StdIOReporter}
-import viper.gobra.util.TypeBounds
+import viper.gobra.util.{TypeBounds, Violation}
 import viper.silver.ast.SourcePosition
 
 import scala.concurrent.duration.Duration

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -184,11 +184,11 @@ case class BaseConfig(moduleName: String = ConfigDefaults.DefaultModuleName,
   def shouldVerify: Boolean = shouldViperEncode
   def shouldChop: Boolean = choppingUpperBound > 1 || isolated.exists(_.nonEmpty)
   lazy val isolated: Option[Vector[SourcePosition]] = {
-    isolate match {
+    val positions = isolate.flatMap{ case (path, idxs) => idxs.map(idx => SourcePosition(path, idx, 0)) }
+    // if there are zero positions, no member should be isolated as verifying the empty program is uninteresting.
+    positions match {
       case Nil => None
-      case pathsWithPos => Some(pathsWithPos.flatMap {
-        case (path, idxs) => idxs.map(idx => SourcePosition(path, idx, 0))
-      }.toVector)
+      case _ => Some(positions.toVector)
     }
   }
 }

--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -207,8 +207,8 @@ object PackageResolver {
     */
   def getSourceFiles(input: InputResource, recursive: Boolean = false): Vector[InputResource] = {
     // get content of directory if it's a directory, otherwise just return the file itself
-    val dirContent = if (Files.isDirectory(input.path)) { input.listContent() } else { Vector(input) }
-    val res = dirContent
+    val dirContentOrInput = if (Files.isDirectory(input.path)) { input.listContent() } else { Vector(input) }
+    val res = dirContentOrInput
       .flatMap { resource =>
         if (recursive && Files.isDirectory(resource.path)) {
           getSourceFiles(resource, recursive)
@@ -223,7 +223,7 @@ object PackageResolver {
         }
       }
     // close all resource that are no longer needed:
-    (dirContent.toSet ++ Set(input)).foreach({
+    (dirContentOrInput.toSet + input).foreach({
       case resource if !res.contains(resource) => resource.close()
       case _ =>
     })

--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -46,14 +46,13 @@ object PackageResolver {
   /**
     * Resolves a package name (i.e. import path) to specific input sources
     * @param importTarget
-    * @param moduleName name of the module under verification
-    * @param includeDirs list of directories that will be used for package resolution before falling back to $GOPATH
+    * @param config
     * @return list of sources belonging to the package (right) or an error message (left) if no directory could be found
     *         or the directory contains input files having different package clauses
     */
-  def resolveSources(importTarget: AbstractImport, moduleName: String, includeDirs: Vector[Path]): Either[String, Vector[ResolveSourcesResult]] = {
+  def resolveSources(importTarget: AbstractImport)(config: Config): Either[String, Vector[ResolveSourcesResult]] = {
     for {
-      resources <- resolve(importTarget, moduleName, includeDirs)
+      resources <- resolve(importTarget)(config)
       sources = resources.map(r => ResolveSourcesResult(r.asSource(), r.builtin))
       // we do no longer need the resources, so we close them:
       _ = resources.foreach(_.close())
@@ -63,24 +62,15 @@ object PackageResolver {
   /**
     * Resolves a package name (i.e. import path) to specific input files
     * @param importTarget
-    * @param moduleName name of the module under verification
-    * @param includeDirs list of directories that will be used for package resolution before falling back to $GOPATH
+    * @param config
     * @return list of files belonging to the package (right) or an error message (left) if no directory could be found
     *         or the directory contains input files having different package clauses
     */
-  private def resolve(importTarget: AbstractImport, moduleName: String, includeDirs: Vector[Path]): Either[String, Vector[InputResource]] = {
-    val sourceFiles = for {
-      // pkgDir stores the path to the directory that should contain source files belonging to the desired package
-      pkgDir <- getLookupPath(importTarget, moduleName, includeDirs)
-      sourceFiles = getSourceFiles(pkgDir)
-    } yield sourceFiles
-
-    sourceFiles.foreach(checkPackageClauses(_, importTarget))
-
+  private def resolve(importTarget: AbstractImport)(config: Config): Either[String, Vector[InputResource]] = {
     for {
       // pkgDir stores the path to the directory that should contain source files belonging to the desired package
-      pkgDir <- getLookupPath(importTarget, moduleName, includeDirs)
-      sourceFiles = getSourceFiles(pkgDir)
+      pkgDir <- getLookupPath(importTarget)(config)
+      sourceFiles = getSourceFiles(pkgDir, onlyFilesWithHeader = config.onlyFilesWithHeader)
       // check whether all found source files belong to the same package (the name used in the package clause can
       // be absolutely independent of the import path)
       // in case of error, iterate over all resources and close them
@@ -97,17 +87,16 @@ object PackageResolver {
     * The returned package name can be used as qualifier for the implicitly qualified import.
     *
     * @param n implicitely qualified import for which a qualifier should be resolved
-    * @param moduleName name of the module under verification
-    * @param includeDirs list of directories that will be used for package resolution before falling back to $GOPATH
+    * @param config
     * @return qualifier with which members of the imported package can be accessed (right) or an error message (left)
     *         if no directory could be found or the directory contains input files having different package clauses
     */
-  def getQualifier(n: PImplicitQualifiedImport, moduleName: String, includeDirs: Vector[Path]): Either[String, String] = {
+  def getQualifier(n: PImplicitQualifiedImport)(config: Config): Either[String, String] = {
     val importTarget = RegularImport(n.importPath)
     for {
       // pkgDir stores the path to the directory that should contain source files belonging to the desired package
-      pkgDir <- getLookupPath(importTarget, moduleName, includeDirs)
-      sourceFiles = getSourceFiles(pkgDir)
+      pkgDir <- getLookupPath(importTarget)(config)
+      sourceFiles = getSourceFiles(pkgDir, onlyFilesWithHeader = config.onlyFilesWithHeader)
       // check whether all found source files belong to the same package (the name used in the package clause can
       // be absolutely independent of the import path)
       pkgName <- checkPackageClauses(sourceFiles, importTarget)
@@ -161,7 +150,9 @@ object PackageResolver {
   /**
     * Resolves import target using includeDirs to a directory which exists and from which source files should be retrieved
     */
-  private def getLookupPath(importTarget: AbstractImport, moduleName: String, includeDirs: Vector[Path]): Either[String, InputResource] = {
+  private def getLookupPath(importTarget: AbstractImport)(config: Config): Either[String, InputResource] = {
+    val moduleName = config.moduleName
+    val includeDirs = config.includeDirs
     val moduleNameWithTrailingSlash = if (moduleName.nonEmpty && !moduleName.endsWith("/")) s"$moduleName/" else moduleName
     importTarget match {
       case BuiltInImport => getBuiltInResource.toRight(s"Loading builtin package has failed")
@@ -201,23 +192,36 @@ object PackageResolver {
   }
 
   /**
+    * Decides whether an input resource should be considered by Gobra when considering only files with headers.
+    */
+  private def isResourceWithHeader(resource: InputResource): Boolean = {
+    resource match {
+      case i: InputResource if i.builtin =>
+        // standard library methods defined in stubs are always considered by Gobra
+        true
+      case _ => Config.sourceHasHeader(resource.asSource())
+    }
+  }
+
+  /**
     * Returns the source files with file extension 'gobraExtension' or 'goExtension' in the input resource which
     * are not test files and are not in a directory with name 'testdata'.
     * Input can also be a file in which case the same file is returned if it passes all tests
     */
-  def getSourceFiles(input: InputResource, recursive: Boolean = false): Vector[InputResource] = {
+  def getSourceFiles(input: InputResource, recursive: Boolean = false, onlyFilesWithHeader: Boolean = false): Vector[InputResource] = {
     // get content of directory if it's a directory, otherwise just return the file itself
     val dirContentOrInput = if (Files.isDirectory(input.path)) { input.listContent() } else { Vector(input) }
     val res = dirContentOrInput
       .flatMap { resource =>
         if (recursive && Files.isDirectory(resource.path)) {
-          getSourceFiles(resource, recursive)
+          getSourceFiles(resource, recursive = recursive, onlyFilesWithHeader = onlyFilesWithHeader)
         } else if (Files.isRegularFile(resource.path)) {
           // only consider files with the particular extension
           val validExtension = FilenameUtils.getExtension(resource.path.toString) == gobraExtension ||
             FilenameUtils.getExtension(resource.path.toString) == goExtension
           val shouldBeConsidered = !shouldIgnoreResource(resource)
-          if (validExtension && shouldBeConsidered) Vector(resource) else Vector()
+          val headerIsMissing = onlyFilesWithHeader && !isResourceWithHeader(resource)
+          if (validExtension && shouldBeConsidered && !headerIsMissing) Vector(resource) else Vector()
         } else {
           Vector()
         }

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -226,7 +226,7 @@ object Parser {
 
       def replace(n: PImplicitQualifiedImport): Option[PExplicitQualifiedImport] = {
         val qualifier = for {
-          qualifierName <- PackageResolver.getQualifier(n, config.moduleName, config.includeDirs)
+          qualifierName <- PackageResolver.getQualifier(n)(config)
           // create a new PIdnDef node and set its positions according to the old node (PositionedRewriter ensures that
           // the same happens for the newly created PExplicitQualifiedImport)
           idnDef = PIdnDef(qualifierName)

--- a/src/main/scala/viper/gobra/frontend/Source.scala
+++ b/src/main/scala/viper/gobra/frontend/Source.scala
@@ -13,7 +13,7 @@ import viper.gobra.util.Violation
 import viper.silver.ast.SourcePosition
 
 import java.security.MessageDigest
-import java.util.{Base64, Objects}
+import java.util.Objects
 import scala.io.BufferedSource
 
 /**

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -13,7 +13,7 @@ import viper.gobra.ast.frontend._
 import viper.gobra.frontend.PackageResolver.{AbstractImport, BuiltInImport, RegularImport}
 import viper.gobra.frontend.info.base.BuiltInMemberTag
 import viper.gobra.frontend.info.base.BuiltInMemberTag.{BuiltInMPredicateTag, BuiltInMethodTag}
-import viper.gobra.frontend.{Config, PackageResolver, Parser, Source}
+import viper.gobra.frontend.{PackageResolver, Parser, Source}
 import viper.gobra.frontend.info.{ExternalTypeInfo, Info}
 import viper.gobra.frontend.info.base.SymbolTable._
 import viper.gobra.frontend.info.base.Type._
@@ -225,12 +225,9 @@ trait MemberResolution { this: TypeInfoImpl =>
 
   def tryPackageLookup(importTarget: AbstractImport, id: PIdnUse, errNode: PNode): Option[(Entity, Vector[MemberPath])] = {
     def parseAndTypeCheck(importTarget: AbstractImport): Either[Vector[VerifierError], ExternalTypeInfo] = {
-      val resolveSourcesResult = PackageResolver.resolveSources(importTarget, config.moduleName, config.includeDirs).getOrElse(Vector())
-      val pkgSources = if (config.onlyFilesWithHeader) {
-        resolveSourcesResult.filter(p => p.isBuiltin || Config.sourceHasHeader(p.source)).map(_.source)
-      } else {
-        resolveSourcesResult.map(_.source)
-      }
+      val pkgSources = PackageResolver.resolveSources(importTarget)(config)
+        .getOrElse(Vector())
+        .map(_.source)
       val res = for {
         nonEmptyPkgSources <- if (pkgSources.isEmpty)
           Left(Vector(NotFoundError(s"No source files for package '$importTarget' found")))

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -31,6 +31,11 @@ case class NotFoundError(message: String) extends VerifierError {
   val id = "not_found_error"
 }
 
+case class ConfigError(message: String) extends VerifierError {
+  val position: Option[SourcePosition] = None
+  val id = "config_error"
+}
+
 case class ParserError(message: String, position: Option[SourcePosition]) extends VerifierError {
   val id = "parser_error"
 }

--- a/src/test/scala/viper/gobra/BenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/BenchmarkTests.scala
@@ -12,7 +12,7 @@ import java.nio.file.Path
 import org.scalatest.{ConfigMap, DoNotDiscover}
 import viper.gobra.frontend.{Config, PackageResolver, ScallopGobraConfig}
 import viper.gobra.reporting.{NoopReporter, VerifierError, VerifierResult}
-import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
+import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext, Violation}
 import viper.silver.ast.{NoPosition, Position}
 import viper.silver.frontend.Frontend
 import viper.silver.testing.StatisticalTestSuite
@@ -71,7 +71,9 @@ trait GobraFrontendForTesting extends Frontend {
     // exception occurs (e.g. a validation failure)
     throwError.value = true
     // Simulate pick of package, Gobra normally does
-    new ScallopGobraConfig(args.toSeq).config.copy(reporter = NoopReporter, z3Exe = z3Exe)
+    val config = new ScallopGobraConfig(args.toSeq).config
+    Violation.violation(config.isRight, "creating the config has failed")
+    config.toOption.get.copy(reporter = NoopReporter, z3Exe = z3Exe)
   }
 
   def gobraResult: VerifierResult

--- a/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
+++ b/src/test/scala/viper/gobra/DetailedBenchmarkTests.scala
@@ -97,7 +97,7 @@ class DetailedBenchmarkTests extends BenchmarkTests {
       val c = config.get
       assert(c.packageInfoInputMap.size == 1)
       val pkgInfo = c.packageInfoInputMap.keys.head
-      config = Some(gobra.getAndMergeInFileConfig(c, pkgInfo))
+      config = gobra.getAndMergeInFileConfig(c, pkgInfo).toOption
     }
 
     private val parsing = InitialStep("parsing", () => {

--- a/src/test/scala/viper/gobra/GobraPackageTests.scala
+++ b/src/test/scala/viper/gobra/GobraPackageTests.scala
@@ -61,8 +61,7 @@ class GobraPackageTests extends GobraTests {
           pkgName <- getPackageClause(input.file.toFile)
           config <- createConfig(Array(
             "--logLevel", "INFO",
-            "-i", currentDir.toFile.getPath,
-            "-p", pkgName,
+            "-p", currentDir.toFile.getPath,
             "-I", currentDir.toFile.getPath
           ))
         } yield config

--- a/src/test/scala/viper/gobra/GobraPackageTests.scala
+++ b/src/test/scala/viper/gobra/GobraPackageTests.scala
@@ -12,7 +12,7 @@ import ch.qos.logback.classic.Level
 import org.bitbucket.inkytonik.kiama.util.Source
 import org.rogach.scallop.exceptions.ValidationFailure
 import org.rogach.scallop.throwError
-import viper.gobra.frontend.Source.FromFileSource
+import viper.gobra.frontend.Source.{FromFileSource, getPackageInfo}
 import viper.gobra.frontend.{Config, PackageInfo, ScallopGobraConfig, Source}
 import viper.gobra.reporting.{NoopReporter, ParserError}
 import viper.gobra.reporting.VerifierResult.{Failure, Success}
@@ -61,7 +61,8 @@ class GobraPackageTests extends GobraTests {
           pkgName <- getPackageClause(input.file.toFile)
           config <- createConfig(Array(
             "--logLevel", "INFO",
-            "-p", currentDir.toFile.getPath,
+            "--directory", currentDir.toFile.getPath,
+            "--projectRoot", currentDir.toFile.getPath, // otherwise, it assumes Gobra's root directory as the project root
             "-I", currentDir.toFile.getPath
           ))
         } yield config
@@ -107,7 +108,7 @@ class GobraPackageTests extends GobraTests {
       // exception occurs (e.g. a validation failure)
       throwError.value = true
 
-      Some(new ScallopGobraConfig(args.toSeq).config)
+      new ScallopGobraConfig(args.toSeq).config.toOption
     } catch {
       case _: ValidationFailure => None
       case other: Throwable => throw other

--- a/src/test/scala/viper/gobra/reporting/StatsCollectorTests.scala
+++ b/src/test/scala/viper/gobra/reporting/StatsCollectorTests.scala
@@ -11,7 +11,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import viper.gobra.ast.frontend._
 import viper.gobra.frontend.info.base.Type
 import viper.gobra.frontend.{Config, PackageInfo, ScallopGobraConfig}
-import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
+import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext, Violation}
 import viper.gobra.Gobra
 
 import scala.concurrent.Await
@@ -32,12 +32,12 @@ class StatsCollectorTests extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("Integration without chopper") {
-    val config = createConfig(Array("-p", statsCollectorTestDir, "-r", "-I", statsCollectorTestDir))
+    val config = createConfig(Array("--recursive", "--projectRoot", statsCollectorTestDir, "-I", statsCollectorTestDir))
     runIntegration(config)
   }
 
   test("Integration with chopper") {
-    val config = createConfig(Array("-p", statsCollectorTestDir, "-r", "-I", statsCollectorTestDir, "--chop", "10"))
+    val config = createConfig(Array("--recursive", "--projectRoot", statsCollectorTestDir, "-I", statsCollectorTestDir, "--chop", "10"))
     runPackagesSeparately(config)
     runIntegration(config)
   }
@@ -47,7 +47,9 @@ class StatsCollectorTests extends AnyFunSuite with BeforeAndAfterAll {
     // exception occurs (e.g. a validation failure)
     throwError.value = true
     // Simulate pick of package, Gobra normally does
-    new ScallopGobraConfig(args.toSeq).config
+    val config = new ScallopGobraConfig(args.toSeq).config
+    Violation.violation(config.isRight, "creating the config has failed")
+    config.toOption.get
   }
 
   private def runPackagesSeparately(config: Config): Unit = {

--- a/src/test/scala/viper/gobra/reporting/StatsCollectorTests.scala
+++ b/src/test/scala/viper/gobra/reporting/StatsCollectorTests.scala
@@ -32,13 +32,12 @@ class StatsCollectorTests extends AnyFunSuite with BeforeAndAfterAll {
   }
 
   test("Integration without chopper") {
-    val config = createConfig(Array("-i", statsCollectorTestDir, "-r", "-I", statsCollectorTestDir))
+    val config = createConfig(Array("-p", statsCollectorTestDir, "-r", "-I", statsCollectorTestDir))
     runIntegration(config)
   }
 
   test("Integration with chopper") {
-    val config = createConfig(Array("-i", statsCollectorTestDir, "-r", "-I", statsCollectorTestDir, "--chop", "10"
-    ))
+    val config = createConfig(Array("-p", statsCollectorTestDir, "-r", "-I", statsCollectorTestDir, "--chop", "10"))
     runPackagesSeparately(config)
     runIntegration(config)
   }


### PR DESCRIPTION
Unifies source file search for inputs and imports and fixes filtering of path containing `testdata`