### PR TITLE
Cleanup config options

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -327,7 +327,7 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     noshort = false
   )
 
-  val onlyFilesWithHeader: ScallopOption[Boolean] = opt(
+  val onlyFilesWithHeader: ScallopOption[Boolean] = opt[Boolean](
     name = "onlyFilesWithHeader",
     descr = s"When enabled, Gobra only looks at files that contain the header comment '${Config.prettyPrintedHeader}'",
     default = Some(false),

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -160,9 +160,9 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     short = 'i'
   )
 
-  val recursive: ScallopOption[Boolean] = toggle(
+  val recursive: ScallopOption[Boolean] = opt[Boolean](
     name = "recursive",
-    descrYes = "Verify nested packages recursively",
+    descr = "Verify nested packages recursively",
     default = Some(false),
     short = 'r'
   )
@@ -201,71 +201,72 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     default = Some(List())
   )(listArgConverter(dir => new File(dir)))
 
-  val backend: ScallopOption[ViperBackend] = opt[ViperBackend](
+  val backend: ScallopOption[ViperBackend] = choice(
+    choices = Seq("SILICON", "CARBON", "VSWITHSILICON", "VSWITHCARBON"),
     name = "backend",
-    descr = "Specifies the used Viper backend, one of VSWITHSILICON, VSWITHCARBON, SILICON, CARBON (default: SILICON)",
-    default = Some(ViperBackends.SiliconBackend),
+    descr = "Specifies the used Viper backend. The default is SILICON.",
+    default = Some("SILICON"),
     noshort = true
-  )(singleArgConverter({
+  ).map{
     case "SILICON" => ViperBackends.SiliconBackend
     case "CARBON" => ViperBackends.CarbonBackend
     case "VSWITHSILICON" => ViperBackends.ViperServerWithSilicon()
     case "VSWITHCARBON" => ViperBackends.ViperServerWithCarbon()
-    case _ => ViperBackends.SiliconBackend
-  }))
+    case s => Violation.violation(s"Unexpected backend option $s")
+  }
 
-  val debug: ScallopOption[Boolean] = toggle(
+  val debug: ScallopOption[Boolean] = opt[Boolean](
     name = "debug",
-    descrYes = "Output additional debug information",
+    descr = "Output additional debug information",
     default = Some(false)
   )
 
-  val logLevel: ScallopOption[Level] = opt[Level](
+  val logLevel: ScallopOption[Level] = choice(
     name = "logLevel",
-    descr =
-      "One of the log levels ALL, TRACE, DEBUG, INFO, WARN, ERROR, OFF (default: OFF)",
-    default = Some(if (debug()) Level.DEBUG else LoggerDefaults.DefaultLevel),
+    choices = Seq("ALL", "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF"),
+    descr = "Specifies the log level. The default is OFF.",
+    default = Some(if (debug()) Level.DEBUG.toString else LoggerDefaults.DefaultLevel.toString),
     noshort = true
-  )(singleArgConverter(arg => Level.toLevel(arg.toUpperCase)))
+  ).map{arg => Level.toLevel(arg)}
 
-  val eraseGhost: ScallopOption[Boolean] = toggle(
+  val eraseGhost: ScallopOption[Boolean] = opt[Boolean](
     name = "eraseGhost",
-    descrYes = "Print the input program without ghost code",
+    descr = "Print the input program without ghost code",
     default = Some(false),
     noshort = true
   )
 
-  val goify: ScallopOption[Boolean] = toggle(
+  val goify: ScallopOption[Boolean] = opt[Boolean](
     name = "goify",
-    descrYes = "Print the input program with the ghost code commented out",
+    descr = "Print the input program with the ghost code commented out",
     default = Some(false),
     noshort = true
   )
 
-  val unparse: ScallopOption[Boolean] = toggle(
+  val unparse: ScallopOption[Boolean] = opt[Boolean](
     name = "unparse",
-    descrYes = "Print the parsed program",
+    descr = "Print the parsed program",
     default = Some(debug()),
     noshort = true
   )
 
-  val printInternal: ScallopOption[Boolean] = toggle(
+  val printInternal: ScallopOption[Boolean] = opt[Boolean](
     name = "printInternal",
-    descrYes = "Print the internal program representation",
+    descr = "Print the internal program representation",
     default = Some(debug()),
     noshort = true
   )
 
-  val printVpr: ScallopOption[Boolean] = toggle(
+  val printVpr: ScallopOption[Boolean] = opt[Boolean](
     name = "printVpr",
-    descrYes = "Print the encoded Viper program",
+    descr = "Print the encoded Viper program",
     default = Some(debug()),
     noshort = true
   )
 
-  val parseOnly: ScallopOption[Boolean] = toggle(
+  val parseOnly: ScallopOption[Boolean] = opt[Boolean](
     name = "parseOnly",
-    descrYes = "Perform only the parsing step",
+    descr = "Perform only the parsing step",
     default = Some(false),
     noshort = true
   )
@@ -298,9 +299,9 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     noshort = true
   )
 
-  val checkOverflows: ScallopOption[Boolean] = toggle(
+  val checkOverflows: ScallopOption[Boolean] = opt[Boolean](
     name = "overflow",
-    descrYes = "Find expressions that may lead to integer overflow",
+    descr = "Find expressions that may lead to integer overflow",
     default = Some(false),
     noshort = false
   )
@@ -319,16 +320,16 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     noshort = true
   )
 
-  val int32Bit: ScallopOption[Boolean] = toggle(
+  val int32Bit: ScallopOption[Boolean] = opt[Boolean](
     name = "int32",
-    descrYes = "Run with 32-bit sized integers",
+    descr = "Run with 32-bit sized integers (the default is 64-bit ints)",
     default = Some(false),
     noshort = false
   )
 
-  val onlyFilesWithHeader: ScallopOption[Boolean] = toggle(
+  val onlyFilesWithHeader: ScallopOption[Boolean] = opt(
     name = "onlyFilesWithHeader",
-    descrYes = s"When enabled, Gobra only looks at files that contain the header comment '${Config.prettyPrintedHeader}'",
+    descr = s"When enabled, Gobra only looks at files that contain the header comment '${Config.prettyPrintedHeader}'",
     default = Some(false),
     noshort = false
   )

--- a/src/test/scala/viper/gobra/GobraPackageTests.scala
+++ b/src/test/scala/viper/gobra/GobraPackageTests.scala
@@ -56,7 +56,7 @@ class GobraPackageTests extends GobraTests {
         val parsedConfig = for {
           pkgName <- getPackageClause(input.file.toFile)
           config <- createConfig(Array(
-            "--logLevel", "Info",
+            "--logLevel", "INFO",
             "-i", currentDir.toFile.getPath,
             "-p", pkgName,
             "-I", currentDir.toFile.getPath


### PR DESCRIPTION
The CLI options contain various redundant options that probably nobody uses. This PR removes them. It should be merged after #434 to avoid conflicts.

Previous output of running gobra with `--help`:
```
[info]  Usage: Gobra -i <input-files or a single package name> [OPTIONS]
[info]  Options:
[info]       --backend  <arg>              Specifies the used Viper backend, one of
[info]                                     VSWITHSILICON, VSWITHCARBON, SILICON, CARBON
[info]                                     (default: SILICON)
[info]       --boogieExe  <arg>            The Boogie executable
[info]       --cacheFile  <arg>            Cache file to be used by Viper Server
[info]       --chop  <arg>                 Number of parts the generated verification
[info]                                     condition is split into (at most)
[info]   -d, --debug                       Output additional debug information
[info]       --nodebug
[info]       --eraseGhost                  Print the input program without ghost code
[info]       --noeraseGhost
[info]       --excludePackages  <arg>...   Packages to ignore. These packages will not
[info]                                     be verified, even if they are found in the
[info]                                     specified directories.
[info]   -g, --gobraDirectory  <arg>       Output directory for Gobra
[info]       --goify                       Print the input program with the ghost code
[info]                                     commented out
[info]       --nogoify
[info]   -I, --include  <arg>...           Uses the provided directories to perform
[info]                                     package-related lookups before falling back
[info]                                     to $GOPATH
[info]   -p, --includePackages  <arg>...   Packages to verify. All packages found in
[info]                                     the specified directories are verified by
[info]                                     default.
[info]   -i, --input  <arg>...             List of Gobra programs, a project directory
[info]                                     or a single package name to verify
[info]       --int32                       Run with 32-bit sized integers
[info]       --noint32
[info]       --logLevel  <arg>             One of the log levels ALL, TRACE, DEBUG,
[info]                                     INFO, WARN, ERROR, OFF (default: OFF)
[info]   -m, --module  <arg>               Name of current module that should be used
[info]                                     for resolving imports
[info]       --onlyFilesWithHeader         When enabled, Gobra only looks at files that
[info]                                     contain the header comment '// +gobra'
[info]       --noonlyFilesWithHeader
[info]   -o, --overflow                    Find expressions that may lead to integer
[info]                                     overflow
[info]       --nooverflow
[info]       --packageTimeout  <arg>       Duration till the verification of a package
[info]                                     times out
[info]       --parseOnly                   Perform only the parsing step
[info]       --noparseOnly
[info]       --printInternal               Print the internal program representation
[info]       --noprintInternal
[info]       --printVpr                    Print the encoded Viper program
[info]       --noprintVpr
[info]       --projectRoot  <arg>          The root directory of the project
[info]   -r, --recursive                   Verify nested packages recursively
[info]       --norecursive
[info]       --unparse                     Print the parsed program
[info]       --nounparse
[info]       --z3Exe  <arg>                The Z3 executable
[info]   -h, --help                        Show help message
[info]   -v, --version                     Show version of this program
```
(56 lines in total)

New output:
```
[info]  Usage: Gobra -i <input-files or a single package name> [OPTIONS]
[info]  Options:
[info]       --backend  <arg>              Specifies the used Viper backend. The
[info]                                     default is SILICON. Choices: SILICON,
[info]                                     CARBON, VSWITHSILICON, VSWITHCARBON
[info]       --boogieExe  <arg>            The Boogie executable
[info]       --cacheFile  <arg>            Cache file to be used by Viper Server
[info]       --chop  <arg>                 Number of parts the generated verification
[info]                                     condition is split into (at most)
[info]   -d, --debug                       Output additional debug information
[info]       --eraseGhost                  Print the input program without ghost code
[info]       --excludePackages  <arg>...   Packages to ignore. These packages will not
[info]                                     be verified, even if they are found in the
[info]                                     specified directories.
[info]   -g, --gobraDirectory  <arg>       Output directory for Gobra
[info]       --goify                       Print the input program with the ghost code
[info]                                     commented out
[info]   -I, --include  <arg>...           Uses the provided directories to perform
[info]                                     package-related lookups before falling back
[info]                                     to $GOPATH
[info]   -p, --includePackages  <arg>...   Packages to verify. All packages found in
[info]                                     the specified directories are verified by
[info]                                     default.
[info]   -i, --input  <arg>...             List of Gobra programs, a project directory
[info]                                     or a single package name to verify
[info]       --int32                       Run with 32-bit sized integers (the default
[info]                                     is 64-bit ints)
[info]       --logLevel  <arg>             Specifies the log level. The default is OFF.
[info]                                     Choices: ALL, TRACE, DEBUG, INFO, WARN,
[info]                                     ERROR, OFF
[info]   -m, --module  <arg>               Name of current module that should be used
[info]                                     for resolving imports
[info]       --onlyFilesWithHeader         When enabled, Gobra only looks at files that
[info]                                     contain the header comment '// +gobra'
[info]   -o, --overflow                    Find expressions that may lead to integer
[info]                                     overflow
[info]       --packageTimeout  <arg>       Duration till the verification of a package
[info]                                     times out
[info]       --parseOnly                   Perform only the parsing step
[info]       --printInternal               Print the internal program representation
[info]       --printVpr                    Print the encoded Viper program
[info]       --projectRoot  <arg>          The root directory of the project
[info]   -r, --recursive                   Verify nested packages recursively
[info]       --unparse                     Print the parsed program
[info]       --z3Exe  <arg>                The Z3 executable
[info]   -h, --help                        Show help message
[info]   -v, --version                     Show version of this program
```
(47 lines in total)