### PR TITLE
Remove annoying message when using closures

### DIFF
--- a/src/main/scala/viper/gobra/translator/encodings/closures/ClosureDomainEncoder.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/closures/ClosureDomainEncoder.scala
@@ -20,7 +20,6 @@ class ClosureDomainEncoder(specs: ClosureSpecsEncoder) {
 
   private var domainNeeded: Boolean = false
   lazy val vprType: vpr.DomainType = {
-    println("Use of closures detected: Closures are an experimental feature and may exhibit bugs.")
     domainNeeded = true
     vpr.DomainType(Names.closureDomain, Map.empty)(Vector.empty)
   }


### PR DESCRIPTION
This message gets annoying after the 1000th time. Everything in Gobra is experimental, I don't see why we need a specific message for closures. 