### PR TITLE
Allow non-side-effectful conversions in spec

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/TypeInfo.scala
+++ b/src/main/scala/viper/gobra/frontend/info/TypeInfo.scala
@@ -26,6 +26,7 @@ trait TypeInfo extends ExternalTypeInfo {
   def regular(n: PIdnNode): Regular
 
   def isDef(n: PIdnUnk): Boolean
+  def isEffectfulConversion(c: AstPattern.Conversion): Boolean
 
   def resolve(n: PExpressionOrType): Option[AstPattern.Pattern]
   def exprOrType(n: PExpressionOrType): Either[PExpression, PType]

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -1055,7 +1055,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
       case t => violation(s"unexpected argument ${expr.exp} of type $t passed to len")
     }
 
-  def isEffectfulConversion(c: ap.Conversion): Boolean = {
+  override def isEffectfulConversion(c: ap.Conversion): Boolean = {
     val fromType = underlyingType(exprType(c.arg))
     val toType = underlyingType(typeSymbType(c.typ))
     (fromType, toType) match {

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -1055,6 +1055,11 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
       case t => violation(s"unexpected argument ${expr.exp} of type $t passed to len")
     }
 
+  /**
+    * True iff a conversion may produce side-effects, such as allocating a slice.
+    * May need to be extended when we introduce support for generics and when we allow
+    * a cast from a `[]T` to a `*[n]T` (described in https://go.dev/ref/spec#Conversions).
+    */
   override def isEffectfulConversion(c: ap.Conversion): Boolean = {
     val fromType = underlyingType(exprType(c.arg))
     val toType = underlyingType(typeSymbType(c.typ))

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -12,7 +12,7 @@ import viper.gobra.frontend.info.base.SymbolTable.{AdtDestructor, AdtDiscriminat
 import viper.gobra.frontend.info.base.Type._
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.util.TypeBounds.{BoundedIntegerKind, UnboundedInteger}
-import viper.gobra.util.{Constants, Violation}
+import viper.gobra.util.{Constants, TypeBounds, Violation}
 
 trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
 
@@ -1054,4 +1054,13 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
       case _: SequenceT | _: SetT | _: MultisetT | _: MathMapT | _: AdtT => UNTYPED_INT_CONST
       case t => violation(s"unexpected argument ${expr.exp} of type $t passed to len")
     }
+
+  def isEffectfulConversion(c: ap.Conversion): Boolean = {
+    val fromType = underlyingType(exprType(c.arg))
+    val toType = underlyingType(typeSymbType(c.typ))
+    (fromType, toType) match {
+      case (StringT, SliceT(IntT(TypeBounds.Byte))) => true
+      case _ => false
+    }
+  }
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -360,14 +360,7 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
       // Might change at some point
       case n: PInvoke => (exprOrType(n.base), resolve(n)) match {
         case (Right(_), Some(p: ap.Conversion)) =>
-          val dstTyp = symbType(p.typ)
-          val exprTyp = typ(p.arg)
-          (underlyingType(dstTyp), underlyingType(exprTyp)) match {
-            case (SliceT(IntT(TypeBounds.Byte)), StringT) =>
-              // this is an effectful conversion which produces permissions to the resulting slice
-              false
-            case _ => go(p.arg)
-          }
+          !isEffectfulConversion(p) && go(p.arg)
         case (Left(callee), Some(p@ap.FunctionCall(f, _))) => go(callee) && p.args.forall(go) && (f match {
           case ap.Function(_, symb) => symb.isPure
           case ap.Closure(_, symb) => symb.isPure

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
@@ -129,7 +129,7 @@ trait GhostWellDef { this: TypeInfoImpl =>
       ) => error(n, "ghost error: Found ghost child expression, but expected none", !noGhostPropagationFromChildren(n))
 
     case n: PInvoke => (exprOrType(n.base), resolve(n)) match {
-      case (Right(_), Some(_: ap.Conversion)) =>  error(n, "ghost error: Found ghost child expression, but expected none", !noGhostPropagationFromChildren(n))
+      case (Right(_), Some(c: ap.Conversion)) => noMessages
       case (Left(_), Some(call: ap.FunctionCall)) => ghostAssignableToCallExpr(call)
       case (Left(_), Some(call: ap.ClosureCall)) => ghostAssignableToClosureCall(call)
       case (Left(_), Some(_: ap.PredicateCall)) => noMessages

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
@@ -129,7 +129,7 @@ trait GhostWellDef { this: TypeInfoImpl =>
       ) => error(n, "ghost error: Found ghost child expression, but expected none", !noGhostPropagationFromChildren(n))
 
     case n: PInvoke => (exprOrType(n.base), resolve(n)) match {
-      case (Right(_), Some(c: ap.Conversion)) => noMessages
+      case (Right(_), Some(_: ap.Conversion)) => noMessages
       case (Left(_), Some(call: ap.FunctionCall)) => ghostAssignableToCallExpr(call)
       case (Left(_), Some(call: ap.ClosureCall)) => ghostAssignableToClosureCall(call)
       case (Left(_), Some(_: ap.PredicateCall)) => noMessages

--- a/src/test/resources/regressions/features/conversion/conversion-fail01.gobra
+++ b/src/test/resources/regressions/features/conversion/conversion-fail01.gobra
@@ -3,6 +3,8 @@
 
 package main
 
+// Rejected, as this conversion is side-effectful, as thus
+// it is not a pure expression.
 //:: ExpectedOutput(type_error)
 ensures res === []byte(s)
 func to64(s string) (res []byte)

--- a/src/test/resources/regressions/features/conversion/conversion-fail01.gobra
+++ b/src/test/resources/regressions/features/conversion/conversion-fail01.gobra
@@ -1,0 +1,8 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+//:: ExpectedOutput(type_error)
+ensures res === []byte(s)
+func to64(s string) (res []byte)

--- a/src/test/resources/regressions/features/conversion/conversion-simple01.gobra
+++ b/src/test/resources/regressions/features/conversion/conversion-simple01.gobra
@@ -1,0 +1,7 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package main
+
+ensures res == int64(i)
+func to64(i int8) (res int64)


### PR DESCRIPTION
Currently, type conversions cannot have ghost child nodes. This is unnecessarily restrictive. This PR lifts such a restriction and allows non-effectful conversions to be used in spec.