### PR TITLE
fix bug where int8 would be parsed as named operand

### DIFF
--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -235,6 +235,7 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
     typ.name match {
       case "perm" => PPermissionType().at(typ)
       case "int" => PIntType().at(typ)
+      case "int8" => PIntType().at(typ)
       case "int16" => PInt16Type().at(typ)
       case "int32" => PInt32Type().at(typ)
       case "int64" => PInt64Type().at(typ)

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -235,7 +235,7 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
     typ.name match {
       case "perm" => PPermissionType().at(typ)
       case "int" => PIntType().at(typ)
-      case "int8" => PIntType().at(typ)
+      case "int8" => PInt8Type().at(typ)
       case "int16" => PInt16Type().at(typ)
       case "int32" => PInt32Type().at(typ)
       case "int64" => PInt64Type().at(typ)


### PR DESCRIPTION
This PR fixes a bug where int8 would be parsed as a named operand and not as a type. It was just a missing case in a match construct.