### PR TITLE
Streaming errors

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -93,7 +93,6 @@ trait GoVerifier extends StrictLogging {
             case VerifierResult.Success => logger.info(s"$name found no errors")
             case VerifierResult.Failure(errors) =>
               logger.error(s"$name has found ${errors.length} error(s) in package $pkgId")
-              errors.foreach(err => logger.error(s"\t${err.formattedMessage}"))
               allVerifierErrors = allVerifierErrors ++ errors
           }
         })(executor)

--- a/src/main/scala/viper/gobra/backend/BackendVerifier.scala
+++ b/src/main/scala/viper/gobra/backend/BackendVerifier.scala
@@ -9,7 +9,7 @@ package viper.gobra.backend
 import viper.gobra.backend.ViperBackends.{CarbonBackend => Carbon}
 import viper.gobra.frontend.{Config, PackageInfo}
 import viper.gobra.reporting.BackTranslator.BackTrackInfo
-import viper.gobra.reporting.{BackTranslator, BacktranslatingReporter, ChoppedProgressMessage}
+import viper.gobra.reporting.{BackTranslator, BacktranslatingReporter, StreamingReporter, ChoppedProgressMessage}
 import viper.gobra.util.{ChopperUtil, GobraExecutionContext}
 import viper.silver
 import viper.silver.verifier.VerificationResult
@@ -49,7 +49,7 @@ object BackendVerifier {
 
     val verificationResults: Future[VerificationResult] =  {
       val verifier = config.backend.create(exePaths, config)
-      val reporter = BacktranslatingReporter(config.reporter, task.backtrack, config)
+      val reporter = BacktranslatingReporter(StreamingReporter(config.reporter), task.backtrack, config)
 
       if (!config.shouldChop) {
         verifier.verify(config.taskName, reporter, task.program)(executor)

--- a/src/main/scala/viper/gobra/backend/BackendVerifier.scala
+++ b/src/main/scala/viper/gobra/backend/BackendVerifier.scala
@@ -9,7 +9,7 @@ package viper.gobra.backend
 import viper.gobra.backend.ViperBackends.{CarbonBackend => Carbon}
 import viper.gobra.frontend.{Config, PackageInfo}
 import viper.gobra.reporting.BackTranslator.BackTrackInfo
-import viper.gobra.reporting.{BackTranslator, BacktranslatingReporter, StreamingReporter, ChoppedProgressMessage}
+import viper.gobra.reporting.{BackTranslator, BacktranslatingReporter, ChoppedProgressMessage}
 import viper.gobra.util.{ChopperUtil, GobraExecutionContext}
 import viper.silver
 import viper.silver.verifier.VerificationResult
@@ -49,7 +49,7 @@ object BackendVerifier {
 
     val verificationResults: Future[VerificationResult] =  {
       val verifier = config.backend.create(exePaths, config)
-      val reporter = BacktranslatingReporter(StreamingReporter(config.reporter), task.backtrack, config)
+      val reporter = BacktranslatingReporter(config.reporter, task.backtrack, config)
 
       if (!config.shouldChop) {
         verifier.verify(config.taskName, reporter, task.program)(executor)

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -16,7 +16,7 @@ import viper.gobra.backend.{ViperBackend, ViperBackends}
 import viper.gobra.GoVerifier
 import viper.gobra.frontend.PackageResolver.FileResource
 import viper.gobra.frontend.Source.getPackageInfo
-import viper.gobra.reporting.{FileWriterReporter, GobraReporter, StdIOReporter}
+import viper.gobra.reporting.{FileWriterReporter, GobraReporter, StdIOReporter, StreamingReporter}
 import viper.gobra.util.{TypeBounds, Violation}
 import viper.silver.ast.SourcePosition
 
@@ -709,13 +709,14 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     gobraDirectory = gobraDirectory(),
     moduleName = module(),
     includeDirs = includeDirs,
-    reporter = FileWriterReporter(
-      unparse = unparse(),
-      eraseGhost = eraseGhost(),
-      goify = goify(),
-      debug = debug(),
-      printInternal = printInternal(),
-      printVpr = printVpr()),
+    reporter = StreamingReporter(
+      FileWriterReporter(
+        unparse = unparse(),
+        eraseGhost = eraseGhost(),
+        goify = goify(),
+        debug = debug(),
+        printInternal = printInternal(),
+        printVpr = printVpr())),
     backend = backend(),
     isolate = isolate,
     choppingUpperBound = chopUpperBound(),

--- a/src/main/scala/viper/gobra/reporting/StreamingReporter.scala
+++ b/src/main/scala/viper/gobra/reporting/StreamingReporter.scala
@@ -1,0 +1,24 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2020 ETH Zurich.
+
+package viper.gobra.reporting
+
+import com.typesafe.scalalogging.StrictLogging
+
+case class StreamingReporter(reporter: GobraReporter) extends GobraReporter with StrictLogging {
+  override val name: String = reporter.name
+
+  def report(msg: GobraMessage): Unit = {
+    msg match {
+      case m:GobraEntityFailureMessage => m.result match {
+        case VerifierResult.Failure(errors) => errors.foreach(err => logger.error(s"Error: ${err.formattedMessage}"))
+        case _ => ;
+      }
+      case _ => ;
+    }
+    reporter.report(msg)
+  }
+}

--- a/src/main/scala/viper/gobra/reporting/StreamingReporter.scala
+++ b/src/main/scala/viper/gobra/reporting/StreamingReporter.scala
@@ -15,9 +15,11 @@ case class StreamingReporter(reporter: GobraReporter) extends GobraReporter with
     msg match {
       case m:GobraEntityFailureMessage => m.result match {
         case VerifierResult.Failure(errors) => errors.foreach(err => logger.error(s"Error at: ${err.formattedMessage}"))
-        case _ => ;
+        case _ => // ignore
       }
-      case _ => ;
+      case m:ParserErrorMessage => m.result.foreach(err => logger.error(s"Error at: ${err.formattedMessage}"))
+      case m:TypeCheckFailureMessage => m.result.foreach(err => logger.error(s"Error at: ${err.formattedMessage}"))
+      case _ => // ignore
     }
     reporter.report(msg)
   }

--- a/src/main/scala/viper/gobra/reporting/StreamingReporter.scala
+++ b/src/main/scala/viper/gobra/reporting/StreamingReporter.scala
@@ -14,7 +14,7 @@ case class StreamingReporter(reporter: GobraReporter) extends GobraReporter with
   def report(msg: GobraMessage): Unit = {
     msg match {
       case m:GobraEntityFailureMessage => m.result match {
-        case VerifierResult.Failure(errors) => errors.foreach(err => logger.error(s"Error: ${err.formattedMessage}"))
+        case VerifierResult.Failure(errors) => errors.foreach(err => logger.error(s"Error at: ${err.formattedMessage}"))
         case _ => ;
       }
       case _ => ;


### PR DESCRIPTION
Instead of printing the  verification errors after the verification for each package ends, stream them.