### PR TITLE
Constant propagation

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -266,9 +266,9 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     * be easily extended to perform more transformations
     */
   private def performInternalTransformations(program: Program, config: Config, pkgInfo: PackageInfo): Either[Vector[VerifierError], Program] = {
-    // having constant propagation before overflow checking will not lead to duplication of errors if
-    // overflow checks are enabled, given that all overflows in constant declarations can be found by the
-    // well-formedness checks
+    // constant propagation does not cause duplication of verification errors caused
+    // by overflow checks (if enabled) because all overflows in constant declarations 
+    // can be found by the well-formedness checks.
     var transformations: Vector[InternalTransform] = Vector(CGEdgesTerminationTransform, ConstantPropagation)
     if (config.checkOverflows) {
       transformations :+= OverflowChecksTransform

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -14,7 +14,7 @@ import com.typesafe.scalalogging.StrictLogging
 import org.slf4j.LoggerFactory
 import viper.gobra.ast.frontend.PPackage
 import viper.gobra.ast.internal.Program
-import viper.gobra.ast.internal.transform.{CGEdgesTerminationTransform, InternalTransform, OverflowChecksTransform}
+import viper.gobra.ast.internal.transform.{CGEdgesTerminationTransform, ConstantPropagation, InternalTransform, OverflowChecksTransform}
 import viper.gobra.backend.BackendVerifier
 import viper.gobra.frontend.info.{Info, TypeInfo}
 import viper.gobra.frontend.{Config, Desugar, PackageInfo, Parser, ScallopGobraConfig}
@@ -266,7 +266,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     * be easily extended to perform more transformations
     */
   private def performInternalTransformations(program: Program, config: Config, pkgInfo: PackageInfo): Either[Vector[VerifierError], Program] = {
-    var transformations: Vector[InternalTransform] = Vector(CGEdgesTerminationTransform)
+    var transformations: Vector[InternalTransform] = Vector(CGEdgesTerminationTransform, ConstantPropagation)
     if (config.checkOverflows) {
       transformations :+= OverflowChecksTransform
     }

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -266,6 +266,9 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     * be easily extended to perform more transformations
     */
   private def performInternalTransformations(program: Program, config: Config, pkgInfo: PackageInfo): Either[Vector[VerifierError], Program] = {
+    // having constant propagation before overflow checking will not lead to duplication of errors if
+    // overflow checks are enabled, given that all overflows in constant declarations can be found by the
+    // well-formedness checks
     var transformations: Vector[InternalTransform] = Vector(CGEdgesTerminationTransform, ConstantPropagation)
     if (config.checkOverflows) {
       transformations :+= OverflowChecksTransform

--- a/src/main/scala/viper/gobra/ast/internal/Program.scala
+++ b/src/main/scala/viper/gobra/ast/internal/Program.scala
@@ -31,24 +31,24 @@ case class Program(
 }
 
 class LookupTable(
-                   private val definedTypes: Map[(String, Addressability), Type] = Map.empty,
-                   private val definedMethods: Map[MethodProxy, MethodLikeMember] = Map.empty,
-                   private val definedFunctions: Map[FunctionProxy, FunctionLikeMember] = Map.empty,
-                   private val definedMPredicates: Map[MPredicateProxy, MPredicateLikeMember] = Map.empty,
-                   private val definedFPredicates: Map[FPredicateProxy, FPredicateLikeMember] = Map.empty,
-                   private val definedFuncLiterals: Map[FunctionLitProxy, FunctionLitLike] = Map.empty,
+                   private[internal] val definedTypes: Map[(String, Addressability), Type] = Map.empty,
+                   private[internal] val definedMethods: Map[MethodProxy, MethodLikeMember] = Map.empty,
+                   private[internal] val definedFunctions: Map[FunctionProxy, FunctionLikeMember] = Map.empty,
+                   private[internal] val definedMPredicates: Map[MPredicateProxy, MPredicateLikeMember] = Map.empty,
+                   private[internal] val definedFPredicates: Map[FPredicateProxy, FPredicateLikeMember] = Map.empty,
+                   private[internal] val definedFuncLiterals: Map[FunctionLitProxy, FunctionLitLike] = Map.empty,
 
                    /**
                    * only has to be defined on types that implement an interface // might change depending on how embedding support changes
                    * SortedSet is used to achieve a consistent ordering of members across runs of Gobra
                    */
-                   private val directMemberProxies: Map[Type, SortedSet[MemberProxy]] = Map.empty,
+                   private[internal] val directMemberProxies: Map[Type, SortedSet[MemberProxy]] = Map.empty,
                    /**
                    * empty interface does not have to be included
                    * SortedSet is used to achieve a consistent ordering of members across runs of Gobra
                    */
-                   private val directInterfaceImplementations: Map[InterfaceT, SortedSet[Type]] = Map.empty,
-                   private val implementationProofPredicateAliases: Map[(Type, InterfaceT, String), FPredicateProxy] = Map.empty,
+                   private[internal] val directInterfaceImplementations: Map[InterfaceT, SortedSet[Type]] = Map.empty,
+                   private[internal] val implementationProofPredicateAliases: Map[(Type, InterfaceT, String), FPredicateProxy] = Map.empty,
                  ) {
   def lookup(t: DefinedT): Type = definedTypes(t.name, t.addressability)
   def lookup(m: MethodProxy): MethodLikeMember = definedMethods(m)

--- a/src/main/scala/viper/gobra/ast/internal/transform/ConstantPropagation.scala
+++ b/src/main/scala/viper/gobra/ast/internal/transform/ConstantPropagation.scala
@@ -1,0 +1,38 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2021 ETH Zurich.
+
+package viper.gobra.ast.internal.transform
+
+import viper.gobra.ast.{internal => in}
+import viper.gobra.util.Violation
+
+object ConstantPropagation extends InternalTransform {
+  override def name(): String = "constant_propagation"
+
+  /**
+    * Program-to-program transformation
+    */
+  override def transform(p: in.Program): in.Program = {
+    val (constDecls, noConstDecls) = p.members partition(_.isInstanceOf[in.GlobalConstDecl])
+    val progNoConsts = in.Program(
+      types = p.types,
+      members = noConstDecls,
+      table = p.table,
+    )(p.info)
+
+    println(p.table.getMPredicates.forall(x => noConstDecls.contains(x)))
+    println(p.table.getFPredicates.forall(x => noConstDecls.contains(x)))
+    p.table
+    progNoConsts transform {
+      case c: in.GlobalConst =>
+        val litOpt = constDecls collectFirst { case in.GlobalConstDecl(l, r) if l == c => r.withInfo(c.info) }
+        litOpt match {
+          case Some(l) => l
+          case _ => Violation.violation(s"Did not find declaration of constant $c")
+        }
+    }
+  }
+}

--- a/src/main/scala/viper/gobra/ast/internal/transform/ConstantPropagation.scala
+++ b/src/main/scala/viper/gobra/ast/internal/transform/ConstantPropagation.scala
@@ -23,9 +23,6 @@ object ConstantPropagation extends InternalTransform {
       table = p.table,
     )(p.info)
 
-    println(p.table.getMPredicates.forall(x => noConstDecls.contains(x)))
-    println(p.table.getFPredicates.forall(x => noConstDecls.contains(x)))
-    p.table
     progNoConsts transform {
       case c: in.GlobalConst =>
         val litOpt = constDecls collectFirst { case in.GlobalConstDecl(l, r) if l == c => r.withInfo(c.info) }

--- a/src/main/scala/viper/gobra/ast/internal/transform/ConstantPropagation.scala
+++ b/src/main/scala/viper/gobra/ast/internal/transform/ConstantPropagation.scala
@@ -12,18 +12,9 @@ import viper.gobra.util.Violation
 object ConstantPropagation extends InternalTransform {
   override def name(): String = "constant_propagation"
 
-  /**
-    * Program-to-program transformation
-    */
   override def transform(p: in.Program): in.Program = {
-    val (constDecls, noConstDecls) = p.members partition(_.isInstanceOf[in.GlobalConstDecl])
-    val progNoConsts = in.Program(
-      types = p.types,
-      members = noConstDecls,
-      table = p.table,
-    )(p.info)
-
-    progNoConsts transform {
+    val (constDecls, noConstDecls) = p.members.partition(_.isInstanceOf[in.GlobalConstDecl])
+    def propagate[T <: in.Node](n: T): T = n.transform{
       case c: in.GlobalConst =>
         val litOpt = constDecls collectFirst { case in.GlobalConstDecl(l, r) if l == c => r.withInfo(c.info) }
         litOpt match {
@@ -31,5 +22,24 @@ object ConstantPropagation extends InternalTransform {
           case _ => Violation.violation(s"Did not find declaration of constant $c")
         }
     }
+
+    // TODO: duplicated work can be avoided - currently, propagate is applied twice per member
+    val newTable = new in.LookupTable(
+      definedTypes = p.table.definedTypes,
+      definedMethods = p.table.definedMethods.view.mapValues(propagate).toMap,
+      definedFunctions = p.table.definedFunctions.view.mapValues(propagate).toMap,
+      definedMPredicates = p.table.definedMPredicates.view.mapValues(propagate).toMap,
+      definedFPredicates = p.table.definedFPredicates.view.mapValues(propagate).toMap,
+      definedFuncLiterals = p.table.definedFuncLiterals.view.mapValues(propagate).toMap,
+      directMemberProxies = p.table.directMemberProxies,
+      directInterfaceImplementations = p.table.directInterfaceImplementations,
+      implementationProofPredicateAliases = p.table.implementationProofPredicateAliases,
+    )
+
+    in.Program(
+      types = p.types,
+      members = noConstDecls.map(propagate), // does not emit constant declarations
+      table = newTable,
+    )(p.info)
   }
 }


### PR DESCRIPTION
This PR introduces an optimization that reduces the size of the emitted Viper code by folding all constants. Doing this allows us to save a domain definition and one domain function per constant