### PR TITLE
Reduce the size of names in the encoding

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -3136,6 +3136,13 @@ object Desugar {
       * are consistently named across verification runs (i.e. independent of modifications to other function)
       */
     private var scopeCounter: Map[PCodeRoot, Int] = Map.empty
+
+    /**
+      * 'scopeMap' should return a unique identifier only within a package,
+      * and thus may not be unique in the resulting Viper encoding.
+      * This should be fine as long as the resulting name is only used in a non-global scope.
+      * Currently, it is used for variables, in and out parameters, and receivers.
+      */
     private var scopeMap: Map[PScope, Int] = Map.empty
 
     private def maybeRegister(s: PScope, ctx: ExternalTypeInfo): Unit = {

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -3154,24 +3154,24 @@ object Desugar {
       maybeRegister(s, context)
 
       // n has occur first in order that function inverse properly works
-      s"${n}_${context.pkgInfo.viperId}_$postfix${scopeMap(s)}" // deterministic
+      s"${n}_$postfix${scopeMap(s)}" // deterministic
     }
 
-    private def nameWithoutScope(postfix: String)(n: String, context: ExternalTypeInfo): String = {
+    private def topLevelName(postfix: String)(n: String, context: ExternalTypeInfo): String = {
       // n has occur first in order that function inverse properly works
       s"${n}_${context.pkgInfo.viperId}_$postfix" // deterministic
     }
 
     def variable(n: String, s: PScope, context: ExternalTypeInfo): String = name(VARIABLE_PREFIX)(n, s, context)
-    def global  (n: String, context: ExternalTypeInfo): String = nameWithoutScope(GLOBAL_PREFIX)(n, context)
-    def typ     (n: String, context: ExternalTypeInfo): String = nameWithoutScope(TYPE_PREFIX)(n, context)
+    def global  (n: String, context: ExternalTypeInfo): String = topLevelName(GLOBAL_PREFIX)(n, context)
+    def typ     (n: String, context: ExternalTypeInfo): String = topLevelName(TYPE_PREFIX)(n, context)
     def field   (n: String, @unused s: StructT): String = s"$n$FIELD_PREFIX" // Field names must preserve their equality from the Go level
-    def function(n: String, context: ExternalTypeInfo): String = nameWithoutScope(FUNCTION_PREFIX)(n, context)
+    def function(n: String, context: ExternalTypeInfo): String = topLevelName(FUNCTION_PREFIX)(n, context)
     def spec    (n: String, t: Type.InterfaceT, context: ExternalTypeInfo): String =
-      nameWithoutScope(s"$METHODSPEC_PREFIX${interface(t)}")(n, context)
+      topLevelName(s"$METHODSPEC_PREFIX${interface(t)}")(n, context)
     def method  (n: String, t: PMethodRecvType, context: ExternalTypeInfo): String = t match {
-      case PMethodReceiveName(typ)    => nameWithoutScope(s"$METHOD_PREFIX${typ.name}")(n, context)
-      case PMethodReceivePointer(typ) => nameWithoutScope(s"P$METHOD_PREFIX${typ.name}")(n, context)
+      case PMethodReceiveName(typ)    => topLevelName(s"$METHOD_PREFIX${typ.name}")(n, context)
+      case PMethodReceivePointer(typ) => topLevelName(s"P$METHOD_PREFIX${typ.name}")(n, context)
     }
     private def stringifyType(typ: in.Type): String = Names.serializeType(typ)
     def builtInMember(tag: BuiltInMemberTag, dependantTypes: Vector[in.Type]): String = {

--- a/src/main/scala/viper/gobra/frontend/Source.scala
+++ b/src/main/scala/viper/gobra/frontend/Source.scala
@@ -13,7 +13,7 @@ import viper.gobra.util.Violation
 import viper.silver.ast.SourcePosition
 
 import java.security.MessageDigest
-import java.util.Objects
+import java.util.{Base64, Objects}
 import scala.io.BufferedSource
 
 /**
@@ -26,15 +26,17 @@ import scala.io.BufferedSource
  * @param isBuiltIn a flag indicating, if the package comes from within Gobra
  */
 class PackageInfo(val id: String, val name: String, val isBuiltIn: Boolean) {
+  // encoder without padding chars (=) to generate valid identifiers
+  private val encoder = Base64.getEncoder.withoutPadding()
+  private val digestAlg = MessageDigest.getInstance("SHA-1")
+
   /**
    * Unique id of the package to use in Viper member names.
    *
    * We use a Hex representation of the real package it to make sure that only allowed characters are used inside the id,
    * while also keeping the uniqueness of the package id.
    */
-  lazy val viperId: String = MessageDigest.getInstance("SHA-1")
-    .digest(id.getBytes("UTF-8"))
-    .map("%02x".format(_)).mkString
+  lazy val viperId: String = encoder.encodeToString(digestAlg.digest(id.getBytes("UTF-8")))
 
   override def equals(obj: Any): Boolean = obj match {
     case other: PackageInfo => other.id == this.id


### PR DESCRIPTION
Right now, the identifiers obtained in the encoding are so big that reading the generated viper file for debugging is very hard. This PR tackles that problem in two fronts:
1. remove the viper id from the identifiers of local variables - @ArquintL maybe I'm missing something, but I do not see the purpose in including this in every local variable
2. (less impactful) use base64 instead of hexadecimal to print the hashsum of the package identifier when needed, which should lead to smaller names