### PR TITLE
Make `receive` executable

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -1574,6 +1574,10 @@ object Desugar {
               // create temporary local variables to assign them the expression in `w.res`
               val targetTypes = info.typ(e) match {
                 case InternalTupleT(ts) => ts
+                case InternalSingleMulti(s, _) =>
+                  // when an expression that can yield a single or multiple return values depending on the context
+                  // is executed as a stmt, we consider only the single return value
+                  Vector(s)
                 case t => Vector(t)
               }
               val targets = targetTypes.map(typ => freshExclusiveVar(typeD(typ, Addressability.exclusiveVariable)(src), stmt, info)(src))

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Executability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Executability.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.frontend.info.implementation.property
 
-import viper.gobra.ast.frontend.{PBuildIn, PExpression, PInvoke, AstPattern => ap}
+import viper.gobra.ast.frontend.{PBuildIn, PExpression, PInvoke, PReceive, AstPattern => ap}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 
 trait Executability extends BaseProperty { this: TypeInfoImpl =>
@@ -22,6 +22,7 @@ trait Executability extends BaseProperty { this: TypeInfoImpl =>
         case Some(_: ap.ClosureCall) => true
         case _ => false
       }
+    case _: PReceive => true
     case _ => false
   }
 

--- a/src/test/resources/regressions/features/channels/channel-fail9.go
+++ b/src/test/resources/regressions/features/channels/channel-fail9.go
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+func c() <-chan struct{}
+
+func test1() {
+	//:: ExpectedOutput(precondition_error)
+	<-c()
+}
+
+type T interface {
+	getC() <-chan struct{}
+}
+
+func test2(t T) {
+	//:: ExpectedOutput(precondition_error)
+	<-t.getC()
+}

--- a/src/test/resources/regressions/features/channels/channel-fail9.go
+++ b/src/test/resources/regressions/features/channels/channel-fail9.go
@@ -15,6 +15,6 @@ type T interface {
 }
 
 func test2(t T) {
-	//:: ExpectedOutput(precondition_error)
+	//:: ExpectedOutput(receive_error:permission_error)
 	<-t.getC()
 }

--- a/src/test/resources/regressions/features/channels/channel-fail9.go
+++ b/src/test/resources/regressions/features/channels/channel-fail9.go
@@ -3,18 +3,19 @@
 
 package pkg
 
-func c() <-chan struct{}
+// @ ensures res.RecvChannel() && res.RecvGivenPerm()()
+func c() (res <-chan struct{})
 
 func test1() {
-	//:: ExpectedOutput(precondition_error)
 	<-c()
 }
 
 type T interface {
-	getC() <-chan struct{}
+	// @ ensures res.RecvChannel() && res.RecvGivenPerm()()
+	getC() (res <-chan struct{})
 }
 
+// @ requires t != nil
 func test2(t T) {
-	//:: ExpectedOutput(receive_error:permission_error)
 	<-t.getC()
 }


### PR DESCRIPTION
Gobra rejects the following program with a type error because the receive operation is not considered executable:
```go
func c() <-chan struct{}

func test1() {
	<-c()
}
```
This PR addresses that