### PR TITLE
QoL improvements

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -165,7 +165,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
     task.flatMap{
       case Left(Vector()) => Future(VerifierResult.Success)
       case Left(errors)   => Future(VerifierResult.Failure(errors))
-      case Right((job, finalConfig)) => verifyAst(finalConfig, pkgInfo, job.program,  job.backtrack)(executor)
+      case Right((job, finalConfig)) => performVerification(finalConfig, pkgInfo, job.program,  job.backtrack)(executor)
     }
   }
 
@@ -260,6 +260,14 @@ class Gobra extends GoVerifier with GoIdeVerifier {
       Right(Desugar.desugar(parsedPackage, typeInfo)(config))
     } else {
       Left(Vector())
+    }
+  }
+
+  private def performVerification(config: Config, pkgInfo: PackageInfo, ast: vpr.Program, backtrack: BackTranslator.BackTrackInfo)(executor: GobraExecutionContext): Future[VerifierResult] = {
+    if (config.noVerify) {
+      Future(VerifierResult.Success)(executor)
+    } else {
+      verifyAst(config, pkgInfo, ast, backtrack)(executor)
     }
   }
 

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -25,6 +25,8 @@ import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
 import viper.silicon.BuildInfo
 import viper.silver.{ast => vpr}
 
+import java.time.format.DateTimeFormatter
+import java.time.LocalTime
 import scala.concurrent.{Await, Future, TimeoutException}
 
 object GoVerifier {
@@ -77,9 +79,10 @@ trait GoVerifier extends StrictLogging {
       }
     })
 
+    val timeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss");
     config.packageInfoInputMap.keys.foreach(pkgInfo => {
       val pkgId = pkgInfo.id
-      logger.info(s"Verifying Package $pkgId")
+      logger.info(s"Verifying package $pkgId [${LocalTime.now().format(timeFormatter)}]")
       val future = verify(pkgInfo, config.copy(reporter = statsCollector, taskName = pkgId))(executor)
         .map(result => {
           // report that verification of this package has finished in order that `statsCollector` can free space by getting rid of this package's typeInfo

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -65,6 +65,7 @@ object ConfigDefaults {
   lazy val DefaultParallelizeBranches: Boolean = false
   lazy val DefaultDisableMoreCompleteExhale: Boolean = false
   lazy val DefaultEnableLazyImports: Boolean = false
+  lazy val DefaultNoVerify: Boolean = false
 }
 
 case class Config(
@@ -113,6 +114,7 @@ case class Config(
                    parallelizeBranches: Boolean = ConfigDefaults.DefaultParallelizeBranches,
                    disableMoreCompleteExhale: Boolean = ConfigDefaults.DefaultDisableMoreCompleteExhale,
                    enableLazyImports: Boolean = ConfigDefaults.DefaultEnableLazyImports,
+                   noVerify: Boolean = ConfigDefaults.DefaultNoVerify,
 ) {
 
   def merge(other: Config): Config = {
@@ -155,6 +157,7 @@ case class Config(
       parallelizeBranches = parallelizeBranches,
       disableMoreCompleteExhale = disableMoreCompleteExhale,
       enableLazyImports = enableLazyImports || other.enableLazyImports,
+      noVerify = noVerify || other.noVerify,
     )
   }
 
@@ -202,6 +205,7 @@ case class BaseConfig(gobraDirectory: Path = ConfigDefaults.DefaultGobraDirector
                       parallelizeBranches: Boolean = ConfigDefaults.DefaultParallelizeBranches,
                       disableMoreCompleteExhale: Boolean = ConfigDefaults.DefaultDisableMoreCompleteExhale,
                       enableLazyImports: Boolean = ConfigDefaults.DefaultEnableLazyImports,
+                      noVerify: Boolean = ConfigDefaults.DefaultNoVerify,
                      ) {
   def shouldParse: Boolean = true
   def shouldTypeCheck: Boolean = !shouldParseOnly
@@ -253,6 +257,7 @@ trait RawConfig {
     parallelizeBranches = baseConfig.parallelizeBranches,
     disableMoreCompleteExhale = baseConfig.disableMoreCompleteExhale,
     enableLazyImports = baseConfig.enableLazyImports,
+    noVerify = baseConfig.noVerify,
   )
 }
 
@@ -601,6 +606,13 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     noshort = true,
   )
 
+  val noVerify: ScallopOption[Boolean] = opt[Boolean](
+    name = "noVerify",
+    descr = s"Skip the verification step performed after encoding the Gobra program into Viper.",
+    default = Some(ConfigDefaults.DefaultNoVerify),
+    noshort = true,
+  )
+
   /**
     * Exception handling
     */
@@ -735,5 +747,6 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     parallelizeBranches = parallelizeBranches(),
     disableMoreCompleteExhale = disableMoreCompleteExhale(),
     enableLazyImports = enableLazyImports(),
+    noVerify = noVerify(),
   )
 }


### PR DESCRIPTION
1. print the time when a verification job starts
2. introduce the --noVerify flag to skip verification. Useful when we are only interested in generating the viper file