### PR TITLE
Treat values of type InternalSingleMulti(t, ms) as t for nested dictionaries

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -205,11 +205,11 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
           case t => error(op, s"expected a sequence, multiset or option type, but got $t")
         }
         case PMapKeys(exp) => underlyingType(exprType(exp)) match {
-          case Single(_: MathMapT) | Single(_: MapT) => isExpr(exp).out
+          case Single(_: MathMapT | _: MapT) => isExpr(exp).out
           case t => error(expr, s"expected a map, but got $t")
         }
         case PMapValues(exp) => underlyingType(exprType(exp)) match {
-          case Single(_: MathMapT) | Single(_: MapT) => isExpr(exp).out
+          case Single(_: MathMapT | _: MapT) => isExpr(exp).out
           case t => error(expr, s"expected a map, but got $t")
         }
       }
@@ -315,19 +315,13 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
           case t => violation(s"expected a sequence, set, multiset or option type, but got $t")
         }
         case PMapKeys(exp) => underlyingType(exprType(exp)) match {
-          case Single(t) => t match {
-            case t: MathMapT => SetT(t.key)
-            case t: MapT => SetT(t.key)
-            case t => violation(s"expected a map, but got $t")
-          }
+          case Single(t: MathMapT) => SetT(t.key)
+          case Single(t: MapT) => SetT(t.key)
           case t => violation(s"expected a map, but got $t")
         }
         case PMapValues(exp) => underlyingType(exprType(exp)) match {
-          case Single(t) => t match {
-            case t: MathMapT => SetT(t.elem)
-            case t: MapT => SetT(t.elem)
-            case t => violation(s"expected a map, but got $t")
-          }
+          case Single(t: MathMapT) => SetT(t.elem)
+          case Single(t: MapT) => SetT(t.elem)
           case t => violation(s"expected a map, but got $t")
         }
       }

--- a/src/main/scala/viper/gobra/translator/Names.scala
+++ b/src/main/scala/viper/gobra/translator/Names.scala
@@ -62,6 +62,7 @@ object Names {
     case in.ArrayT(len, elemT, addr) => s"Array$len${serializeType(elemT)}${serializeAddressability(addr)}"
     case in.SliceT(elemT, addr) => s"Slice${serializeType(elemT)}${serializeAddressability(addr)}"
     case in.MapT(keyT, valueT, addr) => s"Map${serializeType(keyT)}_${serializeType(valueT)}_${serializeAddressability(addr)}"
+    case in.MathMapT(keyT, valueT, addr) => s"Dict${serializeType(keyT)}_${serializeType(valueT)}_${serializeAddressability(addr)}"
     case in.SequenceT(elemT, addr) => s"Sequence${serializeType(elemT)}${serializeAddressability(addr)}"
     case in.SetT(elemT, addr) => s"Set${serializeType(elemT)}${serializeAddressability(addr)}"
     case in.MultisetT(elemT, addr) => s"Multiset${serializeType(elemT)}${serializeAddressability(addr)}"

--- a/src/test/resources/regressions/features/maps/maps-nested.gobra
+++ b/src/test/resources/regressions/features/maps/maps-nested.gobra
@@ -1,0 +1,11 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+ghost
+func foo(){
+    mm := dict[int](dict[int]int){1 : {2:3}}
+    assert mm[1][2] == 3
+    assert 2 in domain(mm[1])
+}

--- a/src/test/resources/regressions/features/options/options-nested-maps.gobra
+++ b/src/test/resources/regressions/features/options/options-nested-maps.gobra
@@ -1,0 +1,19 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+ghost
+pure func bar(m dict[int]int, idx int) option[int] {
+    return idx in domain(m) ? some(m[idx]) : none[int]
+}
+
+ghost
+pure func baz(m dict[int]int, idx int) option[int] {
+    return match idx in domain(m){
+        case true:
+            some(m[idx])
+        case false:
+            none[int]
+    }
+}


### PR DESCRIPTION
Our treatment of expressions with type `InternalSingleMulti(t, ms)` is very iffy atm, leading to issues like those reported in #694. This PR addresses the issue in part. It allows progress on VerifiedSCION to continue, but I recognize that extending this solution to the entire type system is cumbersome. Ideally, we would have a more systematic way to deal with expressions of this type.