### PR TITLE
Aliased type for any = interface{}

### DIFF
--- a/src/main/resources/builtin/builtin.gobra
+++ b/src/main/resources/builtin/builtin.gobra
@@ -8,6 +8,8 @@
 
 package builtin
 
+type any = interface{}
+
 type error interface {
 	pred ErrorMem()
 


### PR DESCRIPTION
In Go (1.18), the type `any` is an alias for `interface{}`.
