### PR TITLE
Fix lazy generation of the string domain

### DIFF
--- a/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
@@ -129,7 +129,7 @@ class StringEncoding extends LeafTypeEncoding {
   override def finalize(addMemberFn: vpr.Member => Unit): Unit = {
     if (isUsed) {
       addMemberFn(genDomain())
-      addMemberFn(strSlice)
+      if (strSliceIsUsed) { addMemberFn(strSlice) }
       byteSliceToStrFuncGenerator.finalize(addMemberFn)
     }
   }
@@ -184,7 +184,9 @@ class StringEncoding extends LeafTypeEncoding {
     * where s is a string id and l and r are the lower and upper bounds of the slice
     */
   private val strSliceName: String = "strSlice"
-  val strSlice: vpr.Function = {
+  private var strSliceIsUsed = false
+  lazy val strSlice: vpr.Function = {
+    strSliceIsUsed = true
     val argS = vpr.LocalVarDecl("s", stringType)()
     val argL = vpr.LocalVarDecl("l", vpr.Int)()
     val argH = vpr.LocalVarDecl("h", vpr.Int)()


### PR DESCRIPTION
Currently, the `String` domain is always generated, even if it is not used because function `strSlice` is marked as non-lazy. This PR addresses that.