### PR TITLE
Add option to disable the behaviour of "moreCompleteExhale"

### DIFF
--- a/src/main/scala/viper/gobra/backend/ViperBackends.scala
+++ b/src/main/scala/viper/gobra/backend/ViperBackends.scala
@@ -25,7 +25,9 @@ object ViperBackends {
       var options: Vector[String] = Vector.empty
       options ++= Vector("--logLevel", "ERROR")
       options ++= Vector("--disableCatchingExceptions")
-      options ++= Vector("--enableMoreCompleteExhale")
+      if (!config.disableMoreCompleteExhale) {
+        options ++= Vector("--enableMoreCompleteExhale")
+      }
       if (config.assumeInjectivityOnInhale) {
         options ++= Vector("--assumeInjectivityOnInhale")
       }
@@ -96,7 +98,9 @@ object ViperBackends {
       var options: Vector[String] = Vector.empty
       options ++= Vector("--logLevel", "ERROR")
       options ++= Vector("--disableCatchingExceptions")
-      options ++= Vector("--enableMoreCompleteExhale")
+      if (!config.disableMoreCompleteExhale) {
+        options ++= Vector("--enableMoreCompleteExhale")
+      }
       if (config.assumeInjectivityOnInhale) {
         options ++= Vector("--assumeInjectivityOnInhale")
       }

--- a/src/main/scala/viper/gobra/backend/ViperBackends.scala
+++ b/src/main/scala/viper/gobra/backend/ViperBackends.scala
@@ -15,11 +15,9 @@ trait ViperBackend {
   def create(exePaths: Vector[String], config: Config)(implicit executor: GobraExecutionContext): ViperVerifier
 }
 
-trait ParallelizableBackend extends ViperBackend
-
 object ViperBackends {
 
-  object SiliconBackend extends ViperBackend with ParallelizableBackend {
+  object SiliconBackend extends ViperBackend {
     def create(exePaths: Vector[String], config: Config)(implicit executor: GobraExecutionContext): Silicon = {
 
       var options: Vector[String] = Vector.empty
@@ -93,7 +91,7 @@ object ViperBackends {
       server = None
   }
 
-  case class ViperServerWithSilicon(initialServer: Option[ViperCoreServer] = None) extends ViperServerBackend(initialServer) with ParallelizableBackend {
+  case class ViperServerWithSilicon(initialServer: Option[ViperCoreServer] = None) extends ViperServerBackend(initialServer) {
     override def getViperVerifierConfig(exePaths: Vector[String], config: Config): ViperVerifierConfig = {
       var options: Vector[String] = Vector.empty
       options ++= Vector("--logLevel", "ERROR")

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -61,6 +61,7 @@ object ConfigDefaults {
   lazy val DefaultTaskName: String = "gobra-task"
   lazy val DefaultAssumeInjectivityOnInhale: Boolean = true
   lazy val DefaultParallelizeBranches: Boolean = false
+  lazy val DefaultDisableMoreCompleteExhale: Boolean = false
 }
 
 case class Config(
@@ -107,6 +108,7 @@ case class Config(
                    // if enabled, and if the chosen backend is either SILICON or VSWITHSILICON,
                    // branches will be verified in parallel
                    parallelizeBranches: Boolean = ConfigDefaults.DefaultParallelizeBranches,
+                   disableMoreCompleteExhale: Boolean = ConfigDefaults.DefaultDisableMoreCompleteExhale,
 ) {
 
   def merge(other: Config): Config = {
@@ -147,6 +149,7 @@ case class Config(
       onlyFilesWithHeader = onlyFilesWithHeader || other.onlyFilesWithHeader,
       assumeInjectivityOnInhale = assumeInjectivityOnInhale || other.assumeInjectivityOnInhale,
       parallelizeBranches = parallelizeBranches,
+      disableMoreCompleteExhale = disableMoreCompleteExhale,
     )
   }
 
@@ -188,6 +191,7 @@ case class BaseConfig(gobraDirectory: Path = ConfigDefaults.DefaultGobraDirector
                       onlyFilesWithHeader: Boolean = ConfigDefaults.DefaultOnlyFilesWithHeader,
                       assumeInjectivityOnInhale: Boolean = ConfigDefaults.DefaultAssumeInjectivityOnInhale,
                       parallelizeBranches: Boolean = ConfigDefaults.DefaultParallelizeBranches,
+                      disableMoreCompleteExhale: Boolean = ConfigDefaults.DefaultDisableMoreCompleteExhale,
                      ) {
   def shouldParse: Boolean = true
   def shouldTypeCheck: Boolean = !shouldParseOnly
@@ -237,6 +241,7 @@ trait RawConfig {
     onlyFilesWithHeader = baseConfig.onlyFilesWithHeader,
     assumeInjectivityOnInhale = baseConfig.assumeInjectivityOnInhale,
     parallelizeBranches = baseConfig.parallelizeBranches,
+    disableMoreCompleteExhale = baseConfig.disableMoreCompleteExhale,
   )
 }
 
@@ -571,6 +576,14 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     noshort = true,
   )
 
+  // TODO: check that this flag is only passed with silicon or VSWITHSILICON
+  val disableMoreCompleteExhale: ScallopOption[Boolean] = opt[Boolean](
+    name = "disableMoreCompleteExhale",
+    descr = "Do not pass the flag --enableMoreCompleteExhale to Viper",
+    default = Some(ConfigDefaults.DefaultParallelizeBranches),
+    noshort = true,
+  )
+
   /**
     * Exception handling
     */
@@ -690,5 +703,6 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     onlyFilesWithHeader = onlyFilesWithHeader(),
     assumeInjectivityOnInhale = assumeInjectivityOnInhale(),
     parallelizeBranches = parallelizeBranches(),
+    disableMoreCompleteExhale = disableMoreCompleteExhale(),
   )
 }


### PR DESCRIPTION
In some cases in SCION, I observed that not passing the flag `--enableMoreCompleteExhale` to silicon improves performance drastically, without any observable side effects. This PR introduces a way to disable this default behaviour whenever desired.