### PR TITLE
Create gobrafied debug files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ tmp/
 sync/
 
 logger.log
+.DS_Store
 
 *.go.*
 *.gobra.*

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -44,6 +44,10 @@ object Parser {
   def parse(input: Vector[Source], pkgInfo: PackageInfo, specOnly: Boolean = false)(config: Config): Either[Vector[VerifierError], PPackage] = {
     val sources = input
       .map(Gobrafier.gobrafy)
+      .map(s => {
+        config.reporter report PreprocessedInputMessage(s.name, () => s.content)
+        s
+      })
     for {
       parseAst <- parseSources(sources, pkgInfo, specOnly)(config)
       postprocessedAst <- new ImportPostprocessor(parseAst.positions.positions).postprocess(parseAst)(config)

--- a/src/main/scala/viper/gobra/reporting/Reporter.scala
+++ b/src/main/scala/viper/gobra/reporting/Reporter.scala
@@ -47,6 +47,7 @@ case class FileWriterReporter(name: String = "filewriter_reporter",
     Logger(LoggerFactory.getLogger(getClass.getName))
 
   override def report(msg: GobraMessage): Unit = msg match {
+    case PreprocessedInputMessage(input, content) if unparse => write(input, "gobrafied", content())
     case ParsedInputMessage(input, program) if unparse => write(input, "unparsed", program().formatted)
     case TypeCheckSuccessMessage(inputs, _, _, _, erasedGhostCode, goifiedGhostCode) =>
       if (eraseGhost) write(inputs, "ghostLess", erasedGhostCode())


### PR DESCRIPTION
If `unparse` is enabled, `.gobrafied` files will be created with the gobrafied content of the input files.
This is useful to count the number of lines of specification in the following way:
LOC = lines of code of a `.go` file counted by the usual tools
LOS = lines of code of a `.gobrafied` file - LOC + hybrid lines

A hybrid line is a line that contains actual code and annotations. The following command can be used to count these hybrid lines:
```
awk 'fname != FILENAME { printf "%s: %s\n", fname, count; fname = FILENAME; count = 0 } /.*\/\*@.*@\*\/.*/ { count++; total++ } END { print total }' $(find . -name '*.go' -or -name '*.gobra')
```