### PR TITLE
Remove redundant checks when comparing interfaces with the `nil` literal

### DIFF
--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
@@ -135,7 +135,7 @@ class InterfaceEncoding extends LeafTypeEncoding {
 
   /** also checks that the compared interface is comparable. */
   override def goEqual(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = default(super.goEqual(ctx)) {
-    case (lhs :: ctx.Interface(_), rhs :: ctx.Interface(_), src) if rhs.isInstanceOf[in.NilLit] =>
+    case (lhs :: ctx.Interface(_), rhs :: ctx.Interface(_), src) if lhs.isInstanceOf[in.NilLit] || rhs.isInstanceOf[in.NilLit] =>
       // Optimization:
       // The case where an interface value is compared to the nil literal is very common. In those cases,
       // we can skip the proof obligations that ensure that at least one of the operands is comparable.


### PR DESCRIPTION
It is very common to compare an interface value with the literal `nil`. Currently, this comparison is encoded as an equality, preceded by a check that one of the operands is comparable. This check is redundant and I removed it in this PR.