### PR TITLE
Fix duplicate type tags in the encoding

### DIFF
--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/TypeComponentImpl.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/TypeComponentImpl.scala
@@ -189,10 +189,12 @@ class TypeComponentImpl extends TypeComponent {
     * }
     */
   private def genPreciseEqualityAxioms(typeHead: TypeHead, args: Vector[vpr.Type])(ctx: Context): Unit = {
-    if (args.nonEmpty && !preciseTypes.contains(typeHead)) {
-      preciseTypes += typeHead
 
-      val name = serialize(typeHead)
+    val name = serialize(typeHead)
+
+    if (args.nonEmpty && !preciseTypes.contains(name)) {
+      preciseTypes += name
+
 
       val funArgDecl = vpr.LocalVarDecl("t", domainType)()
       val getterVarDecls = args.zipWithIndex map {
@@ -223,7 +225,9 @@ class TypeComponentImpl extends TypeComponent {
       genAxioms ::= axiom
     }
   }
-  private var preciseTypes: Set[TypeHead] = Set.empty
+
+  // Set of serialized type names of types (which guarantees that type synonyms are serialized to the same value).
+  private var preciseTypes: Set[String] = Set.empty
 
 
   /**
@@ -256,11 +260,11 @@ class TypeComponentImpl extends TypeComponent {
     */
   private def genTypeFunc(typeHead: TypeHead, args: Vector[vpr.Type])(ctx: Context): vpr.DomainFunc = {
 
-    if (genTypesMap.contains(typeHead)) {
-      genTypesMap(typeHead)
+    val name = serialize(typeHead)
+    if (genTypesMap.contains(name)) {
+      genTypesMap(name)
     } else {
 
-      val name = serialize(typeHead)
       val varsDecl = args.zipWithIndex.map{ case(t,i) => vpr.LocalVarDecl(s"p$i", t)() }
       val vars = varsDecl map (_.localVar)
 
@@ -315,12 +319,14 @@ class TypeComponentImpl extends TypeComponent {
       genAxioms ::= comparableAxiom
       genBehavioralSubtypeAxioms(ctx)
 
-      genTypesMap += (typeHead -> func)
+      genTypesMap += (name -> func)
 
       func
     }
   }
-  private var genTypesMap: Map[TypeHead, vpr.DomainFunc] = Map.empty
+
+  // Maps serialized type names (which guarantees that type synonyms are serialized to the same value) to DomainFunc.
+  private var genTypesMap: Map[String, vpr.DomainFunc] = Map.empty
 
   /** Type of viper expressions encoding Gobra types.  */
   override def typ()(ctx: Context): vpr.Type = domainType

--- a/src/test/resources/regressions/features/runes/type-equality.gobra
+++ b/src/test/resources/regressions/features/runes/type-equality.gobra
@@ -1,0 +1,9 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+func typeSynonymsAreEqual() {
+	assert type[int32] == type[rune]
+	assert type[uint8] == type[byte]
+}


### PR DESCRIPTION
As it stands, Gobra generates repeated occurrences of the following four functions, corresponding to the type tags of `int32` and `rune` (its synonym), and `int8` and `bytes` (also synonyms) (for some reason, this problem was never triggered in the CI before). This PR addresses that.

```
  function int32_Types(): Types
  unique function int32_Types_tag(): Int
  function byte_Types(): Types
  unique function byte_Types_tag(): Int
```