### PR TITLE
Fix #625

### DIFF
--- a/src/main/scala/viper/gobra/backend/ViperBackends.scala
+++ b/src/main/scala/viper/gobra/backend/ViperBackends.scala
@@ -78,7 +78,7 @@ object ViperBackends {
     /** returns an existing ViperCoreServer instance or otherwise creates a new one */
     protected def getOrCreateServer(config: Config)(executionContext: GobraExecutionContext): ViperCoreServer = {
       server.getOrElse({
-        var serverConfig = List("--logLevel", config.logLevel.levelStr)
+        var serverConfig = List("--disablePlugins", "--logLevel", config.logLevel.levelStr)
         if(config.cacheFile.isDefined) {
           serverConfig = serverConfig.appendedAll(List("--cacheFile", config.cacheFile.get.toString))
         }


### PR DESCRIPTION
This PR makes Gobra use the new ViperServer flag `--disablePlugins` when choosing ViperServer as verification backend

Closes #625
