### PR TITLE
Improving the Import of Termination Axioms

### DIFF
--- a/src/main/scala/viper/gobra/reporting/Message.scala
+++ b/src/main/scala/viper/gobra/reporting/Message.scala
@@ -166,7 +166,7 @@ case class GeneratedViperMessage(taskName: String, inputs: Vector[String], vprAs
   override val name: String = s"generated_viper_message"
 
   override def toString: String = s"generated_viper_message(" +
-    s"taskName=$taskName"
+    s"taskName=$taskName" +
     s"files=$inputs, " +
     s"vprFormated=$vprAstFormatted)"
 

--- a/src/main/scala/viper/gobra/translator/Translator.scala
+++ b/src/main/scala/viper/gobra/translator/Translator.scala
@@ -43,15 +43,13 @@ object Translator {
     transformedTask
   }
 
+  /**
+    * sorts AST members alphabetically to ease the comparison of (similar) Viper ASTs
+    */
   def sortAst(program: vpr.Program): vpr.Program = {
-    implicit def domainOrdering: Ordering[vpr.Domain] = Ordering.by(_.name)
-    implicit def domainFnOrdering: Ordering[vpr.DomainFunc] = Ordering.by(_.name)
-    implicit def domainAxOrdering: Ordering[vpr.DomainAxiom] = Ordering.by(FastPrettyPrinter.pretty(_))
-    implicit def fieldOrdering: Ordering[vpr.Field] = Ordering.by(_.name)
-    implicit def functionOrdering: Ordering[vpr.Function] = Ordering.by(_.name)
-    implicit def predicateOrdering: Ordering[vpr.Predicate] = Ordering.by(_.name)
-    implicit def methodOrdering: Ordering[vpr.Method] = Ordering.by(_.name)
-    implicit def extensionOrdering: Ordering[vpr.ExtensionMember] = Ordering.by(_.name)
+    lazy val memberOrdering: Ordering[vpr.Member] = Ordering.by(_.name)
+    implicit lazy val domainFnOrdering: Ordering[vpr.DomainFunc] = Ordering.by(_.name)
+    implicit lazy val domainAxOrdering: Ordering[vpr.DomainAxiom] = Ordering.by(FastPrettyPrinter.pretty(_))
 
     def sortDomain(domain: vpr.Domain): vpr.Domain = {
       vpr.Domain(
@@ -63,12 +61,12 @@ object Translator {
     }
 
     vpr.Program(
-      program.domains.map(sortDomain).sorted,
-      program.fields.sorted,
-      program.functions.sorted,
-      program.predicates.sorted,
-      program.methods.sorted,
-      program.extensions.sorted,
+      program.domains.map(sortDomain).sorted(memberOrdering),
+      program.fields.sorted(memberOrdering),
+      program.functions.sorted(memberOrdering),
+      program.predicates.sorted(memberOrdering),
+      program.methods.sorted(memberOrdering),
+      program.extensions.sorted(memberOrdering),
     )(program.pos, program.info, program.errT)
   }
 }

--- a/src/main/scala/viper/gobra/translator/Translator.scala
+++ b/src/main/scala/viper/gobra/translator/Translator.scala
@@ -24,8 +24,6 @@ object Translator {
     val translationConfig = new DfltTranslatorConfig()
     val programTranslator = new ProgramsImpl()
     val task = programTranslator.translate(program)(translationConfig)
-    // we report the un-transformed program as this is much more readable
-    config.reporter report GeneratedViperMessage(config.taskName, config.packageInfoInputMap(pkgInfo).map(_.name), () => sortAst(task.program), () => task.backtrack)
 
     if (config.checkConsistency) {
       val errors = task.program.checkTransitively
@@ -37,9 +35,12 @@ object Translator {
       new TerminationTransformer
     )
 
-    transformers.foldLeft(task) {
+    val transformedTask = transformers.foldLeft(task) {
       case (t, transformer) => transformer.transform(t)
     }
+
+    config.reporter report GeneratedViperMessage(config.taskName, config.packageInfoInputMap(pkgInfo).map(_.name), () => sortAst(transformedTask.program), () => transformedTask.backtrack)
+    transformedTask
   }
 
   def sortAst(program: vpr.Program): vpr.Program = {

--- a/src/main/scala/viper/gobra/translator/transformers/TerminationTransformer.scala
+++ b/src/main/scala/viper/gobra/translator/transformers/TerminationTransformer.scala
@@ -6,13 +6,13 @@
 
 package viper.gobra.translator.transformers
 import java.nio.file.Path
-
 import viper.gobra.backend.BackendVerifier
 import viper.gobra.util.Violation
 import viper.silicon.Silicon
 import viper.silver.{ast => vpr}
 import viper.silver.frontend.{DefaultStates, ViperAstProvider}
-import viper.silver.plugin.standard.termination.TerminationPlugin
+import viper.silver.plugin.standard.predicateinstance.PredicateInstance.PredicateInstanceDomainName
+import viper.silver.plugin.standard.termination.{DecreasesTuple, TerminationPlugin}
 import viper.silver.reporter.{NoopReporter, Reporter}
 import viper.silver.plugin.standard.predicateinstance.PredicateInstancePlugin
 
@@ -26,9 +26,33 @@ class TerminationTransformer extends ViperTransformer {
     // constructs a separate Viper program (as a string) that should be parsed
     // after parsing this separate Viper program, the resulting AST is combined with `task`
 
+    val allImport = "decreases/all.vpr"
+    def type2Import(typ: vpr.Type): String = typ match {
+      case vpr.Bool => "decreases/bool.vpr"
+      case vpr.Int => "decreases/int.vpr"
+      case vpr.MultisetType(_) => "decreases/multiset.vpr"
+      case vpr.Perm => "decreases/rational.vpr"
+      case vpr.Ref => "decreases/ref.vpr"
+      case vpr.SeqType(_) => "decreases/seq.vpr"
+      case vpr.SetType(_) => "decreases/set.vpr"
+      case vpr.DomainType(name, _) if name == PredicateInstanceDomainName => "decreases/predicate_instance.vpr"
+      case _ => allImport // fallback
+    }
+
+    // find the types of all expressions used as decreases measues
+    val measureTypes = task.program.deepCollect {
+      case DecreasesTuple(tupleExpressions, _) => tupleExpressions.map(_.typ)
+    }.flatten.distinct
+    // map these types to the respective files that should be imported
+    val imports = measureTypes
+      .map(type2Import)
+      .distinct
+    // if `allImport` is in the list of files that should be imported, we can ignore all others and instead only import
+    // `allImport`
+    val importsAll = imports.contains(allImport)
     /** list of Viper standard imports that should be parsed */
-    val imports = Seq("decreases/all.vpr")
-    val progWithImports = imports.map(p => s"import <${p}>").mkString("\n")
+    val filteredImports = if (importsAll) Seq(allImport) else imports
+    val progWithImports = filteredImports.map(p => s"import <${p}>").mkString("\n")
     val vprProgram = parseVpr(progWithImports)
     combine(task, vprProgram)
   }


### PR DESCRIPTION
This PR optimizes the import of axioms for termination measures to only import those that are actually needed based on the type of termination measure tuples.

Furthermore, this PR sorts the Viper members reported by `GeneratedViperMessage`