### PR TITLE
Add Mem predicate in Error

### DIFF
--- a/src/main/resources/builtin/builtin.gobra
+++ b/src/main/resources/builtin/builtin.gobra
@@ -2,14 +2,18 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in https://golang.org/LICENSE
 
+// This package is imported implicitly in every other package.
+// Because Go does not allow cyclic import relations, files in
+// this package cannot have imports.
+
 package builtin
 
 type error interface {
-    pred ErrorMem()
+	pred ErrorMem()
 
-    preserves ErrorMem()
-    decreases
-    Error() string
+	preserves ErrorMem()
+	decreases
+	Error() string
 }
 
 // The panic built-in function stops normal execution of the current

--- a/src/main/resources/builtin/builtin.gobra
+++ b/src/main/resources/builtin/builtin.gobra
@@ -5,6 +5,10 @@
 package builtin
 
 type error interface {
+    pred ErrorMem()
+
+    preserves ErrorMem()
+    decreases
     Error() string
 }
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
@@ -30,6 +30,9 @@ trait Enclosing { this: TypeInfoImpl =>
     case _ => id
   })
 
+  lazy val tryEnclosingPackage: PNode => Option[PPackage] =
+    down[Option[PPackage]](None) { case x: PPackage => Some(x) }
+
   lazy val tryEnclosingUnorderedScope: PNode => Option[PUnorderedScope] =
     down[Option[PUnorderedScope]](None) { case x: PUnorderedScope => Some(x) }
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -294,9 +294,14 @@ trait MemberResolution { this: TypeInfoImpl =>
   }
 
   lazy val tryUnqualifiedPackageLookup: PIdnUse => Entity = { id =>
+    // Determines if the given PPackage is the `builtin` package provided by Gobra
     val isBuiltinPackage: PPackage => Boolean = {
-      // package `builtin` provided by Gobra
-      p => p.packageClause.id.name == "builtin" // && p.info.isBuiltIn // TEST
+      // TODO: as it stands, no user-provided package can be named `builtin`,
+      //       otherwise Gobra might behave unexpectedly. This could be avoided
+      //       by adding the conjunct 'p.info.isBuiltIn' to the check below, but
+      //       this flag seems to only be properly set when the Gobra std library
+      //       is read from a `FromFileSource`.
+      p => p.packageClause.id.name == "builtin"
     }
     tryEnclosingPackage(id) match {
       case Some(p) if isBuiltinPackage(p) =>

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -19,6 +19,7 @@ import viper.gobra.frontend.info.base.SymbolTable._
 import viper.gobra.frontend.info.base.Type._
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.reporting.{NotFoundError, VerifierError}
+import viper.gobra.util.Violation
 
 import scala.annotation.tailrec
 
@@ -292,16 +293,28 @@ trait MemberResolution { this: TypeInfoImpl =>
     }
   }
 
-  lazy val tryUnqualifiedPackageLookup: PIdnUse => Entity =
-    attr[PIdnUse, Entity] {
-      id =>
+  lazy val tryUnqualifiedPackageLookup: PIdnUse => Entity = { id =>
+    val isBuiltinPackage: PPackage => Boolean = {
+      // package `builtin` provided by Gobra
+      p => p.packageClause.id.name == "builtin" && p.info.isBuiltIn
+    }
+    tryEnclosingPackage(id) match {
+      case Some(p) if isBuiltinPackage(p) =>
+        // The `builtin` package is imported implicitly by every package. If the importing package is `builtin`,
+        // then the call to this method should not cause a call to `tryUnqualifiedBuiltInPackageLookup`, otherwise
+        // Gobra complains about a cyclic import relation consisting of the cycle "[BuiltInImport]", as observed in
+        // the first commit of https://github.com/viperproject/gobra/pull/457 .
+        UnknownEntity()
+      case Some(_) =>
         // Go is weird in the sense that it let's you redeclare built-in identifiers such as "error" but won't complain
         // about the redeclaration. If the redeclaration happens in the same package, the redeclaration is
         // used (instead of the built-in one). If the redeclaration happens in an imported package Go's behavior is not
         // fully clear since "error" is not exported. However, we give higher precedence to the built-in one in Gobra
         // to approximate Go's behavior.
         tryUnqualifiedBuiltInPackageLookup(id).getOrElse(tryUnqualifiedRegularPackageLookup(id))
+      case None => Violation.violation(s"Expected node $id to have a parent of type PPackage, but none found.")
     }
+  }
 
   def tryUnqualifiedBuiltInPackageLookup(id: PIdnUse): Option[Entity] =
     tryPackageLookup(BuiltInImport, id, id).map(_._1)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -296,7 +296,7 @@ trait MemberResolution { this: TypeInfoImpl =>
   lazy val tryUnqualifiedPackageLookup: PIdnUse => Entity = { id =>
     val isBuiltinPackage: PPackage => Boolean = {
       // package `builtin` provided by Gobra
-      p => p.packageClause.id.name == "builtin" && p.info.isBuiltIn
+      p => p.packageClause.id.name == "builtin" // && p.info.isBuiltIn // TEST
     }
     tryEnclosingPackage(id) match {
       case Some(p) if isBuiltinPackage(p) =>

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -293,33 +293,34 @@ trait MemberResolution { this: TypeInfoImpl =>
     }
   }
 
-  lazy val tryUnqualifiedPackageLookup: PIdnUse => Entity = { id =>
-    // Determines if the given PPackage is the `builtin` package provided by Gobra
-    val isBuiltinPackage: PPackage => Boolean = {
-      // TODO: as it stands, no user-provided package can be named `builtin`,
-      //       otherwise Gobra might behave unexpectedly. This could be avoided
-      //       by adding the conjunct 'p.info.isBuiltIn' to the check below, but
-      //       this flag seems to only be properly set when the Gobra std library
-      //       is read from a `FromFileSource`.
-      p => p.packageClause.id.name == "builtin"
+  lazy val tryUnqualifiedPackageLookup: PIdnUse => Entity =
+    attr[PIdnUse, Entity] { id =>
+      // Determines if the given PPackage is the `builtin` package provided by Gobra
+      val isBuiltinPackage: PPackage => Boolean = {
+        // TODO: as it stands, no user-provided package can be named `builtin`,
+        //       otherwise Gobra might behave unexpectedly. This could be avoided
+        //       by adding the conjunct 'p.info.isBuiltIn' to the check below, but
+        //       this flag seems to only be properly set when the Gobra std library
+        //       is read from a `FromFileSource`.
+        p => p.packageClause.id.name == "builtin"
+      }
+      tryEnclosingPackage(id) match {
+        case Some(p) if isBuiltinPackage(p) =>
+          // The `builtin` package is imported implicitly by every package. If the importing package is `builtin`,
+          // then the call to this method should not cause a call to `tryUnqualifiedBuiltInPackageLookup`, otherwise
+          // Gobra complains about a cyclic import relation consisting of the cycle "[BuiltInImport]", as observed in
+          // the first commit of https://github.com/viperproject/gobra/pull/457 .
+          UnknownEntity()
+        case Some(_) =>
+          // Go is weird in the sense that it let's you redeclare built-in identifiers such as "error" but won't complain
+          // about the redeclaration. If the redeclaration happens in the same package, the redeclaration is
+          // used (instead of the built-in one). If the redeclaration happens in an imported package Go's behavior is not
+          // fully clear since "error" is not exported. However, we give higher precedence to the built-in one in Gobra
+          // to approximate Go's behavior.
+          tryUnqualifiedBuiltInPackageLookup(id).getOrElse(tryUnqualifiedRegularPackageLookup(id))
+        case None => Violation.violation(s"Expected node $id to have a parent of type PPackage, but none found.")
+      }
     }
-    tryEnclosingPackage(id) match {
-      case Some(p) if isBuiltinPackage(p) =>
-        // The `builtin` package is imported implicitly by every package. If the importing package is `builtin`,
-        // then the call to this method should not cause a call to `tryUnqualifiedBuiltInPackageLookup`, otherwise
-        // Gobra complains about a cyclic import relation consisting of the cycle "[BuiltInImport]", as observed in
-        // the first commit of https://github.com/viperproject/gobra/pull/457 .
-        UnknownEntity()
-      case Some(_) =>
-        // Go is weird in the sense that it let's you redeclare built-in identifiers such as "error" but won't complain
-        // about the redeclaration. If the redeclaration happens in the same package, the redeclaration is
-        // used (instead of the built-in one). If the redeclaration happens in an imported package Go's behavior is not
-        // fully clear since "error" is not exported. However, we give higher precedence to the built-in one in Gobra
-        // to approximate Go's behavior.
-        tryUnqualifiedBuiltInPackageLookup(id).getOrElse(tryUnqualifiedRegularPackageLookup(id))
-      case None => Violation.violation(s"Expected node $id to have a parent of type PPackage, but none found.")
-    }
-  }
 
   def tryUnqualifiedBuiltInPackageLookup(id: PIdnUse): Option[Entity] =
     tryPackageLookup(BuiltInImport, id, id).map(_._1)


### PR DESCRIPTION
This PR introduces a predicate `ErrorMem` in the `error` interface. An instance of this predicate is required to be able to call the `Error` method.

This PR also addresses the cyclic import error that is caused when `ErrorMem` is introduced. To solve that, we remove the call to method `tryUnqualifiedBuiltInPackageLookup` in method `tryUnqualifiedPackageLookup` when the importing package is `builtin`.