### PR TITLE
Remove unnecessary occurrences of the 'true' literal

### DIFF
--- a/src/main/scala/viper/gobra/translator/util/ViperUtil.scala
+++ b/src/main/scala/viper/gobra/translator/util/ViperUtil.scala
@@ -27,7 +27,12 @@ object ViperUtil {
   }
 
   def bigAnd(it: Iterable[Exp])(pos: Position, info: Info, errT: ErrorTrafo): Exp = {
-    it.foldLeft[Exp](TrueLit()(pos, info, errT)){case (l, r) => And(l, r)(pos, info, errT)}
+    it.headOption match {
+      case Some(hd) =>
+        val tl = it.tail
+        tl.foldLeft[Exp](hd){ case (accum, elem) => And(accum, elem)(pos, info, errT) }
+      case None => TrueLit()(pos, info, errT)
+    }
   }
 
   def seqn(ss: Vector[Stmt])(pos: Position, info: Info, errT: ErrorTrafo): Seqn = Seqn(ss, Vector.empty)(pos, info, errT)


### PR DESCRIPTION
Our encoding currently introduces unnecessary occurrences of the `true` literal. This PR eliminates those that are created by the method `bigAnd`.