### PR TITLE
CLI Option for Disabling Support for Global Variables

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -62,6 +62,7 @@ object ConfigDefaults {
   lazy val DefaultAssumeInjectivityOnInhale: Boolean = true
   lazy val DefaultParallelizeBranches: Boolean = false
   lazy val DefaultDisableMoreCompleteExhale: Boolean = false
+  lazy val DefaultDisableGlobalVars: Boolean = false
 }
 
 case class Config(
@@ -109,6 +110,7 @@ case class Config(
                    // branches will be verified in parallel
                    parallelizeBranches: Boolean = ConfigDefaults.DefaultParallelizeBranches,
                    disableMoreCompleteExhale: Boolean = ConfigDefaults.DefaultDisableMoreCompleteExhale,
+                   disableGlobalVars: Boolean = ConfigDefaults.DefaultDisableGlobalVars,
 ) {
 
   def merge(other: Config): Config = {
@@ -150,6 +152,7 @@ case class Config(
       assumeInjectivityOnInhale = assumeInjectivityOnInhale || other.assumeInjectivityOnInhale,
       parallelizeBranches = parallelizeBranches,
       disableMoreCompleteExhale = disableMoreCompleteExhale,
+      disableGlobalVars = disableGlobalVars || other.disableGlobalVars,
     )
   }
 
@@ -192,6 +195,7 @@ case class BaseConfig(gobraDirectory: Path = ConfigDefaults.DefaultGobraDirector
                       assumeInjectivityOnInhale: Boolean = ConfigDefaults.DefaultAssumeInjectivityOnInhale,
                       parallelizeBranches: Boolean = ConfigDefaults.DefaultParallelizeBranches,
                       disableMoreCompleteExhale: Boolean = ConfigDefaults.DefaultDisableMoreCompleteExhale,
+                      disableGlobalVars: Boolean = ConfigDefaults.DefaultDisableGlobalVars,
                      ) {
   def shouldParse: Boolean = true
   def shouldTypeCheck: Boolean = !shouldParseOnly
@@ -242,6 +246,7 @@ trait RawConfig {
     assumeInjectivityOnInhale = baseConfig.assumeInjectivityOnInhale,
     parallelizeBranches = baseConfig.parallelizeBranches,
     disableMoreCompleteExhale = baseConfig.disableMoreCompleteExhale,
+    disableGlobalVars = baseConfig.disableGlobalVars,
   )
 }
 
@@ -583,6 +588,13 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     noshort = true,
   )
 
+  val disableGlobalVars: ScallopOption[Boolean] = opt[Boolean](
+    name = "disableGlobalVars",
+    descr = "Disables the support for global variables and thus does not require that the sources of all transitively included packages can be located by Gobra.",
+    default = Some(ConfigDefaults.DefaultDisableGlobalVars),
+    noshort = true,
+  )
+
   /**
     * Exception handling
     */
@@ -715,5 +727,6 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     assumeInjectivityOnInhale = assumeInjectivityOnInhale(),
     parallelizeBranches = parallelizeBranches(),
     disableMoreCompleteExhale = disableMoreCompleteExhale(),
+    disableGlobalVars = disableGlobalVars(),
   )
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ImportTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ImportTyping.scala
@@ -14,13 +14,17 @@ import viper.gobra.frontend.info.implementation.TypeInfoImpl
 trait ImportTyping extends BaseTyping { this: TypeInfoImpl =>
 
   lazy val wellDefImport: WellDefinedness[PImport] = createWellDef { imp =>
-    forceNonLazyImport(imp.importPath, imp)
-    imp match {
+    (if (config.disableGlobalVars) {
+      imp.importPres.flatMap(importPre => message(importPre, s"Support for global variables has been disabled but an import precondition has been found"))
+    } else {
+      forceNonLazyImport(imp.importPath, imp)
+      noMessages
+    }) ++ (imp match {
       case _: PExplicitQualifiedImport => noMessages
       case _: PUnqualifiedImport => noMessages
       // this case should never occur as these nodes should get converted in the parse postprocessing step
       case n: PImplicitQualifiedImport => message(n, s"Explicit qualifier could not be derived")
-    }
+    })
   }
 
   // This method forces a package to be processed non-lazily - every import can cause side effects,

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ProgramTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ProgramTyping.scala
@@ -7,7 +7,7 @@
 package viper.gobra.frontend.info.implementation.typing
 
 import org.bitbucket.inkytonik.kiama.util.Entity
-import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error}
+import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error, message}
 import viper.gobra.ast.frontend.{PExpression, POld, PPackage, PProgram, PVarDecl}
 import viper.gobra.frontend.info.base.{SymbolTable => st}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
@@ -18,30 +18,34 @@ trait ProgramTyping extends BaseTyping { this: TypeInfoImpl =>
 
   lazy val wellDefProgram: WellDefinedness[PProgram] = createWellDef {
     case PProgram(_, posts, imports, members) =>
-      // Obtains global variable declarations sorted by the order in which they appear in the file
-      val sortedByPosDecls: Vector[PVarDecl] = {
-        val unsortedDecls: Vector[PVarDecl] = members.collect{ case d: PVarDecl => d }
-        // we require a package to be able to obtain position information
-        val pkgOpt: Option[PPackage] = unsortedDecls.headOption.flatMap(tryEnclosingPackage)
-        // sort declarations by the order in which they appear in the program
-        unsortedDecls.sortBy{ decl =>
-          pkgOpt.get.positions.positions.getStart(decl) match {
-            case Some(pos) => (pos.line, pos.column)
-            case _ => Violation.violation(s"Could not find position information of $decl.")
+      if (config.disableGlobalVars) {
+        posts.flatMap(post => message(post, s"Support for global variables has been disabled but an init postcondition has been found"))
+      } else {
+        // Obtains global variable declarations sorted by the order in which they appear in the file
+        val sortedByPosDecls: Vector[PVarDecl] = {
+          val unsortedDecls: Vector[PVarDecl] = members.collect{ case d: PVarDecl => d }
+          // we require a package to be able to obtain position information
+          val pkgOpt: Option[PPackage] = unsortedDecls.headOption.flatMap(tryEnclosingPackage)
+          // sort declarations by the order in which they appear in the program
+          unsortedDecls.sortBy{ decl =>
+            pkgOpt.get.positions.positions.getStart(decl) match {
+              case Some(pos) => (pos.line, pos.column)
+              case _ => Violation.violation(s"Could not find position information of $decl.")
+            }
           }
         }
-      }
-      // HACK: without this explicit check, Gobra does not find repeated declarations
-      //       of global variables. This has to do with the changes introduced in PR #186.
-      //       We need this check nonetheless because the checks performed in the "true" branch
-      //       assume that the ids are well-defined.
-      val idsOkMsgs = sortedByPosDecls.flatMap(d => d.left).flatMap(l => wellDefID(l).out)
-      if (idsOkMsgs.isEmpty) {
-        globalDeclSatisfiesDepOrder(sortedByPosDecls) ++
-          hasOldExpression(posts) ++
-          hasOldExpression(imports.flatMap(_.importPres))
-      } else {
-        idsOkMsgs
+        // HACK: without this explicit check, Gobra does not find repeated declarations
+        //       of global variables. This has to do with the changes introduced in PR #186.
+        //       We need this check nonetheless because the checks performed in the "true" branch
+        //       assume that the ids are well-defined.
+        val idsOkMsgs = sortedByPosDecls.flatMap(d => d.left).flatMap(l => wellDefID(l).out)
+        if (idsOkMsgs.isEmpty) {
+          globalDeclSatisfiesDepOrder(sortedByPosDecls) ++
+            hasOldExpression(posts) ++
+            hasOldExpression(imports.flatMap(_.importPres))
+        } else {
+          idsOkMsgs
+        }
       }
   }
 

--- a/src/test/resources/regressions/features/globals/globals-disabled-fail01.gobra
+++ b/src/test/resources/regressions/features/globals/globals-disabled-fail01.gobra
@@ -1,0 +1,58 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// this is the same file as `globals-simple01.gobra` but additionally provides the `--disableGlobalVars` flag to Gobra.
+// ##(--disableGlobalVars)
+
+//:: ExpectedOutput(type_error)
+initEnsures acc(&A) && acc(&B) && acc(&C, 1/2)
+package pkg
+
+//:: ExpectedOutput(type_error)
+importRequires true
+import "fmt"
+
+import (
+    //:: ExpectedOutput(type_error)
+	importRequires true
+	//:: ExpectedOutput(type_error)
+	importRequires true
+	"bytes"
+	//:: ExpectedOutput(type_error)
+	importRequires true
+	"sync"
+)
+
+
+//:: ExpectedOutput(type_error)
+var A int = 0
+//:: ExpectedOutput(type_error)
+var B, C = f()
+//:: ExpectedOutput(type_error)
+var _ = g()
+//:: ExpectedOutput(type_error)
+var D struct{}
+
+decreases
+func f() (int, bool)
+
+decreases
+func g() interface{}
+
+requires acc(&A, 1/2) && A == 1
+ensures  acc(&A, 1/2)
+func testRead() {
+	var v1 int = A
+	assert v1 == 1
+}
+
+requires acc(&C) && C
+func testWrite() {
+	C = false
+}
+
+// Variable hiding works correctly, as in Go
+func tesVarHiding() {
+	var A int = 0
+	assert A == 0
+}


### PR DESCRIPTION
This might be another slightly controversial PR :P 
I just had again a case where Gobra wanted me to create "fake" source files for some transitively imported packages.
I'm even on the fence with myself whether I should actually do it or use my option but in any case it might be handy to (temporarily or not) disable the support for global variables.
I reject a program if it's using global variables, init postconditions or import preconditions. Did I forget any other check?