### PR TITLE
Verify chopped parts in parallel

### DIFF
--- a/src/main/scala/viper/gobra/backend/BackendVerifier.scala
+++ b/src/main/scala/viper/gobra/backend/BackendVerifier.scala
@@ -64,7 +64,7 @@ object BackendVerifier {
           val programID = s"${config.taskName}_$idx"
           verifier.verify(programID, reporter, program)(executor).andThen { _ =>
             // this block ensures that progress messages are printed in order
-            this.synchronized { counter += 1; config.reporter report ChoppedProgressMessage(counter, num) }
+            this.synchronized { counter += 1; config.reporter report ChoppedProgressMessage(counter, num, idx) }
           }
         }
 

--- a/src/main/scala/viper/gobra/reporting/Message.scala
+++ b/src/main/scala/viper/gobra/reporting/Message.scala
@@ -83,9 +83,9 @@ case class GobraEntityFailureMessage(taskName: String, verifier: String, entity:
     s"cached=$cached)"
 }
 
-case class ChoppedProgressMessage(idx: Int, of: Int) extends GobraMessage {
+case class ChoppedProgressMessage(status: Int, total: Int, taskIdx: Int) extends GobraMessage {
   override val name: String = "chopped_progress_message"
-  override def toString: String = s"$name(idx=$idx,of=$of)"
+  override def toString: String = s"$name(progress=$status/$total,taskId=$taskIdx)"
 }
 
 case class PreprocessedInputMessage(input: String, preprocessedContent: () => String) extends GobraMessage {


### PR DESCRIPTION
Currently, chopping a program in multiple parts causes all parts to be verified sequentially. This PR enables concurrent verification of those parts.