### PR TITLE
Encode slice `make` as a method call

### DIFF
--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -501,7 +501,7 @@ case class SpecNotImplementedByClosure(info: Verifier.Info, closure: String, spe
 }
 
 case class SliceMakePreconditionFailed(info: Source.Verifier.Info) extends VerificationErrorReason {
-  override def id: String = "make_precondition_error"
+  override def id: String = "make_precondition_false"
   override def message: String = s"The provided length might not be smaller or equal to the provided capacity, or length and capacity might be negative"
 }
 

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -269,11 +269,6 @@ case class ImportPreconditionNotEstablished(info: Source.Verifier.Info) extends 
     s"The import precondition might not be established by the initialization code of the imported package"
 }
 
-case class ArrayMakePreconditionError(info: Source.Verifier.Info) extends VerificationError {
-  override def localId: String = "make_precondition_error"
-  override def localMessage: String = s"The provided length might not be smaller or equals to the provided capacity, or length and capacity might not be non-negative"
-}
-
 case class ChannelMakePreconditionError(info: Source.Verifier.Info) extends VerificationError {
   override def localId: String = "make_precondition_error"
   override def localMessage: String = s"The provided length to ${info.origin.tag.trim} might be negative"
@@ -503,6 +498,11 @@ case class LabelledStateNotReached(info: Source.Verifier.Info) extends Verificat
 case class SpecNotImplementedByClosure(info: Verifier.Info, closure: String, spec: String) extends VerificationErrorReason {
   override def id = "spec_not_implemented"
   override def message: String = s"$closure might not implement $spec."
+}
+
+case class SliceMakePreconditionFailed(info: Source.Verifier.Info) extends VerificationErrorReason {
+  override def id: String = "make_precondition_error"
+  override def message: String = s"The provided length might not be smaller or equal to the provided capacity, or length and capacity might be negative"
 }
 
 sealed trait VerificationErrorClarification {

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -501,8 +501,8 @@ case class SpecNotImplementedByClosure(info: Verifier.Info, closure: String, spe
 }
 
 case class SliceMakePreconditionFailed(info: Source.Verifier.Info) extends VerificationErrorReason {
-  override def id: String = "make_precondition_false"
-  override def message: String = s"The provided length might not be smaller or equal to the provided capacity, or length and capacity might be negative"
+  override def id: String = "make_precondition_error"
+  override def message: String = s"The provided length might not be smaller or equal to the provided capacity, or length or capacity might be negative"
 }
 
 sealed trait VerificationErrorClarification {

--- a/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
@@ -637,6 +637,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       *   ensures scap(res) == cap
       *   ensures forall i: Int :: { [ &res[i] ] } 0 <= i && i < cap ==> acc([ &res[i] ], write)
       *   ensures forall i: Int :: { [ &res[i] ] } 0 <= i && i < len ==> [ res[i] ] == [ dflt(T) ]
+      *   decreases _
       */
     override def genMethod(t: in.Type)(ctx: Context): vpr.Method = {
       val tName = Names.serializeType(t)

--- a/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
@@ -635,11 +635,10 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
       val qtfVar = vpr.LocalVarDecl("i", vpr.Int)()
 
       val dfltValWriter = ctx.expression(in.DfltVal(t.withAddressability(Addressability.Exclusive))(Source.Parser.Internal))
-      val dfltVal = dfltValWriter.res
-      require(dfltValWriter.sum.data.isEmpty && dfltValWriter.sum.remainder.isEmpty)
+      val dfltVal = pure(dfltValWriter)(ctx).res
 
       val post1 = vpr.EqCmp(ctx.slice.len(result.localVar)(), lenDecl.localVar)()
-      val post2 = vpr.EqCmp(ctx.slice.len(result.localVar)(), lenDecl.localVar)()
+      val post2 = vpr.EqCmp(ctx.slice.cap(result.localVar)(), capDecl.localVar)()
       val post3 = vpr.Forall(
         variables = Seq(qtfVar),
         triggers  = Seq(vpr.Trigger(Seq(ctx.slice.loc(result.localVar, qtfVar.localVar)()))()),

--- a/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
@@ -626,6 +626,18 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
   }
 
   private val makeMethodGenerator: MethodGenerator[in.Type] = new MethodGenerator[in.Type] {
+    /**
+      * Generates viper method for making slices with elements of type T:
+      *
+      * method makeSliceMethodT(len: Int, cap: Int) returns (res: Slice[Ref])
+      *   requires 0 <= len
+      *   requires 0 <= cap
+      *   requires len <= cap
+      *   ensures slen(res) == len
+      *   ensures scap(res) == cap
+      *   ensures forall i: Int :: { [ &res[i] ] } 0 <= i && i < cap ==> acc([ &res[i] ], write)
+      *   ensures forall i: Int :: { [ &res[i] ] } 0 <= i && i < len ==> [ res[i] ] == [ dflt(T) ]
+      */
     override def genMethod(t: in.Type)(ctx: Context): vpr.Method = {
       val tName = Names.serializeType(t)
       val lenDecl = vpr.LocalVarDecl("len", vpr.Int)()
@@ -663,7 +675,7 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
             dfltVal
           )())())()
       vpr.Method(
-        name = s"makeMethod$tName",
+        name = s"makeSliceMethod$tName",
         formalArgs = Seq(lenDecl, capDecl),
         formalReturns = Seq(result),
         pres = Seq(

--- a/src/main/scala/viper/gobra/translator/util/MethodGenerator.scala
+++ b/src/main/scala/viper/gobra/translator/util/MethodGenerator.scala
@@ -1,0 +1,35 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2022 ETH Zurich.
+
+package viper.gobra.translator.util
+
+import viper.gobra.translator.library.Generator
+import viper.gobra.translator.context.Context
+import viper.silver.{ast => vpr}
+
+trait MethodGenerator[T] extends Generator {
+
+  override def finalize(addMemberFn: vpr.Member => Unit): Unit = generatedMember foreach addMemberFn
+
+  private var generatedMember: List[vpr.Method] = List.empty
+  private var genMap: Map[T, vpr.Method] = Map.empty
+
+  def genMethod(x: T)(ctx: Context): vpr.Method
+
+  def getMethod(x: T)(ctx: Context): vpr.Method = {
+    genMap.getOrElse(x, {
+      val newMethod = genMethod(x)(ctx)
+      genMap += x -> newMethod
+      generatedMember ::= newMethod
+      newMethod
+    })
+  }
+
+  def apply(args: Vector[vpr.Exp], targets: Seq[vpr.LocalVar], x: T)(pos: vpr.Position = vpr.NoPosition, info: vpr.Info = vpr.NoInfo, errT: vpr.ErrorTrafo = vpr.NoTrafos)(ctx: Context): vpr.MethodCall = {
+    val method = getMethod(x)(ctx)
+    vpr.MethodCall(method, args, targets)(pos, info, errT)
+  }
+}

--- a/src/test/resources/regressions/features/make_and_new/make1.gobra
+++ b/src/test/resources/regressions/features/make_and_new/make1.gobra
@@ -5,14 +5,14 @@ package main
 
 // Throws an error because length might be negative
 func Err1(length int) (ret []int) {
-	//:: ExpectedOutput(precondition_error:make_precondition_false)
+	//:: ExpectedOutput(precondition_error:make_precondition_error)
 	ret := make([]int, length)
 }
 
 // Throws an error because length is not guaranteed to be less than capacity
 requires length > 0 && capacity > 0
 func Err2(length int, capacity int) (ret []int) {
-	//:: ExpectedOutput(precondition_error:make_precondition_false)
+	//:: ExpectedOutput(precondition_error:make_precondition_error)
 	ret := make([]int, length, capacity)
 }
 

--- a/src/test/resources/regressions/features/make_and_new/make1.gobra
+++ b/src/test/resources/regressions/features/make_and_new/make1.gobra
@@ -5,14 +5,14 @@ package main
 
 // Throws an error because length might be negative
 func Err1(length int) (ret []int) {
-	//:: ExpectedOutput(make_precondition_error)
+	//:: ExpectedOutput(precondition_error:make_precondition_false)
 	ret := make([]int, length)
 }
 
 // Throws an error because length is not guaranteed to be less than capacity
 requires length > 0 && capacity > 0
 func Err2(length int, capacity int) (ret []int) {
-	//:: ExpectedOutput(make_precondition_error)
+	//:: ExpectedOutput(precondition_error:make_precondition_false)
 	ret := make([]int, length, capacity)
 }
 


### PR DESCRIPTION
Instead of encoding calls to `make` for slices as a sequence of exhales and inhales that encode a function call, this PR generates a method instead and encodes the calls to make at the Gobra level as method calls to the generated method.

This is the first of a few PRs I have in mind to make the Viper code generated by Viper more readable