### PR TITLE
Rename 'ReceiverNotInjective' -> 'QPAssertionNotInjective'

### DIFF
--- a/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
@@ -67,7 +67,7 @@ object DefaultErrorBackTranslator {
       //      case vprrea.InvalidPermMultiplication(offendingNode) =>
       case vprrea.MagicWandChunkNotFound(CertainSource(info)) =>
         MagicWandChunkNotFound(info)
-      case vprrea.ReceiverNotInjective(CertainSource(info)) =>
+      case vprrea.QPAssertionNotInjective(CertainSource(info)) =>
         ReceiverNotInjectiveReason(info)
       case vprrea.LabelledStateNotReached(CertainSource(info)) =>
         LabelledStateNotReached(info)


### PR DESCRIPTION
In the most recent version of Silver `viper.silver.verifier.reasons.ReceiverNotInjective` was renamed to `QPAssertionNotInjective`. I'm not sure if this is worth merging into master just yet for compatibility.