### PR TITLE
Add support for short-hand for implementation proofs

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -382,7 +382,7 @@ object Desugar {
         underlyingType(typ).isInstanceOf[Type.InterfaceT]
       }
       val rightArePureExpr = decl.right.forall(info.isPureExpression)
-      if (leftAreWildcards && typIsInterface && rightArePureExpr ) {
+      if (leftAreWildcards && typIsInterface && rightArePureExpr) {
         // When the lhs is a wildcard of an interface type and the rhs are pure expressions,
         // the variable declaration can be safely ignored. In some codebases, this idiom is
         // used to check that types implement interfaces.

--- a/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
+++ b/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
@@ -78,6 +78,8 @@ trait ExternalTypeInfo {
 
   def stringConstantEvaluation(expr: PExpression): Option[String]
 
+  def isPureExpression(expr: PExpression): Boolean
+
   def keyElementIndices(elems : Vector[PKeyedElement]) : Vector[BigInt]
 
   def getTypeInfo: TypeInfo

--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -132,4 +132,6 @@ class TypeInfoImpl(final val tree: Info.GoTree, final val context: Info.Context,
   override def stringConstantEvaluation(expr: PExpression): Option[String] = stringConstantEval(expr)
 
   override def getTypeInfo: TypeInfo = this
+
+  override def isPureExpression(expr: PExpression): Boolean = isPureExpr(expr).isEmpty
 }

--- a/src/test/resources/regressions/features/globals/impl-shorthand-fail01.gobra
+++ b/src/test/resources/regressions/features/globals/impl-shorthand-fail01.gobra
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type Ifc interface {
+	f()
+}
+
+type Impl *struct{}
+
+//:: ExpectedOutput(type_error)
+var _ Ifc = Impl(nil)

--- a/src/test/resources/regressions/features/globals/impl-shorthand-fail02.gobra
+++ b/src/test/resources/regressions/features/globals/impl-shorthand-fail02.gobra
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type Ifc interface {
+	f()
+}
+
+type Impl *struct{}
+
+// Because of this precondition, Impl is
+// not a behavioral subtype of Ifc
+//:: ExpectedOutput(generated_implementation_proof:precondition_error)
+requires false
+func (i Impl) f() {
+	return
+}
+
+var _ Ifc = Impl(nil)

--- a/src/test/resources/regressions/features/globals/impl-shorthand-simple01.gobra
+++ b/src/test/resources/regressions/features/globals/impl-shorthand-simple01.gobra
@@ -1,0 +1,16 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type Ifc interface {
+	f()
+}
+
+type Impl *struct{}
+
+func (i Impl) f() {
+	return
+}
+
+var _ Ifc = Impl(nil)


### PR DESCRIPTION
A typical pattern in some Go codebases is to add lines like the following to enforce that `ImplType` is an implementation of `InterfaceType`.
```go
var _ InterfaceType = ImplType(nil)
```
Because this does not have any effect at runtime, we can already add support for it without the more in-depth support for global variables. Having the line above is also compatible with explicitly providing an implementation proof in Gobra.