### PR TITLE
Optimize map encoding

### DIFF
--- a/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
@@ -245,10 +245,9 @@ class MapEncoding extends LeafTypeEncoding {
   /**
     * Encodes an assignment.
     * [ mapExp[idx] = newVal ] ->
-    *     var res: Ref
     *     var m: Map[ [k], [v] ]
     *     m = [mapExp].underlyingMapField
-    *     [mapExp].underlyingMapField == m[ [idx] = [newVal] ]
+    *     [mapExp].underlyingMapField := m[ [idx] = [newVal] ]
     */
   override def assignment(ctx: Context): (in.Assignee, in.Expr, in.Node) ==> CodeWriter[vpr.Stmt] = {
 


### PR DESCRIPTION
Changes:
- Generates as many fields as possible to represent different map types, instead of generating a single field called `underlyingMapField`. Should have performance implications like PR #568. (This is somewhat confirmed by our experiments with SCION, where verifying a pacakge that uses maps heavily went down from 17min to 12)
- Removes one level of indirection which, in hindsight, does not seem to be necessary (through the `getMap` function)

In a separate PR, I plan to generate more auxiliary functions for `len` and `lookup`, which should expose better triggers at the surface language

PS: some trivial changes like inserting spaces and what not happened because my IDE decided randomly that it is good to automatically apply a code style now -.-