### PR TITLE
Make `defer` statement ghostifiable

### DIFF
--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -260,7 +260,7 @@ case class PShortForRange(range: PRange, shorts: Vector[PIdnUnk], body: PBlock) 
 case class PGoStmt(exp: PExpression) extends PActualStatement
 
 sealed trait PDeferrable extends PNode
-case class PDeferStmt(exp: PDeferrable) extends PActualStatement
+case class PDeferStmt(exp: PDeferrable) extends PActualStatement with PGhostifiableStatement
 
 case class PSelectStmt(send: Vector[PSelectSend], rec: Vector[PSelectRecv], aRec: Vector[PSelectAssRecv], sRec: Vector[PSelectShortRecv], dflt: Vector[PSelectDflt]) extends PActualStatement with PScope
 

--- a/src/test/resources/regressions/features/defer/defer-simple-04.gobra
+++ b/src/test/resources/regressions/features/defer/defer-simple-04.gobra
@@ -1,0 +1,16 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+pred Mem(x *int) {
+	acc(x)
+}
+
+ensures Mem(r)
+decreases
+func f() (r *int) {
+	x@ := 2
+	ghost defer fold Mem(&x)
+	return &x
+}


### PR DESCRIPTION
Just noticed that `defer` cannot be used in ghost contexts, which is useful when deferring a fold/unfold.