### PR TITLE
Simplify encoding of `NewSliceLit`

### DIFF
--- a/src/main/scala/viper/gobra/translator/context/Context.scala
+++ b/src/main/scala/viper/gobra/translator/context/Context.scala
@@ -77,6 +77,8 @@ trait Context {
 
   def initialization(x: in.Location): CodeWriter[vpr.Stmt] = typeEncoding.initialization(this)(x)
 
+  def allocation(x: in.Location): CodeWriter[vpr.Stmt] = typeEncoding.allocate(this)(x)
+
   def assignment(x: in.Assignee, rhs: in.Expr)(src: in.Node): CodeWriter[vpr.Stmt] = typeEncoding.assignment(this)(x, rhs, src)
 
   def equal(lhs: in.Expr, rhs: in.Expr)(src: in.Node): CodeWriter[vpr.Exp] = typeEncoding.equal(this)(lhs, rhs, src)

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -126,15 +126,12 @@ trait TypeEncoding extends Generator {
   }
 
   /**
-    * TODO: describe better
-    * Returns initialization code for a declared location with the scope of a body.
-    * The initialization code has to guarantee that:
-    * (1) the declared variable has its default value afterwards
-    * (2) all permissions for the declared variables are owned afterwards
+    * Returns the allocation code for a declared location with the scope of a body.
+    * The initialization code has to guarantee that all permissions for the declared variables are owned afterwards
     *
     * The default implements:
-    * Initialize[loc: T°] -> assume [loc == dflt(T)]
-    * Initialize[loc: T@] -> inhale Footprint[loc]; assume [loc == dflt(T°)] && [&loc != nil(*T)]
+    * Allocate[loc: T°] -> EmptyStmt
+    * Allocate[loc: T@] -> inhale Footprint[loc]; assume [&loc != nil(*T)]
     */
   def allocate(ctx: Context): in.Location ==> CodeWriter[vpr.Stmt] = {
     case loc :: t / Exclusive if typ(ctx).isDefinedAt(t) =>

--- a/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
@@ -196,15 +196,12 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
         val (pos, info, errT) = lit.vprMeta
         val litA = lit.asArrayLit
         val tmp = in.LocalVar(ctx.freshNames.next(), litA.typ.withAddressability(Addressability.pointerBase))(lit.info)
-        //println(s"tmp: $tmp")
         val tmpT = ctx.variable(tmp)
-        //println(s"tmpT: $tmpT")
         val underlyingTyp = underlyingType(lit.typ)(ctx)
-        //println(s"underlyingTyp: $underlyingTyp")
         for {
+          _ <- local(tmpT)
           initT <- ctx.allocation(tmp)
           _ <- write(initT)
-          _ <- local(tmpT)
           eq <- ctx.equal(tmp, litA)(lit)
           inhale = vpr.Inhale(eq)(pos, info, errT)
           _ <- write(inhale)
@@ -214,34 +211,6 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
           )(lit)
         } yield ass
       }
-        /*
-        for {
-          // initT <- ctx.initialization(tmp)
-          // _ = println(s"initT: $initT")
-          assignT <- ctx.assignment(in.Assignee.Var(tmp), litA)(lit)
-          // _ = println(s"assignT: $assignT")
-          _ <- local(tmpT)
-          // _ <- write(initT)
-          _ <- write(assignT)
-          ass <- ctx.assignment(
-            in.Assignee.Var(lit.target),
-            in.Slice(tmp, in.IntLit(0)(lit.info), in.IntLit(litA.length)(lit.info), None, underlyingTyp)(lit.info)
-          )(lit)
-        } yield ass
-
-         */
-
-        /*
-        val (pos, info, errT) = src.vprMeta
-        seqn(
-        for {
-          footprint <- addressFootprint(ctx)(loc, in.FullPerm(loc.info))
-          eq <- ctx.equal(loc, rhs)(src)
-          _ <- write(vpr.Exhale(footprint)(pos, info, errT))
-          inhale = vpr.Inhale(vpr.And(footprint, eq)(pos, info, errT))(pos, info, errT)
-        } yield inhale
-        )
-         */
     }
 
   /**

--- a/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
@@ -193,23 +193,56 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
         )
 
       case lit: in.NewSliceLit =>
+        val (pos, info, errT) = lit.vprMeta
         val litA = lit.asArrayLit
         val tmp = in.LocalVar(ctx.freshNames.next(), litA.typ.withAddressability(Addressability.pointerBase))(lit.info)
+        //println(s"tmp: $tmp")
         val tmpT = ctx.variable(tmp)
+        //println(s"tmpT: $tmpT")
         val underlyingTyp = underlyingType(lit.typ)(ctx)
+        //println(s"underlyingTyp: $underlyingTyp")
         for {
-          initT <- ctx.initialization(tmp)
-          assignT <- ctx.assignment(in.Assignee.Var(tmp), litA)(lit)
-          _ <- local(tmpT)
+          initT <- ctx.allocation(tmp)
           _ <- write(initT)
+          _ <- local(tmpT)
+          eq <- ctx.equal(tmp, litA)(lit)
+          inhale = vpr.Inhale(eq)(pos, info, errT)
+          _ <- write(inhale)
+          ass <- ctx.assignment(
+            in.Assignee.Var(lit.target),
+            in.Slice(tmp, in.IntLit(0)(lit.info), in.IntLit(litA.length)(lit.info), None, underlyingTyp)(lit.info)
+          )(lit)
+        } yield ass
+      }
+        /*
+        for {
+          // initT <- ctx.initialization(tmp)
+          // _ = println(s"initT: $initT")
+          assignT <- ctx.assignment(in.Assignee.Var(tmp), litA)(lit)
+          // _ = println(s"assignT: $assignT")
+          _ <- local(tmpT)
+          // _ <- write(initT)
           _ <- write(assignT)
           ass <- ctx.assignment(
             in.Assignee.Var(lit.target),
             in.Slice(tmp, in.IntLit(0)(lit.info), in.IntLit(litA.length)(lit.info), None, underlyingTyp)(lit.info)
           )(lit)
         } yield ass
+
+         */
+
+        /*
+        val (pos, info, errT) = src.vprMeta
+        seqn(
+        for {
+          footprint <- addressFootprint(ctx)(loc, in.FullPerm(loc.info))
+          eq <- ctx.equal(loc, rhs)(src)
+          _ <- write(vpr.Exhale(footprint)(pos, info, errT))
+          inhale = vpr.Inhale(vpr.And(footprint, eq)(pos, info, errT))(pos, info, errT)
+        } yield inhale
+        )
+         */
     }
-  }
 
   /**
     * Obtains permission to all cells of a slice


### PR DESCRIPTION
Currently, our slice literals introduce unnecessary proof obligations.

```go
func test() {
	var s []int
	s = []int{1, 2, 3}
}
```
For this example, the currently generated Viper method is
```
method test_7b972028_F()
{
  // decl 
  
  // decl s_V0: []int°, N0: []int°
  var N0: Slice[Ref]
  var s_V0: Slice[Ref]
  
  // init s_V0
  inhale s_V0 == sliceDefault_Intint$$$_S_$$$()
  
  // s_V0 = dflt[[]int]
  s_V0 := sliceDefault_Intint$$$_S_$$$()
  
  // N0 = new([]int { 0:1, 1:2, 2:3 })
  var fn$$2: Emb_3_Intint$$$_S_$$$
  var fn$$3: Emb_3_Intint$$$$_E_$$$
  var fn$$0: Emb_3_Intint$$$_S_$$$
  fn$$2 := fn$$0
  fn$$3 := arrayDefault_3_Intint$$$$_E_$$$()
  inhale (forall fn$$1: Int ::
      { (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0), fn$$1): Ref) }
      0 <= fn$$1 && fn$$1 < 3 ==>
      acc((ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0), fn$$1): Ref).val$_Int, write)) &&
    ((forall fn$$4: Int ::
      { (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$2), fn$$4): Ref) }
      { unbox_Emb_3_Intint$$$$_E_$$$_Seq_Int(fn$$3)[fn$$4] }
      0 <= fn$$4 && fn$$4 < 3 ==>
      (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$2), fn$$4): Ref).val$_Int ==
      unbox_Emb_3_Intint$$$$_E_$$$_Seq_Int(fn$$3)[fn$$4]) &&
    !(fn$$0 ==
    box_Emb_3_Intint$$$_S_$$$_ShArray_Ref(arrayNil_3_Intint$$$_S_$$$())))
  var fn$$6: Emb_3_Intint$$$_S_$$$
  var fn$$7: Emb_3_Intint$$$$_E_$$$
  fn$$6 := fn$$0
  fn$$7 := box_Emb_3_Intint$$$$_E_$$$_Seq_Int(Seq(1, 2, 3))
  exhale (forall fn$$5: Int ::
      { (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0), fn$$5): Ref) }
      0 <= fn$$5 && fn$$5 < 3 ==>
      acc((ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0), fn$$5): Ref).val$_Int, write))
  inhale (forall fn$$5: Int ::
      { (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0), fn$$5): Ref) }
      0 <= fn$$5 && fn$$5 < 3 ==>
      acc((ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0), fn$$5): Ref).val$_Int, write)) &&
    (forall fn$$8: Int ::
      { (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$6), fn$$8): Ref) }
      { unbox_Emb_3_Intint$$$$_E_$$$_Seq_Int(fn$$7)[fn$$8] }
      0 <= fn$$8 && fn$$8 < 3 ==>
      (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$6), fn$$8): Ref).val$_Int ==
      unbox_Emb_3_Intint$$$$_E_$$$_Seq_Int(fn$$7)[fn$$8])
  N0 := ssliceFromArray_Ref(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0),
    0, 3)
  
  // s_V0 = N0
  s_V0 := N0
  label returnLabel
}
```

This PR avoids the unnecessary inhaling and exhaling of the footprint of the underlying array. For this particular case, the obtained viper method is now
```
method test_7b972028_F()
{  
  // decl 

  // decl s_V0: []int°, N0: []int°
  var N0: Slice[Ref]
  var s_V0: Slice[Ref]
  
  // init s_V0
  inhale s_V0 == sliceDefault_Intint$$$_S_$$$()
  
  // s_V0 = dflt[[]int]
  s_V0 := sliceDefault_Intint$$$_S_$$$()
  
  // N0 = new([]int { 0:1, 1:2, 2:3 })
  var fn$$0: Emb_3_Intint$$$_S_$$$
  var fn$$2: Emb_3_Intint$$$_S_$$$
  var fn$$3: Emb_3_Intint$$$$_E_$$$
  inhale (forall fn$$1: Int ::
      { (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0), fn$$1): Ref) }
      0 <= fn$$1 && fn$$1 < 3 ==>
      acc((ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0), fn$$1): Ref).val$_Int, write)) &&
    !(fn$$0 ==
    box_Emb_3_Intint$$$_S_$$$_ShArray_Ref(arrayNil_3_Intint$$$_S_$$$()))
  fn$$2 := fn$$0
  fn$$3 := box_Emb_3_Intint$$$$_E_$$$_Seq_Int(Seq(1, 2, 3))
  inhale (forall fn$$4: Int ::
      { (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$2), fn$$4): Ref) }
      { unbox_Emb_3_Intint$$$$_E_$$$_Seq_Int(fn$$3)[fn$$4] }
      0 <= fn$$4 && fn$$4 < 3 ==>
      (ShArrayloc(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$2), fn$$4): Ref).val$_Int ==
      unbox_Emb_3_Intint$$$$_E_$$$_Seq_Int(fn$$3)[fn$$4])
  N0 := ssliceFromArray_Ref(unbox_Emb_3_Intint$$$_S_$$$_ShArray_Ref(fn$$0),
    0, 3)
  
  // s_V0 = N0
  s_V0 := N0
  label returnLabel
}
```