### PR TITLE
support nested dicts, maps and dicts-maps in options

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -3698,7 +3698,10 @@ object Desugar extends LazyLogging {
         val valuesD = typeD(values, Addressability.mapValue)(src)
         in.MapT(keysD, valuesD, addrMod)
       case Type.GhostSliceT(elem) => in.SliceT(typeD(elem, Addressability.sliceElement)(src), addrMod)
-      case Type.OptionT(elem) => in.OptionT(typeD(elem, Addressability.mathDataStructureElement)(src), addrMod)
+      case Type.OptionT(elem) => elem match {
+        case InternalSingleMulti(trueElem, _) => in.OptionT(typeD(trueElem, Addressability.mathDataStructureElement)(src), addrMod)
+        case _ => in.OptionT(typeD(elem, Addressability.mathDataStructureElement)(src), addrMod)
+      }
       case PointerT(elem) => registerType(in.PointerT(typeD(elem, Addressability.pointerBase)(src), addrMod))
       case Type.ChannelT(elem, _) => in.ChannelT(typeD(elem, Addressability.channelElement)(src), addrMod)
       case Type.SequenceT(elem) => in.SequenceT(typeD(elem, Addressability.mathDataStructureElement)(src), addrMod)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -205,11 +205,11 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
           case t => error(op, s"expected a sequence, multiset or option type, but got $t")
         }
         case PMapKeys(exp) => underlyingType(exprType(exp)) match {
-          case _: MathMapT | _: MapT => isExpr(exp).out
+          case _: MathMapT | _: MapT | InternalSingleMulti(_: MathMapT, _) | InternalSingleMulti(_: MapT, _) => isExpr(exp).out
           case t => error(expr, s"expected a map, but got $t")
         }
         case PMapValues(exp) => underlyingType(exprType(exp)) match {
-          case _: MathMapT | _: MapT => isExpr(exp).out
+          case _: MathMapT | _: MapT | InternalSingleMulti(_: MathMapT, _) | InternalSingleMulti(_: MapT, _)=> isExpr(exp).out
           case t => error(expr, s"expected a map, but got $t")
         }
       }
@@ -310,11 +310,15 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
         case PMapKeys(exp) => underlyingType(exprType(exp)) match {
           case t: MathMapT => SetT(t.key)
           case t: MapT => SetT(t.key)
+          case InternalSingleMulti(t: MathMapT, _) => SetT(t.key)
+          case InternalSingleMulti(t: MapT, _) => SetT(t.key)
           case t => violation(s"expected a map, but got $t")
         }
         case PMapValues(exp) => underlyingType(exprType(exp)) match {
           case t: MathMapT => SetT(t.elem)
           case t: MapT => SetT(t.elem)
+          case InternalSingleMulti(t: MathMapT, _) => SetT(t.elem)
+          case InternalSingleMulti(t: MapT, _) => SetT(t.elem)
           case t => violation(s"expected a map, but got $t")
         }
       }

--- a/src/test/resources/regressions/features/maps/maps-nested.gobra
+++ b/src/test/resources/regressions/features/maps/maps-nested.gobra
@@ -1,0 +1,11 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+ghost
+func foo(){
+    mm := dict[int](dict[int]int){1 : {2:3}}
+    assert mm[1][2] == 3
+    assert 2 in domain(mm[1])
+}

--- a/src/test/resources/regressions/features/options/options-nested-maps.gobra
+++ b/src/test/resources/regressions/features/options/options-nested-maps.gobra
@@ -1,0 +1,19 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+ghost
+pure func bar(m dict[int]int, idx int) option[int] {
+    return idx in domain(m) ? some(m[idx]) : none[int]
+}
+
+ghost
+pure func baz(m dict[int]int, idx int) option[int] {
+    return match idx in domain(m){
+        case true:
+            some(m[idx])
+        case false:
+            none[int]
+    }
+}


### PR DESCRIPTION
The new two tests added in this PR were reported by Markus as not type-checking properly.
The problem was with the nested dicts where with a dict `m`, the expression `m[1][1]` would not typecheck since `m[1]` instead of type `MathMapT` has the `InternalSingleMulti` type.
Similar problem existed with options.