### PR TITLE
Improvements in maps

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -4304,6 +4304,7 @@ object Desugar extends LazyLogging {
         } yield underlyingType(dright.typ) match {
           case _: in.SequenceT | _: in.SetT => in.Contains(dleft, dright)(src)
           case _: in.MultisetT => in.LessCmp(in.IntLit(0)(src), in.Contains(dleft, dright)(src))(src)
+          case _: in.MapT => in.Contains(dleft, dright)(src)
           case t => violation(s"expected a sequence or (multi)set type, but got $t")
         }
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -139,6 +139,7 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
       case PIn(left, right) => isExpr(left).out ++ isExpr(right).out ++ {
         underlyingType(exprType(right)) match {
           case t : GhostCollectionType => ghostComparableTypes.errors(exprType(left), t.elem)(expr)
+          case t : MapT => ghostComparableTypes.errors(exprType(left), t.key)(expr)
           case _ : AdtT => noMessages
           case t => error(right, s"expected a ghost collection, but got $t")
         }

--- a/src/main/scala/viper/gobra/translator/context/Context.scala
+++ b/src/main/scala/viper/gobra/translator/context/Context.scala
@@ -87,6 +87,8 @@ trait Context {
 
   def expression(x: in.Expr): CodeWriter[vpr.Exp] = typeEncoding.finalExpression(this)(x)
 
+  def triggerExpr(x: in.TriggerExpr): CodeWriter[vpr.Exp] = typeEncoding.finalTriggerExpr(this)(x)
+
   def assertion(x: in.Assertion): CodeWriter[vpr.Exp] = typeEncoding.finalAssertion(this)(x)
 
   def invariant(x: in.Assertion): (CodeWriter[Unit], vpr.Exp) = typeEncoding.invariant(this)(x)

--- a/src/main/scala/viper/gobra/translator/context/Context.scala
+++ b/src/main/scala/viper/gobra/translator/context/Context.scala
@@ -87,7 +87,7 @@ trait Context {
 
   def expression(x: in.Expr): CodeWriter[vpr.Exp] = typeEncoding.finalExpression(this)(x)
 
-  def triggerExpr(x: in.TriggerExpr): CodeWriter[vpr.Exp] = typeEncoding.finalTriggerExpr(this)(x)
+  def triggerExpr(x: in.TriggerExpr): CodeWriter[vpr.Exp] = typeEncoding.triggerExpr(this)(x)
 
   def assertion(x: in.Assertion): CodeWriter[vpr.Exp] = typeEncoding.finalAssertion(this)(x)
 

--- a/src/main/scala/viper/gobra/translator/context/DfltTranslatorConfig.scala
+++ b/src/main/scala/viper/gobra/translator/context/DfltTranslatorConfig.scala
@@ -16,7 +16,7 @@ import viper.gobra.translator.encodings.closures.ClosureEncoding
 import viper.gobra.translator.encodings.combinators.{DefaultEncoding, FinalTypeEncoding, SafeTypeEncodingCombiner, TypeEncoding}
 import viper.gobra.translator.encodings.interfaces.InterfaceEncoding
 import viper.gobra.translator.encodings.maps.{MapEncoding, MathematicalMapEncoding}
-import viper.gobra.translator.encodings.defaults.{DefaultGlobalVarEncoding, DefaultMethodEncoding, DefaultPredicateEncoding, DefaultPureMethodEncoding}
+import viper.gobra.translator.encodings.defaults.{DefaultGlobalVarEncoding, DefaultMethodEncoding, DefaultPredicateEncoding, DefaultPureMethodEncoding, DefaultTriggerExprEncoding}
 import viper.gobra.translator.encodings.options.OptionEncoding
 import viper.gobra.translator.encodings.preds.PredEncoding
 import viper.gobra.translator.encodings.sequences.SequenceEncoding
@@ -61,6 +61,7 @@ class DfltTranslatorConfig(
   val pureMethodEncoding = new DefaultPureMethodEncoding
   val predicateEncoding = new DefaultPredicateEncoding
   val globalVarEncoding = new DefaultGlobalVarEncoding
+  val triggerExprEncoding = new DefaultTriggerExprEncoding
 
   val typeEncoding: TypeEncoding = new FinalTypeEncoding(
     new SafeTypeEncodingCombiner(Vector(
@@ -73,7 +74,7 @@ class DfltTranslatorConfig(
       new TerminationEncoding, new BuiltInEncoding, new OutlineEncoding, new DeferEncoding,
       new GlobalEncoding, new Comments,
     ), Vector(
-      methodEncoding, pureMethodEncoding, predicateEncoding, globalVarEncoding
+      methodEncoding, pureMethodEncoding, predicateEncoding, globalVarEncoding, triggerExprEncoding
     ))
   )
 

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
@@ -46,7 +46,7 @@ class FinalTypeEncoding(te: TypeEncoding) extends TypeEncoding {
   override def equal(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = te.equal(ctx) orElse expectedMatch("equal")
   override def goEqual(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = te.goEqual(ctx) orElse expectedMatch("equal")
   override def expression(ctx: Context): in.Expr ==> CodeWriter[vpr.Exp] = te.expression(ctx) orElse expectedMatch("expression")
-  override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = te.triggerExpr(ctx) orElse
+  override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = te.triggerExpr(ctx) orElse expectedMatch("trigger expression")
   override def assertion(ctx: Context): in.Assertion ==> CodeWriter[vpr.Exp] = te.assertion(ctx) orElse expectedMatch("assertion")
   override def reference(ctx: Context): in.Location ==> CodeWriter[vpr.Exp] = te.reference(ctx) orElse expectedMatch("reference")
   override def addressFootprint(ctx: Context): (in.Location, in.Expr) ==> CodeWriter[vpr.Exp] = te.addressFootprint(ctx) orElse expectedMatch("addressFootprint")

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
@@ -61,6 +61,7 @@ class FinalTypeEncoding(te: TypeEncoding) extends TypeEncoding {
   override def extendFunction(ctx: Context): in.Member ==> Extension[MemberWriter[vpr.Function]] = te.extendFunction(ctx) orElse { _ => identity }
   override def extendPredicate(ctx: Context): in.Member ==> Extension[MemberWriter[vpr.Predicate]] = te.extendPredicate(ctx) orElse { _ => identity }
   override def extendExpression(ctx: Context): in.Expr ==> Extension[CodeWriter[vpr.Exp]] = te.extendExpression(ctx) orElse { _ => identity }
+  override def extendTriggerExpr(ctx: Context): in.TriggerExpr ==> Extension[CodeWriter[vpr.Exp]] = te.extendTriggerExpr(ctx) orElse { _ => identity }
   override def extendAssertion(ctx: Context): in.Assertion ==> Extension[CodeWriter[vpr.Exp]] = te.extendAssertion(ctx) orElse { _ => identity }
   override def extendStatement(ctx: Context): in.Stmt ==> Extension[CodeWriter[vpr.Stmt]] = te.extendStatement(ctx) orElse { _ => identity }
 }

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
@@ -46,6 +46,9 @@ class FinalTypeEncoding(te: TypeEncoding) extends TypeEncoding {
   override def equal(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = te.equal(ctx) orElse expectedMatch("equal")
   override def goEqual(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = te.goEqual(ctx) orElse expectedMatch("equal")
   override def expression(ctx: Context): in.Expr ==> CodeWriter[vpr.Exp] = te.expression(ctx) orElse expectedMatch("expression")
+  override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = te.triggerExpr(ctx) orElse {
+    case e: in.Expr => te.expression(ctx)(e)
+  }
   override def assertion(ctx: Context): in.Assertion ==> CodeWriter[vpr.Exp] = te.assertion(ctx) orElse expectedMatch("assertion")
   override def reference(ctx: Context): in.Location ==> CodeWriter[vpr.Exp] = te.reference(ctx) orElse expectedMatch("reference")
   override def addressFootprint(ctx: Context): (in.Location, in.Expr) ==> CodeWriter[vpr.Exp] = te.addressFootprint(ctx) orElse expectedMatch("addressFootprint")
@@ -61,7 +64,6 @@ class FinalTypeEncoding(te: TypeEncoding) extends TypeEncoding {
   override def extendFunction(ctx: Context): in.Member ==> Extension[MemberWriter[vpr.Function]] = te.extendFunction(ctx) orElse { _ => identity }
   override def extendPredicate(ctx: Context): in.Member ==> Extension[MemberWriter[vpr.Predicate]] = te.extendPredicate(ctx) orElse { _ => identity }
   override def extendExpression(ctx: Context): in.Expr ==> Extension[CodeWriter[vpr.Exp]] = te.extendExpression(ctx) orElse { _ => identity }
-  override def extendTriggerExpr(ctx: Context): in.TriggerExpr ==> Extension[CodeWriter[vpr.Exp]] = te.extendTriggerExpr(ctx) orElse { _ => identity }
   override def extendAssertion(ctx: Context): in.Assertion ==> Extension[CodeWriter[vpr.Exp]] = te.extendAssertion(ctx) orElse { _ => identity }
   override def extendStatement(ctx: Context): in.Stmt ==> Extension[CodeWriter[vpr.Stmt]] = te.extendStatement(ctx) orElse { _ => identity }
 }

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
@@ -46,15 +46,7 @@ class FinalTypeEncoding(te: TypeEncoding) extends TypeEncoding {
   override def equal(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = te.equal(ctx) orElse expectedMatch("equal")
   override def goEqual(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = te.goEqual(ctx) orElse expectedMatch("equal")
   override def expression(ctx: Context): in.Expr ==> CodeWriter[vpr.Exp] = te.expression(ctx) orElse expectedMatch("expression")
-  override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = te.triggerExpr(ctx) orElse {
-    // use predicate access encoding but then take just the predicate access, i.e. remove `acc` and the permission amount:
-    case in.Accessible.Predicate(op) =>
-      for {
-        v <- ctx.assertion(in.Access(in.Accessible.Predicate(op), in.FullPerm(op.info))(op.info))
-        pap = v.asInstanceOf[vpr.PredicateAccessPredicate]
-      } yield pap.loc
-    case e: in.Expr => te.expression(ctx)(e)
-  }
+  override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = te.triggerExpr(ctx) orElse
   override def assertion(ctx: Context): in.Assertion ==> CodeWriter[vpr.Exp] = te.assertion(ctx) orElse expectedMatch("assertion")
   override def reference(ctx: Context): in.Location ==> CodeWriter[vpr.Exp] = te.reference(ctx) orElse expectedMatch("reference")
   override def addressFootprint(ctx: Context): (in.Location, in.Expr) ==> CodeWriter[vpr.Exp] = te.addressFootprint(ctx) orElse expectedMatch("addressFootprint")

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/FinalTypeEncoding.scala
@@ -47,6 +47,12 @@ class FinalTypeEncoding(te: TypeEncoding) extends TypeEncoding {
   override def goEqual(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = te.goEqual(ctx) orElse expectedMatch("equal")
   override def expression(ctx: Context): in.Expr ==> CodeWriter[vpr.Exp] = te.expression(ctx) orElse expectedMatch("expression")
   override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = te.triggerExpr(ctx) orElse {
+    // use predicate access encoding but then take just the predicate access, i.e. remove `acc` and the permission amount:
+    case in.Accessible.Predicate(op) =>
+      for {
+        v <- ctx.assertion(in.Access(in.Accessible.Predicate(op), in.FullPerm(op.info))(op.info))
+        pap = v.asInstanceOf[vpr.PredicateAccessPredicate]
+      } yield pap.loc
     case e: in.Expr => te.expression(ctx)(e)
   }
   override def assertion(ctx: Context): in.Assertion ==> CodeWriter[vpr.Exp] = te.assertion(ctx) orElse expectedMatch("assertion")

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -233,7 +233,11 @@ trait TypeEncoding extends Generator {
     case in.Conversion(t2, expr :: t) if typ(ctx).isDefinedAt(t) && typ(ctx).isDefinedAt(t2) => ctx.expression(expr)
   }
 
-  // TODO: doc
+  /**
+    * Encodes expressions when they occur as the top-level expression in a trigger. The default implements
+    * an encoding for predicate instances that and defers the encoding of all expressions occurring in
+    * a trigger to the expression encoding.
+    */
   def triggerExpr(@unused ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = PartialFunction.empty
 
   /**

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -233,6 +233,22 @@ trait TypeEncoding extends Generator {
     case in.Conversion(t2, expr :: t) if typ(ctx).isDefinedAt(t) && typ(ctx).isDefinedAt(t2) => ctx.expression(expr)
   }
 
+  // TODO: doc
+  // TODO: enable consistency checks on triggers when --checkConsistency
+  def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = PartialFunction.empty
+
+  /*
+  {
+    // use predicate access encoding but then take just the predicate access, i.e. remove `acc` and the permission amount:
+    case in.Accessible.Predicate(op) =>
+      for {
+        v <- ctx.assertion(in.Access(in.Accessible.Predicate(op), in.FullPerm(op.info))(op.info))
+        pap = v.asInstanceOf[vpr.PredicateAccessPredicate]
+      } yield pap.loc
+    case e: in.Expr => ctx.expression(e)
+  }
+  */
+
   /**
     * Encodes assertions.
     *
@@ -404,6 +420,18 @@ trait TypeEncoding extends Generator {
   def extendExpression(@unused ctx: Context): in.Expr ==> Extension[CodeWriter[vpr.Exp]] = PartialFunction.empty
   final def finalExpression(ctx: Context): in.Expr ==> CodeWriter[vpr.Exp] = {
     val f = expression(ctx); { case n@f(v) => extendExpression(ctx).lift(n).fold(v)(_(v)) }
+  }
+
+  /** Adds to the encoding of [[triggerExpr]]. The extension is applied to the result of the final trigger expression
+    * encoding.
+    */
+  def extendTriggerExpr(@unused ctx: Context): in.TriggerExpr ==> Extension[CodeWriter[vpr.Exp]] = PartialFunction.empty
+
+  final def finalTriggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = {
+    val f = triggerExpr(ctx);
+    {
+      case n@f(v) => extendTriggerExpr(ctx).lift(n).fold(v)(_(v))
+    }
   }
 
   /** Adds to the encoding of [[assertion]]. The extension is applied to the result of the final assertion encoding. */

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -234,18 +234,7 @@ trait TypeEncoding extends Generator {
   }
 
   // TODO: doc
-  // TODO: optimize assert2(true, ...)
-  // TODO: key in map, instead of key in domain(map)
-  // TODO: enable consistency checks on triggers when --checkConsistency
-  def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = {
-    // use predicate access encoding but then take just the predicate access, i.e. remove `acc` and the permission amount:
-    case in.Accessible.Predicate(op) =>
-      for {
-        v <- ctx.assertion(in.Access(in.Accessible.Predicate(op), in.FullPerm(op.info))(op.info))
-        pap = v.asInstanceOf[vpr.PredicateAccessPredicate]
-      } yield pap.loc
-    // case e: in.Expr => ctx.expression(e)
-  }
+  def triggerExpr(@unused ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = PartialFunction.empty
 
   /**
     * Encodes assertions.

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -234,20 +234,18 @@ trait TypeEncoding extends Generator {
   }
 
   // TODO: doc
+  // TODO: optimize assert2(true, ...)
+  // TODO: key in map, instead of key in domain(map)
   // TODO: enable consistency checks on triggers when --checkConsistency
-  def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = PartialFunction.empty
-
-  /*
-  {
+  def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = {
     // use predicate access encoding but then take just the predicate access, i.e. remove `acc` and the permission amount:
     case in.Accessible.Predicate(op) =>
       for {
         v <- ctx.assertion(in.Access(in.Accessible.Predicate(op), in.FullPerm(op.info))(op.info))
         pap = v.asInstanceOf[vpr.PredicateAccessPredicate]
       } yield pap.loc
-    case e: in.Expr => ctx.expression(e)
+    // case e: in.Expr => ctx.expression(e)
   }
-  */
 
   /**
     * Encodes assertions.
@@ -420,18 +418,6 @@ trait TypeEncoding extends Generator {
   def extendExpression(@unused ctx: Context): in.Expr ==> Extension[CodeWriter[vpr.Exp]] = PartialFunction.empty
   final def finalExpression(ctx: Context): in.Expr ==> CodeWriter[vpr.Exp] = {
     val f = expression(ctx); { case n@f(v) => extendExpression(ctx).lift(n).fold(v)(_(v)) }
-  }
-
-  /** Adds to the encoding of [[triggerExpr]]. The extension is applied to the result of the final trigger expression
-    * encoding.
-    */
-  def extendTriggerExpr(@unused ctx: Context): in.TriggerExpr ==> Extension[CodeWriter[vpr.Exp]] = PartialFunction.empty
-
-  final def finalTriggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = {
-    val f = triggerExpr(ctx);
-    {
-      case n@f(v) => extendTriggerExpr(ctx).lift(n).fold(v)(_(v))
-    }
   }
 
   /** Adds to the encoding of [[assertion]]. The extension is applied to the result of the final assertion encoding. */

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -234,9 +234,9 @@ trait TypeEncoding extends Generator {
   }
 
   /**
-    * Encodes expressions when they occur as the top-level expression in a trigger. The default implements
-    * an encoding for predicate instances that and defers the encoding of all expressions occurring in
-    * a trigger to the expression encoding.
+    * Encodes expressions when they occur as the top-level expression in a trigger.
+    * The default implements an encoding for predicate instances and defers the
+    * encoding of all expressions to the expression encoding.
     */
   def triggerExpr(@unused ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = PartialFunction.empty
 

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncodingCombiner.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncodingCombiner.scala
@@ -49,6 +49,7 @@ abstract class TypeEncodingCombiner(encodings: Vector[TypeEncoding], defaults: V
   override def equal(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = combiner(_.equal(ctx))
   override def goEqual(ctx: Context): (in.Expr, in.Expr, in.Node) ==> CodeWriter[vpr.Exp] = combiner(_.goEqual(ctx))
   override def expression(ctx: Context): in.Expr ==> CodeWriter[vpr.Exp] = combiner(_.expression(ctx))
+  override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = combiner(_.triggerExpr(ctx))
   override def assertion(ctx: Context): in.Assertion ==> CodeWriter[vpr.Exp] = combiner(_.assertion(ctx))
   override def reference(ctx: Context): in.Location ==> CodeWriter[vpr.Exp] = combiner(_.reference(ctx))
   override def addressFootprint(ctx: Context): (in.Location, in.Expr) ==> CodeWriter[vpr.Exp] = combiner(_.addressFootprint(ctx))
@@ -64,7 +65,6 @@ abstract class TypeEncodingCombiner(encodings: Vector[TypeEncoding], defaults: V
   override def extendFunction(ctx: Context): in.Member ==> Extension[MemberWriter[vpr.Function]] = extender(_.extendFunction(ctx))
   override def extendPredicate(ctx: Context): in.Member ==> Extension[MemberWriter[vpr.Predicate]] = extender(_.extendPredicate(ctx))
   override def extendExpression(ctx: Context): in.Expr ==> Extension[CodeWriter[vpr.Exp]] = extender(_.extendExpression(ctx))
-  override def extendTriggerExpr(ctx: Context): in.TriggerExpr ==> Extension[CodeWriter[vpr.Exp]] = extender(_.extendTriggerExpr(ctx))
   override def extendAssertion(ctx: Context): in.Assertion ==> Extension[CodeWriter[vpr.Exp]] = extender(_.extendAssertion(ctx))
   override def extendStatement(ctx: Context): in.Stmt ==> Extension[CodeWriter[vpr.Stmt]] = extender(_.extendStatement(ctx))
 }

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncodingCombiner.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncodingCombiner.scala
@@ -64,6 +64,7 @@ abstract class TypeEncodingCombiner(encodings: Vector[TypeEncoding], defaults: V
   override def extendFunction(ctx: Context): in.Member ==> Extension[MemberWriter[vpr.Function]] = extender(_.extendFunction(ctx))
   override def extendPredicate(ctx: Context): in.Member ==> Extension[MemberWriter[vpr.Predicate]] = extender(_.extendPredicate(ctx))
   override def extendExpression(ctx: Context): in.Expr ==> Extension[CodeWriter[vpr.Exp]] = extender(_.extendExpression(ctx))
+  override def extendTriggerExpr(ctx: Context): in.TriggerExpr ==> Extension[CodeWriter[vpr.Exp]] = extender(_.extendTriggerExpr(ctx))
   override def extendAssertion(ctx: Context): in.Assertion ==> Extension[CodeWriter[vpr.Exp]] = extender(_.extendAssertion(ctx))
   override def extendStatement(ctx: Context): in.Stmt ==> Extension[CodeWriter[vpr.Stmt]] = extender(_.extendStatement(ctx))
 }

--- a/src/main/scala/viper/gobra/translator/encodings/defaults/DefaultTriggerExprEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/defaults/DefaultTriggerExprEncoding.scala
@@ -1,0 +1,27 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2023 ETH Zurich.
+
+package viper.gobra.translator.encodings.defaults
+
+import org.bitbucket.inkytonik.kiama.==>
+import viper.gobra.ast.{internal => in}
+import viper.gobra.translator.context.Context
+import viper.gobra.translator.encodings.combinators.Encoding
+import viper.silver.{ast => vpr}
+
+class DefaultTriggerExprEncoding extends Encoding {
+  import viper.gobra.translator.util.ViperWriter._
+
+  override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = {
+    // use predicate access encoding but then take just the predicate access, i.e. remove `acc` and the permission amount:
+    case in.Accessible.Predicate(op) =>
+      for {
+        v <- ctx.assertion(in.Access(in.Accessible.Predicate(op), in.FullPerm(op.info))(op.info))
+        pap = v.asInstanceOf[vpr.PredicateAccessPredicate]
+      } yield pap.loc
+    case e: in.Expr => ctx.expression(e)
+  }
+}

--- a/src/main/scala/viper/gobra/translator/encodings/defaults/DefaultTriggerExprEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/defaults/DefaultTriggerExprEncoding.scala
@@ -16,7 +16,7 @@ class DefaultTriggerExprEncoding extends Encoding {
   import viper.gobra.translator.util.ViperWriter._
 
   override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = {
-    // use predicate access encoding but then take just the predicate access, i.e. remove `acc` and the permission amount:
+    // use predicate access encoding but then take just the predicate access, i.e. without the access predicate:
     case in.Accessible.Predicate(op) =>
       for {
         v <- ctx.assertion(in.Access(in.Accessible.Predicate(op), in.FullPerm(op.info))(op.info))

--- a/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
@@ -129,9 +129,9 @@ class MapEncoding extends LeafTypeEncoding {
 
   /**
     * Encodes expressions when they occur as the top-level expression in a trigger.
-    * Notice that if we had used the expression encoding for the following triggers,
-    * they would have resulted in ill-formed triggers at the Viper level (e.g., because
-    * they would have ternary operations).
+    * Notice that using the expression encoding for the following triggers,
+    * results in ill-formed triggers at the Viper level (e.g., because
+    * they have ternary operations).
     *   { m[i] } -> { getCorrespondingMap([ m ])[ [ i ] ] }
     *   { k in m } -> { [ k ] in getCorrespondingMap([ m ]) }
     *   { k in domain(m) } -> { [ k ] in domain(getCorrespondingMap([ m ])) }

--- a/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
@@ -24,6 +24,9 @@ import viper.silver.verifier.reasons.AssertionFalse
 import viper.silver.verifier.{ErrorReason, errors => err}
 import viper.silver.{ast => vpr}
 
+// TODO: use macros to make the generated code readable?
+// TODO: remove call to assert2 when the condition is the true lit
+
 /**
   * Encoding for Go maps. Unlike slices, maps are not thread-safe;
   * thus, all concurrent accesses to maps must be synchronized. In particular,
@@ -108,6 +111,12 @@ class MapEncoding extends LeafTypeEncoding {
             correspondingMapRange
           ), v)
         } yield res
+    }
+  }
+
+  override def triggerExpr(ctx: Context): in.TriggerExpr ==> CodeWriter[vpr.Exp] = {
+    default(super.triggerExpr(ctx)) {
+      case in.IndexedExp(_ :: ctx.Map(_, _), _, _) => unit(vpr.TrueLit()())
     }
   }
 

--- a/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
@@ -106,18 +106,8 @@ class AssertionEncoding extends Encoding {
 
   def trigger(trigger: in.Trigger)(ctx: Context) : CodeWriter[vpr.Trigger] = {
     val (pos, info, errT) = trigger.vprMeta
-    for { expr <- sequence(trigger.exprs map (triggerExpr(_)(ctx))) }
+    for { expr <- sequence(trigger.exprs map ctx.triggerExpr)}
       yield vpr.Trigger(expr)(pos, info, errT)
-  }
-
-  def triggerExpr(expr: in.TriggerExpr)(ctx: Context): CodeWriter[vpr.Exp] = expr match {
-    // use predicate access encoding but then take just the predicate access, i.e. remove `acc` and the permission amount:
-    case in.Accessible.Predicate(op) =>
-      for {
-        v <- ctx.assertion(in.Access(in.Accessible.Predicate(op), in.FullPerm(op.info))(op.info))
-        pap = v.asInstanceOf[vpr.PredicateAccessPredicate]
-      } yield pap.loc
-    case e: in.Expr => ctx.expression(e)
   }
 
   def quantifier(vars: Vector[in.BoundVar], triggers: Vector[in.Trigger], body: in.Expr)(ctx: Context) : CodeWriter[(Seq[vpr.LocalVarDecl], Seq[vpr.Trigger], vpr.Exp)] = {

--- a/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
+++ b/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
@@ -399,11 +399,12 @@ object ViperWriter {
     /* Can be used in expressions. */
     def assert(cond: vpr.Exp, exp: vpr.Exp, reasonT: (Source.Verifier.Info, ErrorReason) => VerificationError)(ctx: Context): Writer[vpr.Exp] = {
       // In the future, this might do something more sophisticated
-      if (cond.isInstanceOf[vpr.TrueLit]) {
-        unit(exp)
-      } else {
-        val (res, errT) = ctx.condition.assert(cond, exp, reasonT)
-        errorT(errT).map(_ => res)
+      cond match {
+        case vpr.TrueLit() =>
+          unit(exp)
+        case _ =>
+          val (res, errT) = ctx.condition.assert(cond, exp, reasonT)
+          errorT(errT).map(_ => res)
       }
     }
 

--- a/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
+++ b/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
@@ -399,8 +399,12 @@ object ViperWriter {
     /* Can be used in expressions. */
     def assert(cond: vpr.Exp, exp: vpr.Exp, reasonT: (Source.Verifier.Info, ErrorReason) => VerificationError)(ctx: Context): Writer[vpr.Exp] = {
       // In the future, this might do something more sophisticated
-      val (res, errT) = ctx.condition.assert(cond, exp, reasonT)
-      errorT(errT).map(_ => res)
+      if (cond.isInstanceOf[vpr.TrueLit]) {
+        unit(exp)
+      } else {
+        val (res, errT) = ctx.condition.assert(cond, exp, reasonT)
+        errorT(errT).map(_ => res)
+      }
     }
 
     /* Emits Viper statements. */

--- a/src/test/resources/regressions/features/maps/maps-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/maps-simple1.gobra
@@ -52,6 +52,9 @@ func test6() {
 	m[3] = 10
 	v3, ok3 := m[3]
 	assert ok3 && v3 == 10
+
+	// check if key exists in the map
+	assert 3 in m
 }
 
 type T struct {
@@ -110,24 +113,24 @@ func test11() {
 requires acc(m, _)
 requires "key" in domain(m)
 func test12(m map[string]string) (r string){
-    return m["key"]
+	return m["key"]
 }
 
 requires acc(m, _)
 requires "value" in range(m)
 func test13(m map[string]string) {
-    assert exists k string :: m[k] == "value"
+	assert exists k string :: m[k] == "value"
 }
 
 func test14() (res map[int]int) {
 	x := 1
 	y := 2
-    m := map[int]int{x: y, y: x}
+	m := map[int]int{x: y, y: x}
 	return m
 }
 
 func test15() (res map[int]int) {
-    m := map[int]int{C1: C2, C2: C1}
+	m := map[int]int{C1: C2, C2: C1}
 	return m
 }
 
@@ -138,3 +141,7 @@ func test16() {
 	x, contained := m[2]
 	assert x == 0 && !contained
 }
+
+requires m != nil ==> acc(m)
+requires forall s string :: { s in domain(m) } s in domain(m) ==> acc(m[s])
+func test17(m map[string]*int) {}

--- a/src/test/resources/regressions/features/maps/maps-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/maps-simple1.gobra
@@ -145,3 +145,11 @@ func test16() {
 requires m != nil ==> acc(m)
 requires forall s string :: { s in domain(m) } s in domain(m) ==> acc(m[s])
 func test17(m map[string]*int) {}
+
+requires m != nil ==> acc(m)
+requires forall s string :: { s in m } s in m ==> acc(m[s])
+func test18(m map[string]*int) {}
+
+requires m != nil ==> acc(m)
+requires forall i int :: { i in range(m) } i in range(m) ==> 0 < i
+func test19(m map[string]int) {}


### PR DESCRIPTION
This PR extends the `TypeEncoding` with a method `triggerExpr` that is now used to encode expressions that occur in triggers (instead of encoding them with `expression`). This allows us to select well-formed triggers whenever the `expression` encoding generates ill-formed triggers. With this, we solve a long-standing issue where triggers containing a a map (like `m[i]` or `i in range(m)`) are translated to invalid triggers at the Viper level.

Besides, this PR introduces two quality of life improvements
- like in Viper, we now support the idiom `key in m`, where `m` is a map, whereas before we would have had to write `key in domain(m)`. The previous idiom is still supported.
- the `assert` method in `ViperWriter` has been simplified to not generate a call to `assert` whenever the condition is `TrueLit`. Instead, it simplifies to the expression. This makes the resulting Viper code look much cleaner.

In the future, we may re-organize the map encoding as done in https://github.com/viperproject/gobra/pull/606.

TODO:
- [x] doc
- [x] use default encoding for the fallback case instead of having it in the type combiner
- [x] test with the slayers/path package in SCION