### PR TITLE
Fix issue 416

### DIFF
--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -32,12 +32,36 @@ object PackageResolver {
   val fileUriScheme = "file"
   val jarUriScheme = "jar"
 
-  trait AbstractImport
+  sealed trait AbstractImport
   /** represents an implicit unqualified import that should resolve to the built-in package */
   case object BuiltInImport extends AbstractImport
   /** relative import path that should be resolved; an empty importPath results in looking for files in the current directory */
-  case class RegularImport(importPath: String) extends AbstractImport {
+  case class RegularImport private (importPath: String) extends AbstractImport {
     override def toString: String = importPath
+  }
+
+  sealed trait AbstractPackage
+  /** represents an error */
+  case object NoPackage extends AbstractPackage
+  /** represents all built-in packages together */
+  case object BuiltInPackage extends AbstractPackage
+  /** represents a regular package */
+  case class RegularPackage (id: String) extends AbstractPackage
+
+  object AbstractPackage {
+    def apply(imp: AbstractImport)(config: Config): AbstractPackage = {
+      imp match {
+        case BuiltInImport => BuiltInPackage
+        case imp: RegularImport =>
+          getLookupPath(imp)(config) match {
+            case Left(_) => NoPackage
+            case Right(inputResource) =>
+              try {
+                RegularPackage(inputResource.path.toFile.getCanonicalPath)
+              } catch { case _: Throwable => NoPackage }
+          }
+      }
+    }
   }
 
   /** represents some resolved source together with the knowledge of whether it was obtained from a builtin resource or not */

--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -57,7 +57,7 @@ object PackageResolver {
             case Left(_) => NoPackage
             case Right(inputResource) =>
               try {
-                RegularPackage(inputResource.path.toFile.getCanonicalPath)
+                RegularPackage(Source.uniquePath(inputResource.path, config.projectRoot).toString)
               } catch { case _: Throwable => NoPackage }
           }
       }

--- a/src/main/scala/viper/gobra/frontend/PackageResolver.scala
+++ b/src/main/scala/viper/gobra/frontend/PackageResolver.scala
@@ -36,7 +36,7 @@ object PackageResolver {
   /** represents an implicit unqualified import that should resolve to the built-in package */
   case object BuiltInImport extends AbstractImport
   /** relative import path that should be resolved; an empty importPath results in looking for files in the current directory */
-  case class RegularImport private (importPath: String) extends AbstractImport {
+  case class RegularImport(importPath: String) extends AbstractImport {
     override def toString: String = importPath
   }
 
@@ -46,7 +46,7 @@ object PackageResolver {
   /** represents all built-in packages together */
   case object BuiltInPackage extends AbstractPackage
   /** represents a regular package */
-  case class RegularPackage (id: String) extends AbstractPackage
+  case class RegularPackage(id: String) extends AbstractPackage
 
   object AbstractPackage {
     def apply(imp: AbstractImport)(config: Config): AbstractPackage = {

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -239,8 +239,8 @@ trait MemberResolution { this: TypeInfoImpl =>
         info <- Info.check(parsedProgram, nonEmptyPkgSources, context)(config)
       } yield info
       res.fold(
-        errs => context.addErrenousPackage(importTarget, errs),
-        info => context.addPackage(importTarget, info)
+        errs => context.addErrenousPackage(importTarget, errs)(config),
+        info => context.addPackage(importTarget, info)(config)
       )
       res
     }
@@ -260,7 +260,7 @@ trait MemberResolution { this: TypeInfoImpl =>
       }
 
       // check if package was already parsed, otherwise do parsing and type checking:
-      val cachedInfo = context.getTypeInfo(importTarget)
+      val cachedInfo = context.getTypeInfo(importTarget)(config)
       cachedInfo.getOrElse(parseAndTypeCheck(importTarget)).left.map(createImportError)
     }
 

--- a/src/test/resources/regressions/issues/000416.gobra
+++ b/src/test/resources/regressions/issues/000416.gobra
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+// ##(-I ./000416/ -I ./000416/importedImplementationPkg)
+import pkg "importedImplementationPkg"
+import "importedImplementationPkg/shape"
+
+func main () {
+  r@ := pkg.Rect{width: 2, height: 3}
+  fold r.mem()
+  r.Area()
+  Area(&r)
+}
+
+requires s != nil && s.mem() && s.Size()
+func Area(s shape.Shape) (ret int) {
+  return s.Area()
+}

--- a/src/test/resources/regressions/issues/000416/importedImplementationPkg/importedImplementationPkg.gobra
+++ b/src/test/resources/regressions/issues/000416/importedImplementationPkg/importedImplementationPkg.gobra
@@ -1,0 +1,39 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// ##(-I ./)
+import shape "shape"
+
+type Rect struct {
+  width int
+  height int
+}
+
+pred (r *Rect) mem() {
+  acc(r, 1/2)
+}
+
+requires acc(r, 1/2)
+pure func (r *Rect) Size() bool {
+  return r.width > 0 && r.height > 0
+}
+
+requires acc(r, 1/2) && r.Size()
+ensures  acc(r, 1/2) && ret > 0
+func (r *Rect) Area() (ret int) {
+  return r.width * r.height
+}
+
+(*Rect) implements shape.Shape {
+  pure (r *Rect) Size() bool {
+    return unfolding acc(r.mem(), 1/2) in r.Size()
+  }
+
+  (r *Rect) Area() (ret int) {
+    unfold r.mem()
+    ret = r.Area()
+    fold r.mem()
+  }
+}

--- a/src/test/resources/regressions/issues/000416/importedImplementationPkg/shape/shape.gobra
+++ b/src/test/resources/regressions/issues/000416/importedImplementationPkg/shape/shape.gobra
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package shape
+
+type Shape interface {
+   pred mem()
+
+   requires acc(mem(), 1/2)
+   pure Size() bool
+
+   requires mem() && Size()
+   ensures ret > 0
+   Area() (ret int)
+}


### PR DESCRIPTION
Fixes #416 

The problem was that AbstractImport does not uniquely identify a package. In the example, the package shape was parsed twice, once for the import path "shape" and once for the import path "importedImplementationPkg/shape". To fix this I introduce the indirection AbstractPackage which is supposed to uniquely identify a package. It is not clear to me whether tjhe last folder of the import path is always sufficient, e.g. using "shape" for ".../shape". In this PR, I use the canonical path of the directory the package is stored in, which might be overkill. 