### PR TITLE
Iota

### DIFF
--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -142,10 +142,10 @@ sealed trait PCodeRootWithResult extends PCodeRoot {
 
 // TODO: maybe introduce PConstBlockClause instead, make this stmt and all other stuff. Maybe rename to PConstSpec (or whatever name is used in the go lang spec)
 // TODO: might be easy to implement this as a stmt too
-case class PConstBlock(decls: Vector[PConstDecl]) extends PActualMember with PGhostifiableMember
+case class PConstDecl(decls: Vector[PConstSpec]) extends PActualMember with PGhostifiableMember
 
 // TODO: don't make this a member and stmt, rename this to clause
-case class PConstDecl(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration
+case class PConstSpec(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration
 
 case class PVarDecl(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId], addressable: Vector[Boolean]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration
 

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -140,6 +140,10 @@ sealed trait PCodeRootWithResult extends PCodeRoot {
   def result: PResult
 }
 
+// TODO: maybe introduce PConstBlockClause instead, make this stmt and all other stuff
+case class PConstBlock(decls: Vector[PConstDecl]) extends PActualMember with PGhostifiableMember
+
+// TODO: don't make this a member and stmt, rename this to clause
 case class PConstDecl(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration
 
 case class PVarDecl(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId], addressable: Vector[Boolean]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration
@@ -324,6 +328,8 @@ sealed trait PUnaryExp extends PActualExpression {
 case class PBlankIdentifier() extends PAssignee
 
 case class PNamedOperand(id: PIdnUse) extends PActualExpression with PActualType with PExpressionAndType with PAssignee with PLiteralType with PUnqualifiedTypeName with PNameOrDot
+
+case class PIota() extends PActualExpression
 
 sealed trait PLiteral extends PActualExpression
 

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -140,7 +140,8 @@ sealed trait PCodeRootWithResult extends PCodeRoot {
   def result: PResult
 }
 
-// TODO: maybe introduce PConstBlockClause instead, make this stmt and all other stuff
+// TODO: maybe introduce PConstBlockClause instead, make this stmt and all other stuff. Maybe rename to PConstSpec (or whatever name is used in the go lang spec)
+// TODO: might be easy to implement this as a stmt too
 case class PConstBlock(decls: Vector[PConstDecl]) extends PActualMember with PGhostifiableMember
 
 // TODO: don't make this a member and stmt, rename this to clause

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -142,10 +142,10 @@ sealed trait PCodeRootWithResult extends PCodeRoot {
 
 // TODO: maybe introduce PConstBlockClause instead, make this stmt and all other stuff. Maybe rename to PConstSpec (or whatever name is used in the go lang spec)
 // TODO: might be easy to implement this as a stmt too
-case class PConstDecl(decls: Vector[PConstSpec]) extends PActualMember with PGhostifiableMember
+case class PConstDecl(specs: Vector[PConstSpec]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration
 
 // TODO: don't make this a member and stmt, rename this to clause
-case class PConstSpec(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration
+case class PConstSpec(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId]) extends PNode
 
 case class PVarDecl(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId], addressable: Vector[Boolean]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration
 

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -140,11 +140,8 @@ sealed trait PCodeRootWithResult extends PCodeRoot {
   def result: PResult
 }
 
-// TODO: maybe introduce PConstBlockClause instead, make this stmt and all other stuff. Maybe rename to PConstSpec (or whatever name is used in the go lang spec)
-// TODO: might be easy to implement this as a stmt too
 case class PConstDecl(specs: Vector[PConstSpec]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration
 
-// TODO: don't make this a member and stmt, rename this to clause
 case class PConstSpec(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId]) extends PNode
 
 case class PVarDecl(typ: Option[PType], right: Vector[PExpression], left: Vector[PDefLikeId], addressable: Vector[Boolean]) extends PActualMember with PActualStatement with PGhostifiableStatement with PGhostifiableMember with PDeclaration

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -83,6 +83,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
 
   def showMember(mem: PMember): Doc = mem match {
     case mem: PActualMember => mem match {
+      case n: PConstBlock => "const" <+> parens(n.decls.map(showConstDecl).fold(emptyDoc)((a, b) => a <> linebreak <> b)) // TODO
       case n: PConstDecl => showConstDecl(n)
       case n: PVarDecl => showVarDecl(n)
       case n: PTypeDecl => showTypeDecl(n)
@@ -447,6 +448,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
       case PShiftLeft(left, right) => showExpr(left) <+> "<<" <+> showExpr(right)
       case PShiftRight(left, right) => showExpr(left) <+> ">>" <+> showExpr(right)
       case PBitNegation(exp) => "^" <> showExpr(exp)
+      case PIota() => "iota"
     }
     case expr: PGhostExpression => expr match {
       case POld(e) => "old" <> parens(showExpr(e))

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -83,8 +83,8 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
 
   def showMember(mem: PMember): Doc = mem match {
     case mem: PActualMember => mem match {
-      case n: PConstBlock => "const" <+> parens(n.decls.map(showConstDecl).fold(emptyDoc)((a, b) => a <> linebreak <> b)) // TODO
-      case n: PConstDecl => showConstDecl(n)
+      case n: PConstDecl => "const" <+> parens(n.decls.map(showConstDecl).fold(emptyDoc)((a, b) => a <> linebreak <> b)) // TODO
+      case n: PConstSpec => showConstDecl(n)
       case n: PVarDecl => showVarDecl(n)
       case n: PTypeDecl => showTypeDecl(n)
       case PFunctionDecl(id, args, res, spec, body) =>
@@ -164,8 +164,8 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
       "var" <+> showList(left zip addressable){ case (v, a) => showAddressable(a, v) } <> opt(typ)(space <> showType(_)) <> rhs
   }
 
-  def showConstDecl(decl: PConstDecl): Doc = decl match {
-    case PConstDecl(typ, right, left) => "const" <+> showIdList(left) <> opt(typ)(space <> showType(_)) <+> "=" <+> showExprList(right)
+  def showConstDecl(decl: PConstSpec): Doc = decl match {
+    case PConstSpec(typ, right, left) => "const" <+> showIdList(left) <> opt(typ)(space <> showType(_)) <+> "=" <+> showExprList(right)
   }
 
   def showTypeDecl(decl: PTypeDecl): Doc = decl match {
@@ -195,7 +195,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
 
   def showStmt(stmt: PStatement): Doc = stmt match {
     case stmt: PActualStatement => stmt match {
-      case n: PConstDecl => showConstDecl(n)
+      case n: PConstSpec => showConstDecl(n)
       case n: PVarDecl => showVarDecl(n)
       case n: PTypeDecl => showTypeDecl(n)
       case PShortVarDecl(right, left, addressable) =>
@@ -667,7 +667,7 @@ class ShortPrettyPrinter extends DefaultPrettyPrinter {
 
   override def showMember(mem: PMember): Doc = mem match {
     case mem: PActualMember => mem match {
-      case n: PConstDecl => showConstDecl(n)
+      case n: PConstSpec => showConstDecl(n)
       case n: PVarDecl => showVarDecl(n)
       case n: PTypeDecl => showTypeDecl(n)
       case PFunctionDecl(id, args, res, spec, _) =>

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -341,10 +341,7 @@ object Desugar {
       val consideredDecls = p.declarations.collect { case m@NoGhost(x: PMember) if shouldDesugar(x) => m }
       val dMembers = consideredDecls.flatMap{
         case NoGhost(x: PVarDecl) => varDeclGD(x)
-        case NoGhost(x: PConstDecl) =>
-          println(x)
-          constBlockDeclD(x)
-        case NoGhost(x: PConstSpec) => ??? // constDeclD(x)
+        case NoGhost(x: PConstDecl) => println(x); constBlockDeclD(x)
         case NoGhost(x: PMethodDecl) => Vector(registerMethod(x))
         case NoGhost(x: PFunctionDecl) => Vector(registerFunction(x))
         case x: PMPredicateDecl => Vector(registerMPredicate(x))
@@ -381,7 +378,7 @@ object Desugar {
     def varDeclGD(decl: PVarDecl): Vector[in.GlobalVarDecl] = ???
 
     def constDeclD(decl: PConstSpec): Vector[in.GlobalConstDecl] = {
-      decl.left.zipWithIndex.flatMap{ case (l, r) =>
+      decl.left.flatMap { l =>
         info.regular(l) match {
           case sc@st.SingleConstant(_, id, exp, _, _, _) =>
             val src = meta(id)
@@ -410,7 +407,7 @@ object Desugar {
       }
     }
 
-    def constBlockDeclD(block: PConstDecl): Vector[in.GlobalConstDecl] = block.decls.flatMap(constDeclD)
+    def constBlockDeclD(block: PConstDecl): Vector[in.GlobalConstDecl] = block.specs.flatMap(constDeclD)
 
     // Note: Alternatively, we could return the set of type definitions directly.
     //       However, currently, this would require to have versions of [[typeD]].

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -341,10 +341,10 @@ object Desugar {
       val consideredDecls = p.declarations.collect { case m@NoGhost(x: PMember) if shouldDesugar(x) => m }
       val dMembers = consideredDecls.flatMap{
         case NoGhost(x: PVarDecl) => varDeclGD(x)
-        case NoGhost(x: PConstBlock) =>
+        case NoGhost(x: PConstDecl) =>
           println(x)
           constBlockDeclD(x)
-        case NoGhost(x: PConstDecl) => ??? // constDeclD(x)
+        case NoGhost(x: PConstSpec) => ??? // constDeclD(x)
         case NoGhost(x: PMethodDecl) => Vector(registerMethod(x))
         case NoGhost(x: PFunctionDecl) => Vector(registerFunction(x))
         case x: PMPredicateDecl => Vector(registerMPredicate(x))
@@ -380,7 +380,7 @@ object Desugar {
 
     def varDeclGD(decl: PVarDecl): Vector[in.GlobalVarDecl] = ???
 
-    def constDeclD(decl: PConstDecl): Vector[in.GlobalConstDecl] = {
+    def constDeclD(decl: PConstSpec): Vector[in.GlobalConstDecl] = {
       decl.left.zipWithIndex.flatMap{ case (l, r) =>
         info.regular(l) match {
           case sc@st.SingleConstant(_, id, exp, _, _, _) =>
@@ -410,7 +410,7 @@ object Desugar {
       }
     }
 
-    def constBlockDeclD(block: PConstBlock): Vector[in.GlobalConstDecl] = block.decls.flatMap(constDeclD)
+    def constBlockDeclD(block: PConstDecl): Vector[in.GlobalConstDecl] = block.decls.flatMap(constDeclD)
 
     // Note: Alternatively, we could return the set of type definitions directly.
     //       However, currently, this would require to have versions of [[typeD]].

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -380,18 +380,18 @@ object Desugar {
     def constDeclD(block: PConstDecl): Vector[in.GlobalConstDecl] = block.specs.flatMap(constSpecD)
 
     def constSpecD(decl: PConstSpec): Vector[in.GlobalConstDecl] = decl.left.flatMap(l => info.regular(l) match {
-      case sc@st.SingleConstant(_, id, exp, _, _, _) =>
+      case sc@st.SingleConstant(_, id, _, _, _, _) =>
         val src = meta(id)
         val gVar = globalConstD(sc)(src)
         val lit: in.Lit = gVar.typ match {
           case in.BoolT(Addressability.Exclusive) =>
-            val constValue = sc.context.boolConstantEvaluation(exp)
+            val constValue = sc.context.boolConstantEvaluation(sc.exp)
             in.BoolLit(constValue.get)(src)
           case in.StringT(Addressability.Exclusive) =>
-            val constValue = sc.context.stringConstantEvaluation(exp)
+            val constValue = sc.context.stringConstantEvaluation(sc.exp)
             in.StringLit(constValue.get)(src)
           case x if underlyingType(x).isInstanceOf[in.IntT] && x.addressability == Addressability.Exclusive =>
-            val constValue = sc.context.intConstantEvaluation(exp)
+            val constValue = sc.context.intConstantEvaluation(sc.exp)
             in.IntLit(constValue.get)(src)
           case _ => ???
         }

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -341,7 +341,7 @@ object Desugar {
       val consideredDecls = p.declarations.collect { case m@NoGhost(x: PMember) if shouldDesugar(x) => m }
       val dMembers = consideredDecls.flatMap{
         case NoGhost(x: PVarDecl) => varDeclGD(x)
-        case NoGhost(x: PConstDecl) => println(x); constBlockDeclD(x)
+        case NoGhost(x: PConstDecl) => constBlockDeclD(x)
         case NoGhost(x: PMethodDecl) => Vector(registerMethod(x))
         case NoGhost(x: PFunctionDecl) => Vector(registerFunction(x))
         case x: PMPredicateDecl => Vector(registerMPredicate(x))
@@ -1068,9 +1068,7 @@ object Desugar {
               }
             } yield in.Seqn(Vector(dPre, exprAss, clauseBody))(src)
 
-          case p =>
-            println(s"${p.getClass.toString}")
-            ???
+          case _ => ???
         }
       }
     }

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -380,10 +380,8 @@ object Desugar {
 
     def varDeclGD(decl: PVarDecl): Vector[in.GlobalVarDecl] = ???
 
-    def constDeclD(decl: PConstDecl, fallBackExpr: Option[PExpression], iotaVal: Int): Vector[in.GlobalConstDecl] = {
-      decl.left.zipWithIndex.flatMap{ case (l, r) => {
-        println(decl)
-        print(s"iota: $iotaVal")
+    def constDeclD(decl: PConstDecl, fallBackExpr: Option[PExpression]): Vector[in.GlobalConstDecl] = {
+      decl.left.zipWithIndex.flatMap{ case (l, r) =>
         info.regular(l) match {
           case sc@st.SingleConstant(_, id, _, _, _, _) =>
             val src = meta(id)
@@ -398,13 +396,13 @@ object Desugar {
             }
             val lit: in.Lit = gVar.typ match {
               case in.BoolT(Addressability.Exclusive) =>
-                val constValue = sc.context.boolConstantEvaluation(initExpr, Some(iotaVal))
+                val constValue = sc.context.boolConstantEvaluation(initExpr)
                 in.BoolLit(constValue.get)(src)
               case in.StringT(Addressability.Exclusive) =>
                 val constValue = sc.context.stringConstantEvaluation(initExpr)
                 in.StringLit(constValue.get)(src)
               case x if underlyingType(x).isInstanceOf[in.IntT] && x.addressability == Addressability.Exclusive =>
-                val constValue = sc.context.intConstantEvaluation(initExpr, Some(iotaVal))
+                val constValue = sc.context.intConstantEvaluation(initExpr)
                 in.IntLit(constValue.get)(src)
               case _ => ???
             }
@@ -417,7 +415,7 @@ object Desugar {
 
           case _ => ???
         }
-      }}
+      }
     }
 
     def constBlockDeclD(block: PConstBlock): Vector[in.GlobalConstDecl] = {
@@ -427,7 +425,7 @@ object Desugar {
       block.decls.zipWithIndex.flatMap { case (decl, iotaVal) =>
         // TODO: Explain with go compiler
         lastExpr = if (decl.right.length == 1) Some(decl.right.head) else None
-        constDeclD(decl, lastExpr, iotaVal)
+        constDeclD(decl, lastExpr)
       }
     }
 

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -593,7 +593,9 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
     visitListNode[PConstDecl](ctx.constSpec()) match {
       // Make sure the first expression list is not empty
       case Vector(PConstDecl(_, Vector(), _), _*) => fail(ctx)
-      case decls => Vector(PConstBlock(decls))
+      case decls =>
+        println(s"Const Block: $decls")
+        Vector(PConstBlock(decls))
     }
   }
 

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -589,11 +589,11 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
     * <p>The default implementation returns the result of calling
     * {@link #visitChildren} on {@code ctx}.</p>
     */
-  override def visitConstDecl(ctx: GobraParser.ConstDeclContext): Vector[PConstDecl] = {
+  override def visitConstDecl(ctx: GobraParser.ConstDeclContext): Vector[PConstBlock] = {
     visitListNode[PConstDecl](ctx.constSpec()) match {
       // Make sure the first expression list is not empty
       case Vector(PConstDecl(_, Vector(), _), _*) => fail(ctx)
-      case decls => decls
+      case decls => Vector(PConstBlock(decls))
     }
   }
 
@@ -930,7 +930,10 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
   override def visitOperandName(ctx: GobraParser.OperandNameContext): PExpression = {
     visitChildren(ctx) match {
       case idnUseLike(id) => id match {
-        case id@PIdnUse(_) => PNamedOperand(id).at(id)
+        case id@PIdnUse(name) => name match {
+          case "iota" => PIota().at(id)
+          case _ => PNamedOperand(id).at(id)
+        }
         case PWildcard() => PBlankIdentifier().at(ctx)
         case _ => unexpected(ctx)
       }

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -595,7 +595,21 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
       case Vector(PConstDecl(_, Vector(), _), _*) => fail(ctx)
       case decls =>
         println(s"Const Block: $decls")
-        Vector(PConstBlock(decls))
+        val expandedDecls = decls.zipWithIndex.map { case (decl, idx) =>
+          if (decl.right.isEmpty) {
+            // TODO: justify why this cannot fail
+            // TODO: justify why this transformation is better done here
+            val rhs = decls.take(idx).findLast(d => d.right.nonEmpty).get.right.map(_.copy)
+            PConstDecl(
+              typ = decl.typ,
+              left = decl.left,
+              right = rhs
+            ).at(decl)
+          } else {
+            decl
+          }
+        }
+        Vector(PConstBlock(expandedDecls))
     }
   }
 

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -589,10 +589,10 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
     * <p>The default implementation returns the result of calling
     * {@link #visitChildren} on {@code ctx}.</p>
     */
-  override def visitConstDecl(ctx: GobraParser.ConstDeclContext): Vector[PConstBlock] = {
-    visitListNode[PConstDecl](ctx.constSpec()) match {
+  override def visitConstDecl(ctx: GobraParser.ConstDeclContext): Vector[PConstDecl] = {
+    visitListNode[PConstSpec](ctx.constSpec()) match {
       // Make sure the first expression list is not empty
-      case Vector(PConstDecl(_, Vector(), _), _*) => fail(ctx)
+      case Vector(PConstSpec(_, Vector(), _), _*) => fail(ctx)
       case decls =>
         println(s"Const Block: $decls")
         val expandedDecls = decls.zipWithIndex.map { case (decl, idx) =>
@@ -600,16 +600,12 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
             // TODO: justify why this cannot fail
             // TODO: justify why this transformation is better done here
             val rhs = decls.take(idx).findLast(d => d.right.nonEmpty).get.right.map(_.copy)
-            PConstDecl(
-              typ = decl.typ,
-              left = decl.left,
-              right = rhs
-            ).at(decl)
+            PConstSpec(typ = decl.typ, left = decl.left, right = rhs).at(decl)
           } else {
             decl
           }
         }
-        Vector(PConstBlock(expandedDecls))
+        Vector(PConstDecl(expandedDecls))
     }
   }
 
@@ -619,13 +615,13 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
     * <p>The default implementation returns the result of calling
     * {@link #visitChildren} on {@code ctx}.</p>
     */
-  override def visitConstSpec(ctx: GobraParser.ConstSpecContext): PConstDecl = {
+  override def visitConstSpec(ctx: GobraParser.ConstSpecContext): PConstSpec = {
     val typ = if (ctx.type_() != null) Some(visitNode[PType](ctx.type_())) else None
 
     val idnDefLikeList(left) = visitIdentifierList(ctx.identifierList())
     val right = visitExpressionList(ctx.expressionList())
 
-    PConstDecl(typ, right, left).at(ctx)
+    PConstSpec(typ, right, left).at(ctx)
   }
 
 

--- a/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
+++ b/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
@@ -71,9 +71,9 @@ trait ExternalTypeInfo {
 
   def struct(n: PNode): Option[StructT]
 
-  def boolConstantEvaluation(expr: PExpression, iota: Option[Int]): Option[Boolean]
+  def boolConstantEvaluation(expr: PExpression): Option[Boolean]
 
-  def intConstantEvaluation(expr: PExpression, iota: Option[Int]): Option[BigInt]
+  def intConstantEvaluation(expr: PExpression): Option[BigInt]
 
   def stringConstantEvaluation(expr: PExpression): Option[String]
 

--- a/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
+++ b/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
@@ -71,9 +71,9 @@ trait ExternalTypeInfo {
 
   def struct(n: PNode): Option[StructT]
 
-  def boolConstantEvaluation(expr: PExpression): Option[Boolean]
+  def boolConstantEvaluation(expr: PExpression, iota: Option[Int]): Option[Boolean]
 
-  def intConstantEvaluation(expr: PExpression): Option[BigInt]
+  def intConstantEvaluation(expr: PExpression, iota: Option[Int]): Option[BigInt]
 
   def stringConstantEvaluation(expr: PExpression): Option[String]
 

--- a/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
@@ -75,13 +75,13 @@ object SymbolTable extends Environments[Entity] {
   }
 
   sealed trait Constant extends DataEntity {
-    def decl: PConstDecl
+    def decl: PConstSpec
   }
 
   sealed trait ActualConstant extends Constant with ActualDataEntity
 
   // TODO: make this expression (exp) optional
-  case class SingleConstant(decl: PConstDecl, idDef: PIdnDef, exp: PExpression, opt: Option[PType], ghost: Boolean, context: ExternalTypeInfo) extends ActualConstant {
+  case class SingleConstant(decl: PConstSpec, idDef: PIdnDef, exp: PExpression, opt: Option[PType], ghost: Boolean, context: ExternalTypeInfo) extends ActualConstant {
     override def rep: PNode = decl
   }
 

--- a/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
@@ -80,7 +80,7 @@ object SymbolTable extends Environments[Entity] {
 
   sealed trait ActualConstant extends Constant with ActualDataEntity
 
-  // TODO: make exp optional or drop altogether
+  // TODO: make this expression (exp) optional
   case class SingleConstant(decl: PConstDecl, idDef: PIdnDef, exp: PExpression, opt: Option[PType], ghost: Boolean, context: ExternalTypeInfo) extends ActualConstant {
     override def rep: PNode = decl
   }

--- a/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
@@ -80,7 +80,6 @@ object SymbolTable extends Environments[Entity] {
 
   sealed trait ActualConstant extends Constant with ActualDataEntity
 
-  // TODO: make this expression (exp) optional
   case class SingleConstant(decl: PConstSpec, idDef: PIdnDef, exp: PExpression, opt: Option[PType], ghost: Boolean, context: ExternalTypeInfo) extends ActualConstant {
     override def rep: PNode = decl
   }

--- a/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
@@ -80,6 +80,7 @@ object SymbolTable extends Environments[Entity] {
 
   sealed trait ActualConstant extends Constant with ActualDataEntity
 
+  // TODO: make exp optional or drop altogether
   case class SingleConstant(decl: PConstDecl, idDef: PIdnDef, exp: PExpression, opt: Option[PType], ghost: Boolean, context: ExternalTypeInfo) extends ActualConstant {
     override def rep: PNode = decl
   }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -121,9 +121,9 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context,
   override def struct(n: PNode): Option[Type.StructT] =
     enclosingStruct(n).map(structDecl => symbType(structDecl).asInstanceOf[Type.StructT])
 
-  override def boolConstantEvaluation(expr: PExpression): Option[Boolean] = boolConstantEval(expr)
+  override def boolConstantEvaluation(expr: PExpression, iota: Option[Int]): Option[Boolean] = boolConstantEvalWithIota(iota)(expr)
 
-  override def intConstantEvaluation(expr: PExpression): Option[BigInt] = intConstantEval(expr)
+  override def intConstantEvaluation(expr: PExpression, iota: Option[Int]): Option[BigInt] = intConstantEvalWithIota(iota)(expr)
 
   override def stringConstantEvaluation(expr: PExpression): Option[String] = stringConstantEval(expr)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -121,9 +121,9 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context,
   override def struct(n: PNode): Option[Type.StructT] =
     enclosingStruct(n).map(structDecl => symbType(structDecl).asInstanceOf[Type.StructT])
 
-  override def boolConstantEvaluation(expr: PExpression, iota: Option[Int]): Option[Boolean] = boolConstantEvalWithIota(iota)(expr)
+  override def boolConstantEvaluation(expr: PExpression): Option[Boolean] = boolConstantEval(expr)
 
-  override def intConstantEvaluation(expr: PExpression, iota: Option[Int]): Option[BigInt] = intConstantEvalWithIota(iota)(expr)
+  override def intConstantEvaluation(expr: PExpression): Option[BigInt] = intConstantEval(expr)
 
   override def stringConstantEvaluation(expr: PExpression): Option[String] = stringConstantEval(expr)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Addressability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Addressability.scala
@@ -75,6 +75,7 @@ trait Addressability extends BaseProperty { this: TypeInfoImpl =>
         case p => Violation.violation(s"Unexpected dot resolve, got $p")
       }
       case _: PLiteral => AddrMod.literal
+      case _: PIota => AddrMod.iota
       case n: PInvoke => resolve(n) match {
         case Some(_: ap.Conversion) => AddrMod.conversionResult
         case Some(_: ap.FunctionCall) => AddrMod.callResult

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Assignability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Assignability.scala
@@ -285,8 +285,8 @@ trait Assignability extends BaseProperty { this: TypeInfoImpl =>
       case _ => None
     }
     val eval = underlyingType(typ) match {
-      case _: IntT => intConstantEval
-      case BooleanT => boolConstantEval
+      case _: IntT => intConstantEval _
+      case BooleanT => boolConstantEval _
       case StringT => stringConstantEval
       case _ => _: PExpression => None
     }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Assignability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Assignability.scala
@@ -285,8 +285,8 @@ trait Assignability extends BaseProperty { this: TypeInfoImpl =>
       case _ => None
     }
     val eval = underlyingType(typ) match {
-      case _: IntT => intConstantEval _
-      case BooleanT => boolConstantEval _
+      case _: IntT => intConstantEval
+      case BooleanT => boolConstantEval
       case StringT => stringConstantEval
       case _ => _: PExpression => None
     }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Assignability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Assignability.scala
@@ -22,7 +22,7 @@ trait Assignability extends BaseProperty { this: TypeInfoImpl =>
 
   lazy val multiAssignableTo: Property[(Vector[Type], Vector[Type])] = createProperty[(Vector[Type], Vector[Type])] {
     case (right, left) =>
-      StrictAssignModi(left.size, right.size) match {
+      StrictAssignMode(left.size, right.size) match {
         case AssignMode.Single =>
           right match {
             // To support Go's function chaining when a tuple with the results of a function call are passed to the
@@ -50,7 +50,7 @@ trait Assignability extends BaseProperty { this: TypeInfoImpl =>
 
   lazy val variadicAssignableTo: Property[(Vector[Type], Vector[Type])] = createProperty[(Vector[Type], Vector[Type])] {
     case (right, left) =>
-      StrictAssignModi(left.size, right.size) match {
+      StrictAssignMode(left.size, right.size) match {
         case AssignMode.Variadic => left.lastOption match {
           case Some(VariadicT(elem)) =>
             val dummyFill = UnknownType

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
@@ -15,21 +15,22 @@ import viper.gobra.util.Violation.violation
 
 trait ConstantEvaluation { this: TypeInfoImpl =>
 
-  lazy val boolConstantEval: PExpression => Option[Boolean] =
-    attr[PExpression, Option[Boolean]] {
+  def boolConstantEval(exp: PExpression): Option[Boolean] = boolConstantEvalWithIota(None)(exp)
+
+  def boolConstantEvalWithIota(iota: Option[Int]): PExpression => Option[Boolean] = {
       case PBoolLit(lit) => Some(lit)
       case e: PUnaryExp => e match {
-        case _: PNegation => boolConstantEval(e.operand).map(!_)
+        case _: PNegation => boolConstantEvalWithIota(iota)(e.operand).map(!_)
         case _ => None
       }
       case e: PBinaryExp[_,_] =>
         def auxBool[T](l: PExpression, r: PExpression)(f: Boolean => Boolean => Boolean): Option[Boolean] =
-          (boolConstantEval(l), boolConstantEval(r)) match {
+          (boolConstantEvalWithIota(iota)(l), boolConstantEvalWithIota(iota)(r)) match {
             case (Some(a), Some(b)) => Some(f(a)(b))
             case _ => None
           }
         def auxInt[T](l: PExpression, r: PExpression)(f: BigInt => BigInt => Boolean): Option[Boolean] =
-          (intConstantEval(l), intConstantEval(r)) match {
+          (intConstantEvalWithIota(iota)(l), intConstantEvalWithIota(iota)(r)) match {
             case (Some(a), Some(b)) => Some(f(a)(b))
             case _ => None
           }
@@ -53,103 +54,113 @@ trait ConstantEvaluation { this: TypeInfoImpl =>
         } yield res
 
       case PNamedOperand(id) => entity(id) match {
-        case SingleConstant(_, _, exp, _, _, context) => context.boolConstantEvaluation(exp)
+        case SingleConstant(_, _, exp, _, _, context) => context.boolConstantEvaluation(exp, iota)
         case _ => None
       }
       case PDot(_, id) => entity(id) match {
-        case SingleConstant(_, _, exp, _, _, _) => boolConstantEval(exp)
+        case SingleConstant(_, _, exp, _, _, _) => boolConstantEvalWithIota(iota)(exp)
         case _ => None
       }
 
       case _ => None
     }
 
-  lazy val intConstantEval: PExpression => Option[BigInt] =
-    attr[PExpression, Option[BigInt]] {
-      case PIntLit(lit, _) => Some(lit)
-      case inv: PInvoke => resolve(inv) match {
-        case Some(conv: ap.Conversion) => underlyingTypeP(conv.typ) match {
-          case Some(_: PIntegerType) => intConstantEval(conv.arg)
-          case _ => None
-        }
+  def intConstantEval(exp: PExpression): Option[BigInt] = intConstantEvalWithIota(None)(exp)
+
+  def intConstantEvalWithIota(iota: Option[Int]): PExpression => Option[BigInt] = {
+    case PIntLit(lit, _) => Some(lit)
+    case inv: PInvoke => resolve(inv) match {
+      case Some(conv: ap.Conversion) => underlyingTypeP(conv.typ) match {
+        case Some(_: PIntegerType) => intConstantEvalWithIota(iota)(conv.arg)
         case _ => None
       }
-      case PBitNegation(op) =>
-        // Not sufficient to do `intConstantEval(op) map (_.unary_~)`, produces wrong results for unsigned int values
-        exprType(op) match {
-          case IntT(t) =>
-            val constEval = intConstantEval(op)
-            constEval map { constValue =>
-              t match {
-                case UnboundedInteger | _: Signed => ~constValue
-                case u: Unsigned => ~constValue mod (u.upper + 1)
-              }
+      case _ => None
+    }
+    case PBitNegation(op) =>
+      // TODO: change
+      // Not sufficient to do `intConstantEval(op) map (_.unary_~)`, produces wrong results for unsigned int values
+      exprType(op) match {
+        case IntT(t) =>
+          val constEval = intConstantEvalWithIota(iota)(op)
+          constEval map { constValue =>
+            t match {
+              case UnboundedInteger | _: Signed => ~constValue
+              case u: Unsigned => ~constValue mod (u.upper + 1)
             }
+          }
+        case _ => None
+      }
+    case e: PBinaryExp[_, _] =>
+      def aux(l: PExpression, r: PExpression)(f: BigInt => BigInt => BigInt): Option[BigInt] =
+        (intConstantEvalWithIota(iota)(l), intConstantEvalWithIota(iota)(r)) match {
+          case (Some(a), Some(b)) => Some(f(a)(b))
           case _ => None
         }
-      case e: PBinaryExp[_,_] =>
-        def aux(l: PExpression, r: PExpression)(f: BigInt => BigInt => BigInt): Option[BigInt] =
-          (intConstantEval(l), intConstantEval(r)) match {
-            case (Some(a), Some(b)) => Some(f(a)(b))
-            case _ => None
-          }
 
-        for {
-          l <- asExpr(e.left)
-          r <- asExpr(e.right)
-          res <- e match {
-            case _: PAdd => aux(l, r)(x => y => x + y)
-            case _: PSub => aux(l, r)(x => y => x - y)
-            case _: PMul => aux(l, r)(x => y => x * y)
-            case _: PMod => aux(l, r)(x => y => x % y)
-            case _: PDiv => aux(l, r)(x => y => x / y)
-            case _: PShiftLeft =>
-              aux(l, r){
-                x => y =>
+      for {
+        l <- asExpr(e.left)
+        r <- asExpr(e.right)
+        res <- e match {
+          case _: PAdd => aux(l, r)(x => y => x + y)
+          case _: PSub => aux(l, r)(x => y => x - y)
+          case _: PMul => aux(l, r)(x => y => x * y)
+          case _: PMod => aux(l, r)(x => y => x % y)
+          case _: PDiv => aux(l, r)(x => y => x / y)
+          case _: PShiftLeft =>
+            aux(l, r) {
+              x =>
+                y =>
                   // The type system ensures that y is convertible to int
                   violation(y <= Int.MaxValue, s"right-hand operand bigger than expected")
                   x << y.toInt
-              }
-            case _: PShiftRight => exprType(l) match {
-              case IntT(t) => t match {
-                case UnboundedInteger | _: Signed =>
-                  aux(l, r){
-                    x => y =>
+            }
+          case _: PShiftRight => exprType(l) match {
+            case IntT(t) => t match {
+              case UnboundedInteger | _: Signed =>
+                aux(l, r) {
+                  x =>
+                    y =>
                       // The type system ensures that y is convertible to int
                       violation(y <= Int.MaxValue, s"right-hand operand bigger than expected")
                       x >> y.toInt
-                  }
-                case _: Unsigned =>
-                  aux(l, r){
-                    x => y =>
+                }
+              case _: Unsigned =>
+                aux(l, r) {
+                  x =>
+                    y =>
                       // The type system ensures that x is convertible to long and y is convertible to int
                       violation(x <= Long.MaxValue, s"left-hand operand bigger than expected")
                       violation(y <= Int.MaxValue, s"right-hand operand bigger than expected")
                       BigInt(x.toLong >>> y.toInt) // >>> is not implemented for BigInt
-                  }
-              }
-              case _ => None
+                }
             }
-            case _: PBitAnd => aux(l, r)(x => y => x & y)
-            case _: PBitOr => aux(l, r)(x => y => x | y)
-            case _: PBitXor => aux(l, r)(x => y => x ^ y)
-            case _: PBitClear => aux(l, r)(x => y => x &~ y)
-
             case _ => None
           }
-        } yield res
+          case _: PBitAnd => aux(l, r)(x => y => x & y)
+          case _: PBitOr => aux(l, r)(x => y => x | y)
+          case _: PBitXor => aux(l, r)(x => y => x ^ y)
+          case _: PBitClear => aux(l, r)(x => y => x &~ y)
 
-      case PNamedOperand(id) => entity(id) match {
-        case SingleConstant(_, _, exp, _, _, context) => context.intConstantEvaluation(exp)
-        case _ => None
-      }
-      case PDot(_, id) => entity(id) match {
-        case SingleConstant(_, _, exp, _, _, context) => context.intConstantEvaluation(exp)
-        case _ => None
-      }
+          case _ => None
+        }
+      } yield res
 
+    case PNamedOperand(id) => entity(id) match {
+      case SingleConstant(_, _, exp, _, _, context) => context.intConstantEvaluation(exp, iota)
       case _ => None
     }
+    case PDot(_, id) => entity(id) match {
+      case SingleConstant(_, _, exp, _, _, context) => context.intConstantEvaluation(exp, iota)
+      case _ => None
+    }
+
+    case PIota() => iota match {
+      case None => violation("TODO")
+      case _ => iota.map(BigInt(_))
+    }
+
+    case _ => None
+  }
 
   lazy val stringConstantEval: PExpression => Option[String] = {
     attr[PExpression, Option[String]] {

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
@@ -149,7 +149,7 @@ trait ConstantEvaluation { this: TypeInfoImpl =>
       }
 
       case p: PIota =>
-        // obtains from the context the intended value for iota
+        // obtains the intended value for iota from the context
         val res = for {
           constBlock <- enclosingPConstBlock(p)
           constClause <- enclosingPConstDecl(p)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
@@ -155,7 +155,7 @@ trait ConstantEvaluation { this: TypeInfoImpl =>
       val res = for {
         constBlock <- enclosingPConstBlock(p)
         constClause <- enclosingPConstDecl(p)
-        iota = constBlock.decls.indexOf(constClause)
+        iota = constBlock.specs.indexOf(constClause)
       } yield BigInt(iota)
       if (res.isEmpty) violation("TODO") else res
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/ConstantEvaluation.scala
@@ -75,7 +75,6 @@ trait ConstantEvaluation { this: TypeInfoImpl =>
         case _ => None
       }
       case PBitNegation(op) =>
-        // TODO: change
         // Not sufficient to do `intConstantEval(op) map (_.unary_~)`, produces wrong results for unsigned int values
         exprType(op) match {
           case IntT(t) =>
@@ -150,12 +149,14 @@ trait ConstantEvaluation { this: TypeInfoImpl =>
       }
 
       case p: PIota =>
+        // obtains from the context the intended value for iota
         val res = for {
           constBlock <- enclosingPConstBlock(p)
           constClause <- enclosingPConstDecl(p)
           iota = constBlock.specs.indexOf(constClause)
         } yield BigInt(iota)
-        if (res.isEmpty) violation("TODO") else res
+        violation(res.nonEmpty, "iota expression could not be found in a constant declaration")
+        res
 
       case _ => None
     }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/StrictAssignMode.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/StrictAssignMode.scala
@@ -15,7 +15,7 @@ object AssignMode {
   case object Error  extends AssignMode
 }
 
-object StrictAssignModi {
+object StrictAssignMode {
   def apply(left: Int, right: Int): AssignMode =
     if (left > 0 && left == right) AssignMode.Single
     else if (left > right && right == 1) AssignMode.Multi
@@ -24,7 +24,7 @@ object StrictAssignModi {
     else AssignMode.Error
 }
 
-object NonStrictAssignModi {
+object NonStrictAssignMode {
   def apply(left: Int, right: Int): AssignMode =
     if (left >= 0 && left == right) AssignMode.Single
     else if (left > right && right == 1) AssignMode.Multi

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
@@ -54,11 +54,11 @@ trait Enclosing { this: TypeInfoImpl =>
   lazy val enclosingStruct: PNode => Option[PStructType] =
     down[Option[PStructType]](None) { case x: PStructType => Some(x) }
 
-  lazy val enclosingPConstBlock: PNode => Option[PConstBlock] =
-    down[Option[PConstBlock]](None) { case x: PConstBlock => Some(x) }
-
-  lazy val enclosingPConstDecl: PNode => Option[PConstDecl] =
+  lazy val enclosingPConstBlock: PNode => Option[PConstDecl] =
     down[Option[PConstDecl]](None) { case x: PConstDecl => Some(x) }
+
+  lazy val enclosingPConstDecl: PNode => Option[PConstSpec] =
+    down[Option[PConstSpec]](None) { case x: PConstSpec => Some(x) }
 
   def typeSwitchConstraints(id: PIdnNode): Vector[PExpressionOrType] =
     typeSwitchConstraintsLookup(id)(id)
@@ -91,7 +91,7 @@ trait Enclosing { this: TypeInfoImpl =>
     def aux(n: PNode): Option[Type] = {
       n match {
         case tree.parent(p) => p match {
-          case PConstDecl(t, _, _) => t.map(symbType)
+          case PConstSpec(t, _, _) => t.map(symbType)
           case PVarDecl(t, _, _, _) => t.map(symbType)
           case _: PExpressionStmt => None
           case PSendStmt(channel, `n`) => Some(typ(channel).asInstanceOf[Type.ChannelT].elem)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
@@ -54,6 +54,12 @@ trait Enclosing { this: TypeInfoImpl =>
   lazy val enclosingStruct: PNode => Option[PStructType] =
     down[Option[PStructType]](None) { case x: PStructType => Some(x) }
 
+  lazy val enclosingPConstBlock: PNode => Option[PConstBlock] =
+    down[Option[PConstBlock]](None) { case x: PConstBlock => Some(x) }
+
+  lazy val enclosingPConstDecl: PNode => Option[PConstDecl] =
+    down[Option[PConstDecl]](None) { case x: PConstDecl => Some(x) }
+
   def typeSwitchConstraints(id: PIdnNode): Vector[PExpressionOrType] =
     typeSwitchConstraintsLookup(id)(id)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
@@ -32,7 +32,7 @@ trait NameResolution { this: TypeInfoImpl =>
 
         p match {
 
-        case decl: PConstDecl =>
+        case decl: PConstSpec =>
           val idx = decl.left.zipWithIndex.find(_._1 == id).get._2
 
           StrictAssignMode(decl.left.size, decl.right.size) match {
@@ -249,8 +249,8 @@ trait NameResolution { this: TypeInfoImpl =>
 
     m match {
       case a: PActualMember => a match {
-        case d: PConstBlock => d.decls.flatMap(v => v.left.collect{ case x: PIdnDef => x })
-        case d: PConstDecl => d.left.collect{ case x: PIdnDef => x }
+        case d: PConstDecl => d.decls.flatMap(v => v.left.collect{ case x: PIdnDef => x })
+        case d: PConstSpec => d.left.collect{ case x: PIdnDef => x }
         case d: PVarDecl => d.left.collect{ case x: PIdnDef => x }
         case d: PFunctionDecl => Vector(d.id)
         case d: PTypeDecl => Vector(d.left) ++ leakingIdentifier(d.right)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
@@ -193,6 +193,7 @@ trait NameResolution { this: TypeInfoImpl =>
 
     m match {
       case a: PActualMember => a match {
+        case d: PConstBlock => d.decls.flatMap(v => v.left.collect{ case x: PIdnDef => x })
         case d: PConstDecl => d.left.collect{ case x: PIdnDef => x }
         case d: PVarDecl => d.left.collect{ case x: PIdnDef => x }
         case d: PFunctionDecl => Vector(d.id)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
@@ -68,38 +68,6 @@ trait NameResolution { this: TypeInfoImpl =>
                       SingleConstant(decl, idn, expr, decl.typ, isGhost, this)
                   }
               }
-              /*
-
-               {
-
-
-
-
-                _ = defEntity(decl.left(idx)) match {
-                  case Wildcard(_, _) => ???
-                  case SingleConstant(_, _, exp, _, _, _) => SingleConstant(decl, )
-                }
-
-
-              expr = {
-                  for (i <- (idxDecl-1) to 0 by -1) {
-                    if(constBlock.decls(i).right.nonEmpty && constBlock.decls(i).right.length != constClause.left.length) {
-                      violation("sadfsa")
-                    }
-                    if ()
-                  }
-
-                }
-
-                  decl.left(idx) match {
-                  case idn: PIdnDef => ???
-                  case w: PWildcard =>  ??? //Wildcard(w, ???, this)
-                }
-                 _ = ??? // while it is different from the intended
-              } yield ???
-              ???
-            */
-
 
             case _ => UnknownEntity()
           }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
@@ -58,10 +58,15 @@ trait NameResolution { this: TypeInfoImpl =>
                       // should never be the case if the code type checks
                       ???
                   }
-                  val idxDecl = constBlock.decls.indexOf(decl) // TODO: explain purpose
-                  val nonEmptyConstDecl = constBlock.decls.take(idxDecl).findLast { decl => decl.right.lift(idx).isDefined }.get // TODO: explain
-                  val expr = nonEmptyConstDecl.right(idx)
-                  SingleConstant(decl, idn, expr, decl.typ, isGhost, this)
+                  val idxDecl = constBlock.specs.indexOf(decl) // TODO: explain purpose
+                  val nonEmptyConstDeclOpt = constBlock.specs.take(idxDecl).findLast { decl => decl.right.lift(idx).isDefined } // TODO: explain
+                  nonEmptyConstDeclOpt match {
+                    case None =>
+                      UnknownEntity()
+                    case Some(nonEmptyConstDecl) =>
+                      val expr = nonEmptyConstDecl.right(idx)
+                      SingleConstant(decl, idn, expr, decl.typ, isGhost, this)
+                  }
               }
               /*
 
@@ -249,8 +254,7 @@ trait NameResolution { this: TypeInfoImpl =>
 
     m match {
       case a: PActualMember => a match {
-        case d: PConstDecl => d.decls.flatMap(v => v.left.collect{ case x: PIdnDef => x })
-        case d: PConstSpec => d.left.collect{ case x: PIdnDef => x }
+        case d: PConstDecl => d.specs.flatMap(v => v.left.collect{ case x: PIdnDef => x })
         case d: PVarDecl => d.left.collect{ case x: PIdnDef => x }
         case d: PFunctionDecl => Vector(d.id)
         case d: PTypeDecl => Vector(d.left) ++ leakingIdentifier(d.right)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -187,6 +187,8 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
 
     case n: PIntLit => numExprWithinTypeBounds(n)
 
+    case PIota() => noMessages // TODO
+
     case _: PFloatLit => ???
 
     case n@PCompositeLit(t, lit) =>
@@ -711,6 +713,8 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
         case e => violation(s"expression $e cannot be unpacked")
       }
 
+    case PIota() => UNTYPED_INT_CONST
+
     case e => violation(s"unexpected expression $e")
   }
 
@@ -947,8 +951,12 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
   }
 
   private[typing] def wellDefIfConstExpr(expr: PExpression): Messages = typ(expr) match {
-    case BooleanT => error(expr, s"expected constant boolean expression", boolConstantEval(expr).isEmpty)
-    case typ if underlyingType(typ).isInstanceOf[IntT] => error(expr, s"expected constant int expression", intConstantEval(expr).isEmpty)
+    // TODO: put comment here
+    case BooleanT =>
+      error(expr, s"expected constant boolean expression", boolConstantEvalWithIota(Some(0))(expr).isEmpty)
+    case typ if underlyingType(typ).isInstanceOf[IntT] =>
+      // TODO: put comment here
+      error(expr, s"expected constant int expression", intConstantEvalWithIota(Some(0))(expr).isEmpty)
     case StringT => error(expr, s"expected constant string expression", stringConstantEval(expr).isEmpty)
     case _ => error(expr, s"expected a constant expression")
   }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -187,7 +187,8 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
 
     case n: PIntLit => numExprWithinTypeBounds(n)
 
-    case PIota() => noMessages // TODO
+    case n: PIota =>
+      error(n, s"cannot use iota outside of constant declaration", enclosingPConstDecl(n).isEmpty)
 
     case _: PFloatLit => ???
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -770,7 +770,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
 
         // if no type is specified, integer expressions default to unbounded integer in const declarations;
         // there is no need to handle interface types because they are not allowed in constant declarations
-        case PConstDecl(typ, _, _) => typ map typeSymbType orElse Some(UNTYPED_INT_CONST)
+        case PConstSpec(typ, _, _) => typ map typeSymbType orElse Some(UNTYPED_INT_CONST)
 
         // if no type is specified, integer expressions have default type in var declarations
         case PVarDecl(typ, _, _, _) => typ map (x => typeSymbType(x))

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -951,12 +951,8 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
   }
 
   private[typing] def wellDefIfConstExpr(expr: PExpression): Messages = typ(expr) match {
-    // TODO: put comment here
-    case BooleanT =>
-      error(expr, s"expected constant boolean expression", boolConstantEvalWithIota(Some(0))(expr).isEmpty)
-    case typ if underlyingType(typ).isInstanceOf[IntT] =>
-      // TODO: put comment here
-      error(expr, s"expected constant int expression", intConstantEvalWithIota(Some(0))(expr).isEmpty)
+    case BooleanT => error(expr, s"expected constant boolean expression", boolConstantEval(expr).isEmpty)
+    case typ if underlyingType(typ).isInstanceOf[IntT] => error(expr, s"expected constant int expression", intConstantEval(expr).isEmpty)
     case StringT => error(expr, s"expected constant string expression", stringConstantEval(expr).isEmpty)
     case _ => error(expr, s"expected a constant expression")
   }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
@@ -232,7 +232,7 @@ trait IdTyping extends BaseTyping { this: TypeInfoImpl =>
       case tree.parent(p) => p match {
         case PShortVarDecl(right, left, _) => getBlankAssigneeType(w, left, right)
         case PVarDecl(typ, right, left, _) => typ.map(symbType).getOrElse(getBlankAssigneeType(w, left, right))
-        case PConstDecl(typ, right, left) => typ.map(symbType).getOrElse(getBlankAssigneeType(w, left, right))
+        case PConstSpec(typ, right, left) => typ.map(symbType).getOrElse(getBlankAssigneeType(w, left, right))
         case _ => ???
       }
       case _ => ???

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
@@ -12,7 +12,7 @@ import viper.gobra.ast.frontend.{PIdnNode, _}
 import viper.gobra.frontend.info.base.SymbolTable._
 import viper.gobra.frontend.info.base.Type._
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
-import viper.gobra.frontend.info.implementation.property.{AssignMode, StrictAssignModi}
+import viper.gobra.frontend.info.implementation.property.{AssignMode, StrictAssignMode}
 
 trait IdTyping extends BaseTyping { this: TypeInfoImpl =>
 
@@ -216,7 +216,7 @@ trait IdTyping extends BaseTyping { this: TypeInfoImpl =>
     val pos = left indexWhere (n eq _)
     violation(pos >= 0, "did not find expression corresponding to " + n)
 
-    StrictAssignModi(left.length, right.length) match {
+    StrictAssignMode(left.length, right.length) match {
       case AssignMode.Single => exprType(right(pos))
       case AssignMode.Multi => exprType(right.head) match {
         case t: InternalTupleT => t.ts(pos)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
@@ -20,8 +20,8 @@ trait MemberTyping extends BaseTyping { this: TypeInfoImpl =>
   private[typing] def wellDefActualMember(member: PActualMember): Messages = member match {
     case n: PFunctionDecl => wellDefVariadicArgs(n.args) ++ wellDefIfPureFunction(n)
     case m: PMethodDecl => wellDefVariadicArgs(m.args) ++ isReceiverType.errors(miscType(m.receiver))(member) ++ wellDefIfPureMethod(m)
-    case b: PConstBlock => println(s"AQUI: $b"); b.decls.flatMap(wellDefActualMember)
-    case c: PConstDecl =>
+    case b: PConstDecl => println(s"AQUI: $b"); b.decls.flatMap(wellDefActualMember)
+    case c: PConstSpec =>
       // TODO: move this above
       val idenNumMsgs = error(c, s"number of identifiers does not match the number of expressions", c.left.length != c.right.length && c.right.nonEmpty)
       val constExprMsgs = c.right.flatMap(wellDefIfConstExpr)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
@@ -20,8 +20,9 @@ trait MemberTyping extends BaseTyping { this: TypeInfoImpl =>
   private[typing] def wellDefActualMember(member: PActualMember): Messages = member match {
     case n: PFunctionDecl => wellDefVariadicArgs(n.args) ++ wellDefIfPureFunction(n)
     case m: PMethodDecl => wellDefVariadicArgs(m.args) ++ isReceiverType.errors(miscType(m.receiver))(member) ++ wellDefIfPureMethod(m)
-
+    case b: PConstBlock => println(s"AQUI: $b"); b.decls.flatMap(wellDefActualMember)
     case c: PConstDecl =>
+      // TODO: move this above
       val idenNumMsgs = error(c, s"number of identifiers does not match the number of expressions", c.left.length != c.right.length)
       val constExprMsgs = c.right.flatMap(wellDefIfConstExpr)
       idenNumMsgs ++ constExprMsgs

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
@@ -25,7 +25,6 @@ trait MemberTyping extends BaseTyping { this: TypeInfoImpl =>
   }
 
   private[typing] def wellDefConstSpec(spec: PConstSpec): Messages = {
-    // TODO: check problem with unknown identifier
     val hasInitExpr = error(spec, s"missing init expr for ${spec.left}", spec.right.isEmpty)
     lazy val canAssignInitExpr = error(
       spec,

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
@@ -23,7 +23,7 @@ trait MemberTyping extends BaseTyping { this: TypeInfoImpl =>
     case b: PConstBlock => println(s"AQUI: $b"); b.decls.flatMap(wellDefActualMember)
     case c: PConstDecl =>
       // TODO: move this above
-      val idenNumMsgs = error(c, s"number of identifiers does not match the number of expressions", c.left.length != c.right.length)
+      val idenNumMsgs = error(c, s"number of identifiers does not match the number of expressions", c.left.length != c.right.length && c.right.nonEmpty)
       val constExprMsgs = c.right.flatMap(wellDefIfConstExpr)
       idenNumMsgs ++ constExprMsgs
     case s: PActualStatement => wellDefStmt(s).out

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/MemberTyping.scala
@@ -24,7 +24,7 @@ trait MemberTyping extends BaseTyping { this: TypeInfoImpl =>
     case s: PActualStatement => wellDefStmt(s).out
   }
 
-  private[typing] def wellDefConstSpec(spec: PConstSpec): Messages = {
+  private def wellDefConstSpec(spec: PConstSpec): Messages = {
     val hasInitExpr = error(spec, s"missing init expr for ${spec.left}", spec.right.isEmpty)
     lazy val canAssignInitExpr = error(
       spec,

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
@@ -23,6 +23,7 @@ trait StmtTyping extends BaseTyping { this: TypeInfoImpl =>
   private[typing] def wellDefActualStmt(stmt: PActualStatement): Messages = stmt match {
 
     case n@PConstDecl(typ, right, left) =>
+      // TODO:
       right.flatMap(isExpr(_).out) ++
         declarableTo.errors(right map exprType, typ map typeSymbType, left map idType)(n)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
@@ -22,10 +22,11 @@ trait StmtTyping extends BaseTyping { this: TypeInfoImpl =>
 
   private[typing] def wellDefActualStmt(stmt: PActualStatement): Messages = stmt match {
 
-    case n@PConstSpec(typ, right, left) =>
-      // TODO:
-      right.flatMap(isExpr(_).out) ++
-        declarableTo.errors(right map exprType, typ map typeSymbType, left map idType)(n)
+    case PConstDecl(decls) => decls flatMap {
+      case n@PConstSpec(typ, right, left) =>
+        right.flatMap(isExpr(_).out) ++
+          declarableTo.errors(right map exprType, typ map typeSymbType, left map idType)(n)
+    }
 
     case n@PVarDecl(typ, right, left, _) =>
       right.flatMap(isExpr(_).out) ++

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
@@ -22,7 +22,7 @@ trait StmtTyping extends BaseTyping { this: TypeInfoImpl =>
 
   private[typing] def wellDefActualStmt(stmt: PActualStatement): Messages = stmt match {
 
-    case n@PConstDecl(typ, right, left) =>
+    case n@PConstSpec(typ, right, left) =>
       // TODO:
       right.flatMap(isExpr(_).out) ++
         declarableTo.errors(right map exprType, typ map typeSymbType, left map idType)(n)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -317,6 +317,8 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
 
       case _: PBoolLit | _: PIntLit | _: PNilLit | _: PStringLit | _: PFloatLit => true
 
+      case _: PIota => true
+
       // Might change at some point
       case n: PInvoke => (exprOrType(n.base), resolve(n)) match {
         case (Right(_), Some(p: ap.Conversion)) =>

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostAssignability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostAssignability.scala
@@ -11,7 +11,7 @@ import viper.gobra.ast.frontend._
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.ast.frontend.{AstPattern => ap}
 import viper.gobra.frontend.info.ExternalTypeInfo
-import viper.gobra.frontend.info.implementation.property.{AssignMode, NonStrictAssignModi}
+import viper.gobra.frontend.info.implementation.property.{AssignMode, NonStrictAssignMode}
 import viper.gobra.frontend.info.implementation.typing.ghost.separation.GhostType.ghost
 import viper.gobra.util.Violation
 
@@ -81,7 +81,7 @@ trait GhostAssignability {
   }
 
   private def generalGhostAssignableTo[R, L](typing: R => GhostType)(msg: (Boolean, L) => Messages)(rights: R*)(lefts: L*): Messages =
-    NonStrictAssignModi(lefts.size, rights.size) match {
+    NonStrictAssignMode(lefts.size, rights.size) match {
 
       case AssignMode.Single => rights.zip(lefts).flatMap{ case (r,l) => msg(typing(r).isGhost, l) }.toVector
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
@@ -7,7 +7,7 @@
 package viper.gobra.frontend.info.implementation.typing.ghost.separation
 
 import viper.gobra.ast.frontend._
-import viper.gobra.frontend.info.implementation.property.{AssignMode, StrictAssignModi}
+import viper.gobra.frontend.info.implementation.property.{AssignMode, StrictAssignMode}
 import viper.gobra.util.Violation
 
 class GhostLessPrinter(classifier: GhostClassifier) extends DefaultPrettyPrinter {
@@ -104,7 +104,7 @@ class GhostLessPrinter(classifier: GhostClassifier) extends DefaultPrettyPrinter
       res._1 +: remainder
     }
 
-    StrictAssignModi(left.size, right.size) match {
+    StrictAssignMode(left.size, right.size) match {
       case AssignMode.Single =>
         // we have to distinguish for each pair of elements from left and right whether they remain the original
         // operation (i.e. by calling `copy`) or whether the left-hand side is dropped. In the latter case, the

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostTyping.scala
@@ -11,7 +11,7 @@ import viper.gobra.frontend.info.base.SymbolTable.{MultiLocalVariable, Regular, 
 import viper.gobra.frontend.info.base.Type
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.ast.frontend.{AstPattern => ap}
-import viper.gobra.frontend.info.implementation.property.{AssignMode, StrictAssignModi}
+import viper.gobra.frontend.info.implementation.property.{AssignMode, StrictAssignMode}
 import viper.gobra.util.Violation
 
 trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
@@ -27,7 +27,7 @@ trait GhostTyping extends GhostClassifier { this: TypeInfoImpl =>
   /** returns true iff statement is classified as ghost */
   private[separation] lazy val ghostStmtClassification: PStatement => Boolean = {
     def varDeclClassification(left: Vector[PIdnNode], right: Vector[PExpression]): Boolean =
-      StrictAssignModi(left.size, right.size) match {
+      StrictAssignMode(left.size, right.size) match {
         case AssignMode.Single =>
           left.map(Some(_)).zipAll(right.map(Some(_)), None, None).forall {
             case (l, r) => l.exists(ghostIdClassification) || r.exists(ghostExprResultClassification)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
@@ -117,6 +117,7 @@ trait GhostWellDef { this: TypeInfoImpl =>
        | _: PLiteral
        | _: PReference
        | _: PBlankIdentifier
+       | _: PIota
        | _: PPredConstructor
        | _: PUnpackSlice
     => noMessages

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
@@ -7,7 +7,7 @@
 package viper.gobra.frontend.info.implementation.typing.ghost.separation
 
 import viper.gobra.ast.frontend._
-import viper.gobra.frontend.info.implementation.property.{AssignMode, StrictAssignModi}
+import viper.gobra.frontend.info.implementation.property.{AssignMode, StrictAssignMode}
 import viper.gobra.util.{Constants, Violation}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import org.bitbucket.inkytonik.kiama.attribution.Decorators
@@ -157,7 +157,7 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
   override def showStmt(stmt: PStatement): Doc = stmt match {
 
     case PAssignment(right, left) =>
-      StrictAssignModi(left.size, right.size) match {
+      StrictAssignMode(left.size, right.size) match {
         case AssignMode.Single =>
           val (aRight, aLeft) = right.zip(left).filter(p => !classifier.isExprGhost(p._2)).unzip
           val (ghostRight, ghostLeft) = right.zip(left).filter(p => classifier.isExprGhost(p._2)).unzip
@@ -176,7 +176,7 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
       }
 
     case PShortVarDecl(right, left, addressable) =>
-      StrictAssignModi(left.size, right.size) match {
+      StrictAssignMode(left.size, right.size) match {
         case AssignMode.Single =>
           val (aRight, aLeft) = right.zip(left).filter(p => !classifier.isIdGhost(p._2)).unzip
           // List of all non-ghost addressable variables.

--- a/src/main/scala/viper/gobra/theory/Addressability.scala
+++ b/src/main/scala/viper/gobra/theory/Addressability.scala
@@ -111,6 +111,7 @@ object Addressability {
 
   val defaultValue: Addressability = rValue
   val literal: Addressability = rValue
+  val iota: Addressability = rValue
   val unit: Addressability = rValue
   val nil: Addressability = rValue
 

--- a/src/test/resources/regressions/features/iota/iota-fail-01.go
+++ b/src/test/resources/regressions/features/iota/iota-fail-01.go
@@ -1,0 +1,34 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package test
+
+const (
+	// Not allowed - init expression cannot be found for x1.
+	//:: ExpectedOutput(type_error)
+	x1
+	x2 = 1
+)
+
+const (
+	y1 = 1
+	y2, y3 = 2, 2
+	// Not allowed - init expression cannot be found for y4.
+	//:: ExpectedOutput(type_error)
+	y4
+)
+
+const (
+	w1 = 1
+	// Not allowed - init expression cannot be found for w2, w3,
+	// and w4.
+	//:: ExpectedOutput(type_error)
+	w2, w3, w4
+)
+
+func main() {
+	// Not allowed - iota can only occur inside the declaration
+	// of constants.
+	//:: ExpectedOutput(type_error)
+	z := iota
+}

--- a/src/test/resources/regressions/features/iota/iota-simple-01.gobra
+++ b/src/test/resources/regressions/features/iota/iota-simple-01.gobra
@@ -52,10 +52,10 @@ func main() {
 	assert w2 == 3
 	assert w3 == 6
 	//------------
-	assert j1 = 1
-	assert j2 = 2
-	assert j3 = 4
-	assert j4 = 8
+	assert j1 == 1
+	assert j2 == 2
+	assert j3 == 4
+	assert j4 == 8
 	//------------
 	assert i1 == 2
 	assert i2 == 2

--- a/src/test/resources/regressions/features/iota/iota-simple-01.gobra
+++ b/src/test/resources/regressions/features/iota/iota-simple-01.gobra
@@ -1,0 +1,65 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package test
+
+const (
+	x0 = iota
+	x1 = iota
+	x2, x3 int8 = 1, 2
+	x4, x5 uint16 = iota, iota
+	comp1 = iota == iota
+	comp2 bool = iota == x4
+)
+
+const y1 = iota
+const y2 = iota
+
+const (
+	w1 = iota * 3
+	w2
+	w3
+)
+
+const (
+	j1 = 1 << iota
+	j2
+	j3
+	j4
+)
+
+const (
+	i1 = 2
+	i2
+	i3, i4 = 1, 4
+)
+
+func main() {
+	//------------
+	assert x0 == 0
+	assert x1 == 1
+	assert x2 == 1
+	assert x3 == 2
+	assert x4 == 3
+	assert x5 == 3
+	assert comp1
+	assert !comp2
+	//------------
+	assert y1 == 0
+	assert y2 == 0
+	//------------
+	assert w1 == 0
+	assert w2 == 3
+	assert w3 == 6
+	//------------
+	assert j1 = 1
+	assert j2 = 2
+	assert j3 = 4
+	assert j4 = 8
+	//------------
+	assert i1 == 2
+	assert i2 == 2
+	assert i3 == 1
+	assert i4 == 4
+	//------------
+}

--- a/src/test/resources/regressions/features/iota/iota-simple-02.gobra
+++ b/src/test/resources/regressions/features/iota/iota-simple-02.gobra
@@ -1,0 +1,34 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// Example inspired by file
+// https://github.com/scionproto/scion/blob/master/pkg/addr/host.go
+
+package addr
+
+type HostAddrType uint8
+
+const (
+	HostTypeNone HostAddrType = iota
+	HostTypeIPv4
+	HostTypeIPv6
+	HostTypeSVC
+)
+
+func (t HostAddrType) String() string {
+	switch t {
+	case HostTypeNone:
+		return "None"
+	case HostTypeIPv4:
+		return "IPv4"
+	case HostTypeIPv6:
+		return "IPv6"
+	case HostTypeSVC:
+		return "SVC"
+	}
+	return ""
+}
+
+func test() {
+	_ := HostTypeIPv4.String()
+}

--- a/src/test/resources/regressions/features/iota/iota-simple-02.gobra
+++ b/src/test/resources/regressions/features/iota/iota-simple-02.gobra
@@ -31,4 +31,9 @@ func (t HostAddrType) String() string {
 
 func test() {
 	_ := HostTypeIPv4.String()
+	assert HostTypeNone == HostAddrType(0)
+	assert HostTypeIPv4 == HostAddrType(1)
+	assert HostTypeIPv6 == HostAddrType(2)
+	assert HostTypeSVC  == HostAddrType(3)
+
 }

--- a/src/test/scala/viper/gobra/GobraPackageTests.scala
+++ b/src/test/scala/viper/gobra/GobraPackageTests.scala
@@ -12,7 +12,7 @@ import ch.qos.logback.classic.Level
 import org.bitbucket.inkytonik.kiama.util.Source
 import org.rogach.scallop.exceptions.ValidationFailure
 import org.rogach.scallop.throwError
-import viper.gobra.frontend.Source.{FromFileSource, getPackageInfo}
+import viper.gobra.frontend.Source.FromFileSource
 import viper.gobra.frontend.{Config, PackageInfo, ScallopGobraConfig, Source}
 import viper.gobra.reporting.{NoopReporter, ParserError}
 import viper.gobra.reporting.VerifierResult.{Failure, Success}

--- a/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
+++ b/src/test/scala/viper/gobra/erasing/GhostErasureUnitTests.scala
@@ -318,7 +318,7 @@ class GhostErasureUnitTests extends AnyFunSuite with Matchers with Inside {
     @scala.annotation.tailrec
     private def equal(actual: PMember, expected: PMember): Assertion = {
       (actual, expected) match {
-        case (a: PConstDecl, e: PConstDecl) => assert(a == e)
+        case (a: PConstSpec, e: PConstSpec) => assert(a == e)
         case (a: PVarDecl, e: PVarDecl) => assert(a == e)
         case (PFunctionDecl(aId, aArgs, aResult, aSpec, aBody), PFunctionDecl(eId, eArgs, eResult, eSpec, eBody)) =>
           assert(aId == eId)


### PR DESCRIPTION
Current annoyance: redundant messages are produced. E.g., for the following program
```go
const (
    // Should no be allowed, first assigment missing
    xxxx
    yyyy = 1
)
```
we get two errors, one of which is unnecessary:
```
[info] 	</Users/joao/tmp/iota_reject.gobra:5:5> /Users/joao/tmp/iota_reject.gobra:5:5:error: got unknown identifier xxxx
[info]     xxxx
[info]     ^
[info] 	</Users/joao/tmp/iota_reject.gobra:5:5> /Users/joao/tmp/iota_reject.gobra:5:5:error: missing init expr for Vector(xxxx)
[info]     xxxx
[info]     ^
```