### PR TITLE
Add support for ADTs as termination measures

### DIFF
--- a/src/main/scala/viper/gobra/translator/encodings/adts/AdtEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/adts/AdtEncoding.scala
@@ -286,7 +286,7 @@ class AdtEncoding extends LeafTypeEncoding {
           val varZ = vpr.LocalVarDecl("Z", adtT)(aPos, aInfo, aErrT)
           val decrApp1 = applyDecreasing(varX.localVar, varY.localVar)
           val decrApp2 = applyDecreasing(varY.localVar, varZ.localVar)
-          val decrApp3 =  applyDecreasing(varX.localVar, varZ.localVar)
+          val decrApp3 = applyDecreasing(varX.localVar, varZ.localVar)
           val trigger = vpr.Trigger(Seq(decrApp1, decrApp2))(aPos, aInfo, aErrT)
           val body = vpr.Forall(
             variables = Seq(varX, varY, varZ),

--- a/src/main/scala/viper/gobra/translator/encodings/adts/AdtEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/adts/AdtEncoding.scala
@@ -267,7 +267,7 @@ class AdtEncoding extends LeafTypeEncoding {
 
         // For every non-nullary constructor C of arity n and for every index i of a parameter of C with the ADT type,
         // we generate:
-        // forall p1: T1, pi: X, pn: Tn :: { decreasing(pi, C(p1, ..., pn)) } decreasing(pi, C(p1, ..., pn))
+        // forall p1: T1, ..., pi: X, ..., pn: Tn :: { decreasing(pi, C(p1, ..., pn)) } decreasing(pi, C(p1, ..., pn))
         val decreasingAxioms = constructors zip adt.clauses flatMap {
           // clause is required here to get a Seq[LocalVarDecl] for the `variables` param of `vpr.Forall` list. From an
           // element in constructors, we can get only get a Seq[AnyLocalVarDecl]. An alternative would be to re-compute

--- a/src/main/scala/viper/gobra/translator/encodings/adts/AdtEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/adts/AdtEncoding.scala
@@ -267,7 +267,8 @@ class AdtEncoding extends LeafTypeEncoding {
 
         // For every non-nullary constructor C of arity n and for every index i of a parameter of C with the ADT type,
         // we generate:
-        // forall p1: T1, ..., pi: X, ..., pn: Tn :: { decreasing(pi, C(p1, ..., pn)) } decreasing(pi, C(p1, ..., pn))
+        // forall p1: T1, ..., pi: X, ..., pn: Tn :: { decreasing(pi, C(p1, ..., pi, ..., pn)) }
+        //     decreasing(pi, C(p1, ..., pi, ..., pn))
         val decreasingAxioms = constructors zip adt.clauses flatMap {
           // clause is required here to get a Seq[LocalVarDecl] for the `variables` param of `vpr.Forall` list. From an
           // element in constructors, we can get only get a Seq[AnyLocalVarDecl]. An alternative would be to re-compute

--- a/src/test/resources/regressions/features/adts/termination-fail1.gobra
+++ b/src/test/resources/regressions/features/adts/termination-fail1.gobra
@@ -1,0 +1,41 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type tree adt{
+	leaf{ value int }
+	node{ left, right tree }
+}
+
+ghost
+pure
+decreases // cause: wrong termination measure
+func leafCount(t tree) int {
+	return match t {
+		case leaf{_}: 1
+		//:: ExpectedOutput(pure_function_termination_error)
+		case node{?l, ?r}: leafCount(l) + leafCount(r)
+	}
+}
+
+type list adt {
+	Empty{}
+
+	Cons{
+		head any
+		tail list
+	}
+}
+
+ghost
+decreases l
+func length(l list) int {
+	match l {
+		case Empty{}:
+			return 0
+		case Cons{_, ?t}:
+			//:: ExpectedOutput(function_termination_error)
+			return 1 + length(l) // cause: pass l to length instead of t
+	}
+}

--- a/src/test/resources/regressions/features/adts/termination-success1.gobra
+++ b/src/test/resources/regressions/features/adts/termination-success1.gobra
@@ -1,0 +1,39 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type tree adt{
+	leaf{ value int }
+	node{ left, right tree }
+}
+
+ghost
+pure
+decreases t
+func leafCount(t tree) int {
+	return match t {
+		case leaf{_}: 1
+		case node{?l, ?r}: leafCount(l) + leafCount(r)
+	}
+}
+
+type list adt {
+	Empty{}
+
+	Cons{
+		head any
+		tail list
+	}
+}
+
+ghost
+decreases l
+func length(l list) int {
+	match l {
+		case Empty{}:
+			return 0
+		case Cons{_, ?t}:
+			return 1 + length(t)
+	}
+}


### PR DESCRIPTION
Add support for using ADT instances as termination measures. This is just a draft, as I will likely adapt the PR such that:
- we introduce support for `len` for ADTs, which compute the rank of an ADT
- we encode the rank function
The advantage is that we expose `rank` directly to the user, allowing us to prove theorems about it more easily