### PR TITLE
Better error spec

### DIFF
--- a/src/main/resources/builtin/builtin.gobra
+++ b/src/main/resources/builtin/builtin.gobra
@@ -13,7 +13,18 @@ type any = interface{}
 type error interface {
 	pred ErrorMem()
 
-	requires acc(ErrorMem(), _)
+    ghost
+    requires acc(ErrorMem(), _)
+    decreases
+    pure IsDuplicableMem() bool
+
+    ghost
+	preserves ErrorMem()
+	ensures   IsDuplicableMem() ==> ErrorMem() 
+    decreases
+    Duplicate()
+
+	preserves ErrorMem()
 	decreases
 	Error() string
 }

--- a/src/main/resources/builtin/builtin.gobra
+++ b/src/main/resources/builtin/builtin.gobra
@@ -13,16 +13,16 @@ type any = interface{}
 type error interface {
 	pred ErrorMem()
 
-    ghost
-    requires acc(ErrorMem(), _)
-    decreases
-    pure IsDuplicableMem() bool
+	ghost
+	requires acc(ErrorMem(), _)
+	decreases
+	pure IsDuplicableMem() bool
 
-    ghost
+	ghost
 	preserves ErrorMem()
 	ensures   IsDuplicableMem() ==> ErrorMem() 
-    decreases
-    Duplicate()
+	decreases
+	Duplicate()
 
 	preserves ErrorMem()
 	decreases


### PR DESCRIPTION
The version of error introduced in the previous spec caused a big performance degradation in verifiedSCION (likely, due to the use of wildcards in the spec of `Error`. This PR addresses that and recovers the original expressivity of the `error` type (in particular, implementations of `Error` that mutate the underlying data structure are still allowed)