### PR TITLE
Print time-per-step when running with log level `DEBUG`

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -225,8 +225,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
       }
     })
     val (errors, inFileConfigs) = inFileEitherConfigs.partitionMap(identity)
-    if (errors.nonEmpty)
-      Left(errors.map(ConfigError))
+    if (errors.nonEmpty) Left(errors.map(ConfigError))
     else {
       // start with original config `config` and merge in every in file config:
       val mergedConfig = inFileConfigs.flatten.foldLeft(config) {

--- a/src/main/scala/viper/gobra/translator/encodings/closures/ClosureDomainEncoder.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/closures/ClosureDomainEncoder.scala
@@ -20,7 +20,6 @@ class ClosureDomainEncoder(specs: ClosureSpecsEncoder) {
 
   private var domainNeeded: Boolean = false
   lazy val vprType: vpr.DomainType = {
-    println("Use of closures detected: Closures are an experimental feature and may exhibit bugs.")
     domainNeeded = true
     vpr.DomainType(Names.closureDomain, Map.empty)(Vector.empty)
   }


### PR DESCRIPTION
When running with the option `--logLevel=DEBUG` or `--debug`, Gobra will print information about how long each step of Gobra takes, as exemplified below:
```
[info] Verifying package .. - router [20:11:02]
[info] Parsing finished in 9.318s.
[info] Type-checking finished in 14.857s.
[info] Desugaring finished in 2.17s.
[info] Internal transformations performed in 0.643s.
[info] Encoding performed in 19.759s.
```

Furthermore, this PR drops the annoying error message that we get when using closures.