### PR TITLE
Simplify 'copy' function to avoid matching loops

### DIFF
--- a/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
@@ -571,7 +571,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
             in.ExprAssertion(
               in.EqCmp(
                 in.IndexedExp(dstParam, i, dstUnderlyingType)(src),
-                in.IndexedExp(srcParam, i, srcUnderlyingType)(src)
+                in.Old(in.IndexedExp(srcParam, i, srcUnderlyingType)(src), srcUnderlyingType.elems)(src)
               )(src)
             )(src)
           }

--- a/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
@@ -366,18 +366,6 @@ class BuiltInMembersImpl extends BuiltInMembers {
       in.SepForall(Vector(i), trigger(i), in.Implication(range(i), body(i))(src))(src)
     }
 
-    def quantifyPure(trigger: in.BoundVar => Vector[in.Trigger], range: in.BoundVar => in.Expr, body: in.BoundVar => in.Expr): in.Expr = {
-      val i = freshBoundVar()
-      val triggers = trigger(i)
-      val expr = in.Conditional(
-        range(i),
-        body(i),
-        in.BoolLit(b = true)(src),
-        in.BoolT(Addressability.rValue)
-      )(src)
-      in.PureForall(Vector(i), triggers, expr)(src)
-    }
-
     def accessSlice(sliceExpr: in.Expr, perm: in.Expr): in.Assertion =
       quantify(
         trigger = { i => Vector(in.Trigger(Vector(in.IndexedExp(sliceExpr, i, sliceExpr.typ)(src)))(src)) },
@@ -505,16 +493,14 @@ class BuiltInMembersImpl extends BuiltInMembers {
 
       case (CopyFunctionTag, Vector(t1, t2, _)) =>
         /**
-          * requires 0 < p && p < 1
-          * requires forall i int :: { dst[i] } (0 <= i && i < len(dst)) ==> acc(&dst[i], 1-p)
+          * requires 0 < p
+          * requires forall i int :: { dst[i] } (0 <= i && i < len(dst)) ==> acc(&dst[i], write)
           * requires forall i int :: { src[i] } (0 <= i && i < len(src)) ==> acc(&src[i], p)
-          * requires forall i int :: { dst[i] } (0 <= i && i < len(dst) && (forall j int :: 0 <= j && j < len(src) ==> &dst[i] != &src[j])) ==> acc(&dst[i], p)
           * ensures len(dst) <= len(src) ==> res == len(dst)
           * ensures len(src) < len(dst) ==> res == len(src)
-          * ensures forall i int :: { dst[i] } 0 <= i && i < len(dst) ==> acc(&dst[i], 1-p)
+          * ensures forall i int :: { dst[i] } 0 <= i && i < len(dst) ==> acc(&dst[i], write)
           * ensures forall i int :: { src[i] } 0 <= i && i < len(src) ==> acc(&src[i], p)
-          * ensures forall i int :: { dst[i] } (0 <= i && i < len(dst) && (forall j int :: 0 <= j && j < len(src) ==> &dst[i] != &src[j])) ==> acc(&dst[i], p)
-          * ensures forall i int :: { dst[i] } (0 <= i && i < len(src) && i < len(dst)) ==> dst[i] == old(src[i])
+          * ensures forall i int :: { dst[i] } (0 <= i && i < len(src) && i < len(dst)) ==> dst[i] == src[i]
           * ensures forall i int :: { dst[i] } (len(src) <= i && i < len(dst)) ==> dst[i] == old(dst[i])
           * func copy(dst, src []int, ghost p perm) (res int)
           */
@@ -538,17 +524,12 @@ class BuiltInMembersImpl extends BuiltInMembers {
         val results = Vector(resParam)
 
         // preconditions
-        val pPre = in.ExprAssertion(
-          in.And(in.LessCmp(in.NoPerm(src), pParam)(src), in.LessCmp(pParam, in.FullPerm(src))(src))(src)
-        )(src)
+        val pPre = in.ExprAssertion(in.LessCmp(in.NoPerm(src), pParam)(src))(src)
         val preDst = quantify(
           trigger = { i => Vector(in.Trigger(Vector(in.IndexedExp(dstParam, i, dstUnderlyingType)(src)))(src)) },
           range = { i => inRange(i, in.IntLit(0)(src), in.Length(dstParam)(src)) },
           body = { i =>
-            in.Access(
-              in.Accessible.Address(in.IndexedExp(dstParam, i, dstUnderlyingType)(src)),
-              in.PermSub(in.FullPerm(src), pParam)(src)
-            )(src)
+            in.Access(in.Accessible.Address(in.IndexedExp(dstParam, i, dstUnderlyingType)(src)), in.FullPerm(src))(src)
           }
         )
         val preSrc = quantify(
@@ -556,27 +537,8 @@ class BuiltInMembersImpl extends BuiltInMembers {
           range = { i => inRange(i, in.IntLit(0)(src), in.Length(srcParam)(src)) },
           body = { i => in.Access(in.Accessible.Address(in.IndexedExp(srcParam, i, srcUnderlyingType)(src)), pParam)(src) }
         )
-        val preDistinct = quantify(
-          trigger = { i => Vector(in.Trigger(Vector(in.IndexedExp(dstParam, i, dstUnderlyingType)(src)))(src)) },
-          range = { i =>
-            in.And(
-              inRange(i, in.IntLit(0)(src), in.Length(dstParam)(src)),
-              quantifyPure(
-                // no suitable trigger found for this quantifier
-                trigger = { _ => Vector() },
-                range = { j => inRange(j, in.IntLit(0)(src), in.Length(srcParam)(src)) },
-                body = { j =>
-                  in.UneqCmp(
-                    in.Ref(in.IndexedExp(dstParam, i, dstUnderlyingType)(src))(src),
-                    in.Ref(in.IndexedExp(srcParam, j, srcUnderlyingType)(src))(src)
-                  )(src)
-                }
-              )
-            )(src)
-          },
-          body = { i => in.Access(in.Accessible.Address(in.IndexedExp(dstParam, i, dstUnderlyingType)(src)), pParam)(src) })
 
-        val pres = Vector(pPre, preDst, preSrc, preDistinct)
+        val pres = Vector(pPre, preDst, preSrc)
 
         // postconditions
         val postRes1 = in.Implication(
@@ -592,7 +554,6 @@ class BuiltInMembersImpl extends BuiltInMembers {
         // the assertions in the pre-conditions can be reused here
         val postDst = preDst
         val postSrc = preSrc
-        val postDistinct = preDistinct
         val postUpdate = quantify(
           trigger = { i => Vector(in.Trigger(Vector(in.IndexedExp(dstParam, i, dstUnderlyingType)(src)))(src)) },
           range = { i =>
@@ -605,7 +566,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
             in.ExprAssertion(
               in.EqCmp(
                 in.IndexedExp(dstParam, i, dstUnderlyingType)(src),
-                in.Old(in.IndexedExp(srcParam, i, srcUnderlyingType)(src), srcUnderlyingType.elems)(src)
+                in.IndexedExp(srcParam, i, srcUnderlyingType)(src)
               )(src)
             )(src)
           }
@@ -623,7 +584,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
           }
         )
 
-        val posts = Vector(postRes1, postRes2, postDst, postSrc, postDistinct, postUpdate, postSame)
+        val posts = Vector(postRes1, postRes2, postDst, postSrc, postUpdate, postSame)
 
         in.Function(x.name, args, results, pres, posts, Vector(in.WildcardMeasure(None)(src)), None)(src)
 

--- a/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
@@ -500,7 +500,7 @@ class BuiltInMembersImpl extends BuiltInMembers {
           * ensures len(src) < len(dst) ==> res == len(src)
           * ensures forall i int :: { dst[i] } 0 <= i && i < len(dst) ==> acc(&dst[i], write)
           * ensures forall i int :: { src[i] } 0 <= i && i < len(src) ==> acc(&src[i], p)
-          * ensures forall i int :: { dst[i] } (0 <= i && i < len(src) && i < len(dst)) ==> dst[i] == src[i]
+          * ensures forall i int :: { dst[i] } (0 <= i && i < len(src) && i < len(dst)) ==> dst[i] == old(src[i])
           * ensures forall i int :: { dst[i] } (len(src) <= i && i < len(dst)) ==> dst[i] == old(dst[i])
           * func copy(dst, src []int, ghost p perm) (res int)
           */

--- a/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
+++ b/src/main/scala/viper/gobra/translator/implementations/translator/BuiltInMembersImpl.scala
@@ -505,6 +505,11 @@ class BuiltInMembersImpl extends BuiltInMembers {
           * func copy(dst, src []int, ghost p perm) (res int)
           */
 
+        // TODO: add support for the case where `src` and `dst` are aliased. According to the language spec, the result
+        //       of copy should be independent of whether the memory referenced by the arguments overlaps.
+        //       This case used to be supported but was disabled in PR #439
+        //       (https://github.com/viperproject/gobra/pull/439/files) due to bad performance.
+
         // parameters
         val dstParam = in.Parameter.In("dst", t1)(src)
         val dstUnderlyingType: in.SliceT = ctx.underlyingType(t1) match {

--- a/src/test/resources/regressions/features/builtin/copy-fail2.gobra
+++ b/src/test/resources/regressions/features/builtin/copy-fail2.gobra
@@ -32,36 +32,3 @@ func test2() {
 	//:: ExpectedOutput(assert_error)
 	assert s[2] == 3
 }
-
-func test3() {
-	var a = []int{0, 1, 2, 3, 4, 5, 6, 7}
-	var s = make([]int, 6)
-	
-	p := perm(1/2)
-	assert forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
-	n1 := copy(s, a[0:], p)
-	assert n1 == 6
-	assert forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
-	assert s[0] == 0
-	assert s[1] == 1
-	assert s[2] == 2
-	assert s[3] == 3
-	assert s[4] == 4
-	assert s[5] == 5
-
-  /*
-  // disabled since PR #439
-	n2 := copy(s, s[2:], p)
-	// n2 == 4, s == []int{2, 3, 4, 5, 4, 5}
-	assert n2 == 4
-	assert forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
-	assert s[0] == 2
-	assert s[1] == 3
-	assert s[2] == 4
-	assert s[3] == 5
-	assert s[4] == 4
-	// Incompletness: this assertion causes Gobra to diverge
-	//:: ExpectedOutput(assert_error)
-	assert s[5] == 7
-  */
-}

--- a/src/test/resources/regressions/features/builtin/copy-fail2.gobra
+++ b/src/test/resources/regressions/features/builtin/copy-fail2.gobra
@@ -49,6 +49,8 @@ func test3() {
 	assert s[4] == 4
 	assert s[5] == 5
 
+  /*
+  // disabled since PR #439
 	n2 := copy(s, s[2:], p)
 	// n2 == 4, s == []int{2, 3, 4, 5, 4, 5}
 	assert n2 == 4
@@ -61,4 +63,5 @@ func test3() {
 	// Incompletness: this assertion causes Gobra to diverge
 	//:: ExpectedOutput(assert_error)
 	assert s[5] == 7
+  */
 }

--- a/src/test/resources/regressions/features/builtin/copy-fail3.gobra
+++ b/src/test/resources/regressions/features/builtin/copy-fail3.gobra
@@ -1,7 +1,7 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-//:: IgnoreFile(/gobra/issue/439/)
+//:: IgnoreFile(/gobra/issue/440/)
 
 package builtin
 

--- a/src/test/resources/regressions/features/builtin/copy-fail3.gobra
+++ b/src/test/resources/regressions/features/builtin/copy-fail3.gobra
@@ -1,17 +1,17 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
+//:: IgnoreFile(/gobra/issue/439/)
+
 package builtin
 
-func test1() {
+func test0() {
 	var a = []int{0, 1, 2, 3, 4, 5, 6, 7}
 	var s = make([]int, 6)
 	
 	p := perm(1/2)
 	assert forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
-	assert forall i int :: 0 <= i && i < len(a) ==> acc(&a[i])
 	n1 := copy(s, a[0:], p)
-	// n1 == 6, s == []int{0, 1, 2, 3, 4, 5}
 	assert n1 == 6
 	assert forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
 	assert s[0] == 0
@@ -20,4 +20,16 @@ func test1() {
 	assert s[3] == 3
 	assert s[4] == 4
 	assert s[5] == 5
+
+	n2 := copy(s, s[2:], p)
+	// n2 == 4, s == []int{2, 3, 4, 5, 4, 5}
+	assert n2 == 4
+	assert forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
+	assert s[0] == 2
+	assert s[1] == 3
+	assert s[2] == 4
+	assert s[3] == 5
+	assert s[4] == 4
+	//:: ExpectedOutput(assert_error)
+	assert s[5] == 7
 }

--- a/src/test/resources/regressions/features/builtin/copy-simple1.gobra
+++ b/src/test/resources/regressions/features/builtin/copy-simple1.gobra
@@ -21,6 +21,8 @@ func test1() {
 	assert s[4] == 4
 	assert s[5] == 5
 
+  /*
+  // disabled since PR 439
 	n2 := copy(s, s[2:], p)
 	// n2 == 4, s == []int{2, 3, 4, 5, 4, 5}
 	assert n2 == 4
@@ -31,4 +33,5 @@ func test1() {
 	assert s[3] == 5
 	assert s[4] == 4
 	assert s[5] == 5
+  */
 }

--- a/src/test/resources/regressions/features/builtin/copy-simple2.gobra
+++ b/src/test/resources/regressions/features/builtin/copy-simple2.gobra
@@ -1,7 +1,7 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-//:: IgnoreFile(/gobra/issue/439/)
+//:: IgnoreFile(/gobra/issue/440/)
 
 package builtin
 

--- a/src/test/resources/regressions/features/builtin/copy-simple2.gobra
+++ b/src/test/resources/regressions/features/builtin/copy-simple2.gobra
@@ -1,6 +1,8 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
+//:: IgnoreFile(/gobra/issue/439/)
+
 package builtin
 
 func test1() {
@@ -18,6 +20,17 @@ func test1() {
 	assert s[1] == 1
 	assert s[2] == 2
 	assert s[3] == 3
+	assert s[4] == 4
+	assert s[5] == 5
+
+	n2 := copy(s, s[2:], p)
+	// n2 == 4, s == []int{2, 3, 4, 5, 4, 5}
+	assert n2 == 4
+	assert forall i int :: 0 <= i && i < len(s) ==> acc(&s[i])
+	assert s[0] == 2
+	assert s[1] == 3
+	assert s[2] == 4
+	assert s[3] == 5
 	assert s[4] == 4
 	assert s[5] == 5
 }


### PR DESCRIPTION
Our current encoding of `copy` handles all cases supported in Go, including the case when the src and dst are overlapping. The spec is more complicated to deal with this particular (rarely used) case. As it stands, it is also triggering often matching loops. To avoid that problem for now, this PR disables those. This is a temporary solution, until we design a more careful spec for all cases