### PR TITLE
Nil Check with Termination Transformation

### DIFF
--- a/src/test/resources/regressions/features/termination/termination-fail-02.gobra
+++ b/src/test/resources/regressions/features/termination/termination-fail-02.gobra
@@ -1,5 +1,3 @@
-//:: IgnoreFile(/gobra/issue/418/)
-
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
@@ -8,6 +6,7 @@ package termination
 type Func interface {
 	pure
 	decreases n
+	requires a != nil
 	fun(n int, a Func) int
 }
 
@@ -22,6 +21,7 @@ type FuncImpl struct {}
 
 pure
 decreases n
+requires a != nil
 func (f FuncImpl) fun (n int, a Func) int {
 	//:: ExpectedOutput(pure_function_termination_error)
 	return n * a.fun(n, f)


### PR DESCRIPTION
Adds a nil check to the fallback function that is generated by the termination transformer. 
This also enables that the termination-fail-02 testcase can be included again. We could consider closing #418 