### PR TITLE
Fixes Pretty Printer

### DIFF
--- a/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
@@ -140,10 +140,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
     measure match {
       case WildcardMeasure(cond) => "_" <+> showCond(cond)
       case TupleTerminationMeasure(tuple, cond) =>
-        hcat(tuple map {
-          case e: Expr => showExpr(e)
-          case n => violation(s"Unexpected node $n")
-        }) <+> showCond(cond)
+        hcat(tuple map show) <+> showCond(cond)
     }
   }
 

--- a/src/test/scala/viper/gobra/GobraTests.scala
+++ b/src/test/scala/viper/gobra/GobraTests.scala
@@ -16,7 +16,7 @@ import viper.gobra.frontend.Source.FromFileSource
 import viper.gobra.frontend.info.Info
 import viper.gobra.frontend.{Config, PackageResolver, Parser, Source}
 import viper.gobra.reporting.VerifierResult.{Failure, Success}
-import viper.gobra.reporting.{NoopReporter, VerifierError}
+import viper.gobra.reporting.{GobraMessage, GobraReporter, VerifierError}
 import viper.silver.testing.{AbstractOutput, AnnotatedTestInput, ProjectInfo, SystemUnderTest}
 import viper.silver.utility.TimingUtils
 import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
@@ -51,7 +51,7 @@ class GobraTests extends AbstractGobraTests with BeforeAndAfterAll {
   private def getConfig(source: Source): Config =
     Config(
       logLevel = Level.INFO,
-      reporter = NoopReporter,
+      reporter = StringifyReporter,
       packageInfoInputMap = Map(Source.getPackageInfo(source, Path.of("")) -> Vector(source)),
       checkConsistency = true,
       cacheParserAndTypeChecker = cacheParserAndTypeChecker,
@@ -119,5 +119,14 @@ class GobraTests extends AbstractGobraTests with BeforeAndAfterAll {
 
     /** A short and unique identifier for this output. */
     override def fullId: String = error.id
+  }
+
+  case object StringifyReporter extends GobraReporter {
+    override val name: String = "StringifyReporter"
+
+    override def report(msg: GobraMessage): Unit = {
+      // by invoking `toString`, we check that messages are printable, which includes pretty-printing AST nodes:
+      msg.toString
+    }
   }
 }


### PR DESCRIPTION
Pretty printing a termination measure consisting of a predicate instance results in a violation. This PR fixes the pretty printer and adapts the (single-package) unit tests to print Gobra messages, which in turn triggers pretty-printing of ASTs contained in these messages, thus hopefully preventing similar errors in the future.