### PR TITLE
Introduce `len` for ADTs to be used as a termination measure

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -502,7 +502,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
     case PLength(op) => isExpr(op).out ++ {
       underlyingType(exprType(op)) match {
         case _: ArrayT | _: SliceT | _: GhostSliceT | StringT | _: VariadicT | _: MapT | _: MathMapT => noMessages
-        case _: SequenceT | _: SetT | _: MultisetT => isPureExpr(op)
+        case _: SequenceT | _: SetT | _: MultisetT | _: AdtT => isPureExpr(op)
         case typ => error(op, s"expected an array, string, sequence or slice type, but got $typ")
       }
     }
@@ -1051,7 +1051,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
   private[typing] def typeOfPLength(expr: PLength): Type =
     underlyingType(exprType(expr.exp)) match {
       case _: ArrayT | _: SliceT | _: GhostSliceT | StringT | _: VariadicT | _: MapT => INT_TYPE
-      case _: SequenceT | _: SetT | _: MultisetT | _: MathMapT => UNTYPED_INT_CONST
+      case _: SequenceT | _: SetT | _: MultisetT | _: MathMapT | _: AdtT => UNTYPED_INT_CONST
       case t => violation(s"unexpected argument ${expr.exp} of type $t passed to len")
     }
 }

--- a/src/main/scala/viper/gobra/translator/encodings/adts/AdtEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/adts/AdtEncoding.scala
@@ -232,8 +232,8 @@ class AdtEncoding extends LeafTypeEncoding {
       // https://ethz.ch/content/dam/ethz/special-interest/infk/chair-program-method/pm/documents/Education/Theses/Paul_Dahlke_BA_Report.pdf
       val rankFunc = adtRankFunc(adtName)(aPos, aInfo, aErrT)
       val rankAxioms = {
-        // the following axiom is useful for Gobra to easily infer that there is a lower bound to the values produced
-        // by rank:
+        // the following axiom is useful for Gobra to easily infer that there is a lower bound
+        // on the values produced by rank:
         // forall x X :: { rank(x) } 1 <= rank(x)
         val rankIsBounded = {
           val variableDecl = vpr.LocalVarDecl("x", adtT)(aPos, aInfo, aErrT)

--- a/src/test/resources/regressions/features/adts/termination-fail1.gobra
+++ b/src/test/resources/regressions/features/adts/termination-fail1.gobra
@@ -1,0 +1,41 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type tree adt{
+	leaf{ value int }
+	node{ left, right tree }
+}
+
+ghost
+pure
+decreases // cause: wrong termination measure
+func leafCount(t tree) int {
+	return match t {
+		case leaf{_}: 1
+		//:: ExpectedOutput(pure_function_termination_error)
+		case node{?l, ?r}: leafCount(l) + leafCount(r)
+	}
+}
+
+type list adt {
+	Empty{}
+
+	Cons{
+		head any
+		tail list
+	}
+}
+
+ghost
+decreases len(l)
+func length(l list) int {
+	match l {
+		case Empty{}:
+			return 0
+		case Cons{_, ?t}:
+			//:: ExpectedOutput(function_termination_error)
+			return 1 + length(l) // cause: pass l to length instead of t
+	}
+}

--- a/src/test/resources/regressions/features/adts/termination-success1.gobra
+++ b/src/test/resources/regressions/features/adts/termination-success1.gobra
@@ -1,0 +1,56 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type tree adt{
+	leaf{ value int }
+	node{ left, right tree }
+}
+
+ghost
+pure
+decreases len(t)
+func leafCount(t tree) int {
+	return match t {
+		case leaf{_}: 1
+		case node{?l, ?r}: leafCount(l) + leafCount(r)
+	}
+}
+
+type list adt {
+	Empty{}
+
+	Cons{
+		head any
+		tail list
+	}
+}
+
+ghost
+decreases len(l)
+func length(l list) int {
+	match l {
+		case Empty{}:
+			return 0
+		case Cons{_, ?t}:
+			return 1 + length(t)
+	}
+}
+
+ghost
+requires l === r || l.tail.tail === r
+decreases len(l)
+func testSubSubList(l, r list) {
+	if (l === r) {
+		return
+	} else {
+		assert l.tail.tail === r
+		assert l !== r
+		assume l.isCons // Gobra cannot infer this - adt axiomatization still a bit weak?
+		assume l.tail.isCons // Gobra cannot infer this - adt axiomatization still a bit weak?
+		assert len(l.tail) < len(l)
+		assert len(l.tail.tail) < len(l)
+		testSubSubList(l.tail.tail, r)
+	}
+}


### PR DESCRIPTION
This PR introduces support for expressions of the form `len(e)`, where `e` is an expression of an ADT type. This computes the rank of `e`, as defined in [Paul Dahlke's thesis](https://ethz.ch/content/dam/ethz/special-interest/infk/chair-program-method/pm/documents/Education/Theses/Paul_Dahlke_BA_Report.pdf), which is a useful termination measure for functions defined by structural recursion on an ADT instance.

Arguably, it is bad style to overload `len` here for this measure but I would argue that this is consistent with the other overloads of `len` in Go and Gobra, e.g. for things like channels, maps (part of Go) and sets (part of Gobra). Nonetheless, I could introduce a new node if the majority dislikes this design, although this would introduce a new reserved keyword.