### PR TITLE
Add support for arrays of custom declared types

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/TypeTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/TypeTyping.scala
@@ -37,9 +37,6 @@ trait TypeTyping extends BaseTyping { this: TypeInfoImpl =>
 
     case _: PBoolType | _: PIntegerType | _: PFloatType | _: PStringType | _: PPermissionType => noMessages
 
-    case typ @ PArrayType(_, PNamedOperand(_)) =>
-      error(typ, s"arrays of custom declared types are currently not supported")
-
     case n @ PArrayType(len, t) => isType(t).out ++ {
       intConstantEval(len) match {
         case None => error(n, s"expected constant array length, but got $len")

--- a/src/test/resources/regressions/features/arrays/array-type-simple5.gobra
+++ b/src/test/resources/regressions/features/arrays/array-type-simple5.gobra
@@ -10,6 +10,5 @@ type Point struct {
 
 func foo() {
 	// should be implemented later, but does not work currently...
-	//:: ExpectedOutput(type_error)
 	var a [2]Point
 }

--- a/src/test/resources/regressions/features/arrays/array-type-simple5.gobra
+++ b/src/test/resources/regressions/features/arrays/array-type-simple5.gobra
@@ -9,6 +9,5 @@ type Point struct {
 }
 
 func foo() {
-	// should be implemented later, but does not work currently...
 	var a [2]Point
 }

--- a/src/test/resources/regressions/issues/000480.gobra
+++ b/src/test/resources/regressions/issues/000480.gobra
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package test
+
+type T struct{}
+
+func f() {
+	var exclusiveArray [3]T = [3]T{}
+	var sharedArray@   [3]T = [3]T{}
+
+	assert acc(&sharedArray)
+	assert acc(&sharedArray[0])
+}

--- a/src/test/resources/regressions/issues/000480.gobra
+++ b/src/test/resources/regressions/issues/000480.gobra
@@ -3,7 +3,9 @@
 
 package test
 
-type T struct{}
+type T struct{
+	i int
+}
 
 func f() {
 	var exclusiveArray [3]T = [3]T{}
@@ -11,4 +13,5 @@ func f() {
 
 	assert acc(&sharedArray)
 	assert acc(&sharedArray[0])
+	assert acc(&sharedArray[0].i)
 }


### PR DESCRIPTION
As discussed with @Felalolf, the current array encoding should be compatible with "custom declared types". This PR removes the type-checker's check that keeps one from declaring arrays of declared types.