### PR TITLE
Avoid redundant test executions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,11 @@
 
 name: test
 
-on: [push, pull_request]
+on:
+  push: # run this workflow on pushes to master
+    branches:
+    - master
+  pull_request: # run this workflow on every pull_request
 
 jobs:
   # there is a single job to avoid copying the built docker image from one job to the other

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,7 @@
 
 name: test
 
-on:
-  push: # run this workflow on every push
-  pull_request: # run this workflow on every pull_request
+on: [push, pull_request]
 
 jobs:
   # there is a single job to avoid copying the built docker image from one job to the other


### PR DESCRIPTION
As it stands, we run the Gobra tests twice on every push to a PR. This is redundant and wasteful. This PR addresses that by only executing the tests once when there is either a pr or push