### PR TITLE
Improve Gobra Package Information

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,8 +84,11 @@ jobs:
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 
-      # - name: Print metadata
-      #   run: echo ${{ steps.image-build.outputs.metadata }}
+      - name: Print metadata
+        run: |
+          echo "${{ steps.image-metadata.outputs.tags }}"
+          echo "${{ steps.image-metadata.outputs.tags[0] }}"
+          echo "${{ steps.image-metadata.outputs.tags[1] }}"
 
       - name: Execute all tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,6 +53,7 @@ jobs:
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v\.?//')
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
+          echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
           echo "IMAGE_TAG=$IMAGE_ID:$VERSION" >> $GITHUB_ENV
 
       # used to enable Docker caching (see https://github.com/docker/build-push-action)
@@ -64,6 +65,15 @@ jobs:
           CREATED_LABEL="org.opencontainers.image.created=\"$(date --rfc-3339=seconds)\""
           echo "CREATED_LABEL=$CREATED_LABEL" >> $GITHUB_ENV
 
+      - name: Create image metadata
+        id: image-metadata
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_ID }}
+          labels: |
+            ${{ env.IMAGE_LABELS }}
+            ${{ env.CREATED_LABEL }}
+
       - name: Build image up to including stage 'build'
         id: image-build
         # note that the action's name is misleading: this step does NOT push
@@ -73,10 +83,8 @@ jobs:
           load: true # make the built image available in docker (locally)
           target: build # only build up to and including stage 'build'
           file: workflow-container/Dockerfile
-          tags: ${{ env.IMAGE_TAG }}
-          labels: |
-            ${{ env.IMAGE_LABELS }}
-            ${{ env.CREATED_LABEL }}
+          tags: ${{ steps.image-metadata.outputs.tags }}
+          labels: ${{ steps.image-metadata.outputs.labels }}
           push: false
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
@@ -196,10 +204,8 @@ jobs:
           context: .
           load: true # make the built image available in docker (locally)
           file: workflow-container/Dockerfile
-          tags: ${{ env.IMAGE_TAG }}
-          labels: |
-            ${{ env.IMAGE_LABELS }}
-            ${{ env.CREATED_LABEL }}
+          tags: ${{ steps.image-metadata.outputs.tags }}
+          labels: ${{ steps.image-metadata.outputs.labels }}
           push: false
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
@@ -241,10 +247,8 @@ jobs:
         with:
           context: .
           file: workflow-container/Dockerfile
-          tags: ${{ env.IMAGE_TAG }}
-          labels: |
-            ${{ env.IMAGE_LABELS }}
-            ${{ env.CREATED_LABEL }}
+          tags: ${{ steps.image-metadata.outputs.tags }}
+          labels: ${{ steps.image-metadata.outputs.labels }}
           push: true
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: gobra
+      IMAGE_LABELS: |
+        org.opencontainers.image.created=$(date --rfc-3339=seconds)
+        org.opencontainers.image.authors=Viper Project (https://viper.ethz.ch)
+        org.opencontainers.image.url=https://github.com/viperproject/gobra/pkgs/container/gobra
+        org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+        org.opencontainers.image.revision=${{ github.sha }}
+        org.opencontainers.image.licenses=MPL-2.0
+        org.opencontainers.image.description=Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}
       CONCLUSION_SUCCESS: "success"
       CONCLUSION_FAILURE: "failure"
       # Output levels according to severity.
@@ -47,14 +55,14 @@ jobs:
           [ "$VERSION" == "master" ] && VERSION=latest
           echo "IMAGE_TAG=$IMAGE_ID:$VERSION" >> $GITHUB_ENV
           # image labels are new-line separated key value pairs (according to https://specs.opencontainers.org/image-spec/annotations/)
-          CREATED_LABEL="org.opencontainers.image.created=$(date --rfc-3339=seconds)"
-          AUTHORS_LABEL="org.opencontainers.image.authors=Viper Project (https://viper.ethz.ch)"
-          URL_LABEL="org.opencontainers.image.url=https://github.com/viperproject/gobra/pkgs/container/gobra"
-          SOURCE_LABEL="org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}"
-          REVISION_LABEL="org.opencontainers.image.revision=${{ github.sha }}"
-          LICENSE_LABEL="org.opencontainers.image.licenses=MPL-2.0"
-          DESCRIPTION_LABEL="org.opencontainers.image.description=Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}"
-          echo "IMAGE_LABELS=$CREATED_LABEL\n$AUTHORS_LABEL\n$URL_LABEL\n$SOURCE_LABEL\n$REVISION_LABEL\n$LICENSE_LABEL\n$DESCRIPTION_LABEL" >> $GITHUB_ENV
+          # CREATED_LABEL="org.opencontainers.image.created=$(date --rfc-3339=seconds)"
+          # AUTHORS_LABEL="org.opencontainers.image.authors=Viper Project (https://viper.ethz.ch)"
+          # URL_LABEL="org.opencontainers.image.url=https://github.com/viperproject/gobra/pkgs/container/gobra"
+          # SOURCE_LABEL="org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}"
+          # REVISION_LABEL="org.opencontainers.image.revision=${{ github.sha }}"
+          # LICENSE_LABEL="org.opencontainers.image.licenses=MPL-2.0"
+          # DESCRIPTION_LABEL="org.opencontainers.image.description=Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}"
+          # echo "IMAGE_LABELS=$CREATED_LABEL\n$AUTHORS_LABEL\n$URL_LABEL\n$SOURCE_LABEL\n$REVISION_LABEL\n$LICENSE_LABEL\n$DESCRIPTION_LABEL" >> $GITHUB_ENV
 
       # used to enable Docker caching (see https://github.com/docker/build-push-action)
       - name: Set up Docker Buildx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,13 +17,12 @@ jobs:
     env:
       IMAGE_NAME: gobra
       IMAGE_LABELS: |
-        org.opencontainers.image.created=$(date --rfc-3339=seconds)
-        org.opencontainers.image.authors=Viper Project (https://viper.ethz.ch)
-        org.opencontainers.image.url=https://github.com/viperproject/gobra/pkgs/container/gobra
-        org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
-        org.opencontainers.image.revision=${{ github.sha }}
-        org.opencontainers.image.licenses=MPL-2.0
-        org.opencontainers.image.description=Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}
+        org.opencontainers.image.authors="Viper Project (https://viper.ethz.ch)"
+        org.opencontainers.image.url="https://github.com/viperproject/gobra/pkgs/container/gobra"
+        org.opencontainers.image.source="${{ github.server_url }}/${{ github.repository }}"
+        org.opencontainers.image.revision="${{ github.sha }}"
+        org.opencontainers.image.licenses="MPL-2.0"
+        org.opencontainers.image.description="Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}"
       CONCLUSION_SUCCESS: "success"
       CONCLUSION_FAILURE: "failure"
       # Output levels according to severity.
@@ -55,7 +54,7 @@ jobs:
           [ "$VERSION" == "master" ] && VERSION=latest
           echo "IMAGE_TAG=$IMAGE_ID:$VERSION" >> $GITHUB_ENV
           # image labels are new-line separated key value pairs (according to https://specs.opencontainers.org/image-spec/annotations/)
-          # CREATED_LABEL="org.opencontainers.image.created=$(date --rfc-3339=seconds)"
+          CREATED_LABEL="org.opencontainers.image.created=$(date --rfc-3339=seconds)"
           # AUTHORS_LABEL="org.opencontainers.image.authors=Viper Project (https://viper.ethz.ch)"
           # URL_LABEL="org.opencontainers.image.url=https://github.com/viperproject/gobra/pkgs/container/gobra"
           # SOURCE_LABEL="org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}"
@@ -63,6 +62,7 @@ jobs:
           # LICENSE_LABEL="org.opencontainers.image.licenses=MPL-2.0"
           # DESCRIPTION_LABEL="org.opencontainers.image.description=Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}"
           # echo "IMAGE_LABELS=$CREATED_LABEL\n$AUTHORS_LABEL\n$URL_LABEL\n$SOURCE_LABEL\n$REVISION_LABEL\n$LICENSE_LABEL\n$DESCRIPTION_LABEL" >> $GITHUB_ENV
+          echo "CREATED_LABEL=$CREATED_LABEL" >> $GITHUB_ENV
 
       # used to enable Docker caching (see https://github.com/docker/build-push-action)
       - name: Set up Docker Buildx
@@ -77,7 +77,9 @@ jobs:
           target: build # only build up to and including stage 'build'
           file: workflow-container/Dockerfile
           tags: ${{ env.IMAGE_TAG }}
-          labels: ${{ env.IMAGE_LABELS }}
+          labels: |
+            ${{ env.IMAGE_LABELS }}
+            ${{ env.CREATED_LABEL }}
           push: false
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
@@ -195,7 +197,9 @@ jobs:
           load: true # make the built image available in docker (locally)
           file: workflow-container/Dockerfile
           tags: ${{ env.IMAGE_TAG }}
-          labels: ${{ env.IMAGE_LABELS }}
+          labels: |
+            ${{ env.IMAGE_LABELS }}
+            ${{ env.CREATED_LABEL }}
           push: false
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
@@ -238,7 +242,9 @@ jobs:
           context: .
           file: workflow-container/Dockerfile
           tags: ${{ env.IMAGE_TAG }}
-          labels: ${{ env.IMAGE_LABELS }}
+          labels: |
+            ${{ env.IMAGE_LABELS }}
+            ${{ env.CREATED_LABEL }}
           push: true
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,12 +10,14 @@ on:
   push: # run this workflow on every push
   pull_request: # run this workflow on every pull_request
 
+env:
+  IMAGE_NAME: gobra
+
 jobs:
   # there is a single job to avoid copying the built docker image from one job to the other
   build-test-deploy-container:
     runs-on: ubuntu-latest
     env:
-      IMAGE_NAME: gobra
       IMAGE_ID: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
       # image labels are new-line separated key value pairs (according to https://specs.opencontainers.org/image-spec/annotations/):
       IMAGE_LABELS: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,9 @@ jobs:
             type=sha
           # the first 4 tags correspond to the default options. We additionally add the commit hash
 
+      - name: Get first tag
+        run: echo "IMAGE_TAG=$(echo "${{ steps.image-metadata.outputs.tags }}" | head -1)" >> $GITHUB_ENV
+
       - name: Build image up to including stage 'build'
         id: image-build
         # note that the action's name is misleading: this step does NOT push
@@ -84,24 +87,18 @@ jobs:
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 
-      - name: Print metadata
-        run: |
-          echo "${{ steps.image-metadata.outputs.tags }}"
-          echo "${{ steps.image-metadata.outputs.tags[0] }}"
-          echo "${{ steps.image-metadata.outputs.tags[1] }}"
-
       - name: Execute all tests
         run: |
           # create a directory to sync with the docker container and to store the created pidstats
           mkdir -p $PWD/sync
           docker run \
             --mount type=volume,dst=/build/gobra/sync,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/sync \
-            ${{ steps.image-metadata.outputs.tags[0] }} \
+            ${{ env.IMAGE_TAG }} \
             /bin/sh -c "echo 'Test'"
           
           # docker run \
           #  --mount type=volume,dst=/build/gobra/sync,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/sync \
-          #  ${{ steps.image-metadata.outputs.tags[0] }} \
+          #  ${{ env.IMAGE_TAG }} \
           #  /bin/sh -c "$(cat .github/test-and-measure-ram.sh)"
 
       - name: Get max RAM usage by Java and Z3
@@ -212,7 +209,7 @@ jobs:
       - name: Test final container by verifying a file
         run: |
           docker run \
-            ${{ steps.image-metadata.outputs.tags[0] }} \
+            ${{ env.IMAGE_TAG }} \
             -i tutorial-examples/basicAnnotations.gobra
 
       - name: Decide whether image should be deployed or not

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,8 +67,8 @@ jobs:
             type=ref,event=pr
             # use (short) commit hash as tag:
             type=sha
-            # set latest tag for default branch:
-            type=raw,value=latest,enable={{is_default_branch}}
+            # use latest tag for default branch and with highest priority (1000 is the highest default priority for the other types):
+            type=raw,value=latest,priority=1100,enable={{is_default_branch}}
 
       - name: Get first tag
         run: echo "IMAGE_TAG=$(echo "${{ steps.image-metadata.outputs.tags }}" | head -1)" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
           SILICON_SILVER_REF=$(git -C viperserver/silicon/silver rev-parse HEAD) && \
           CARBON_SILVER_REF=$(git -C viperserver/carbon/silver rev-parse HEAD) && \
           if [ "$SILICON_SILVER_REF" != "$CARBON_SILVER_REF" ]; then echo "Silicon and Carbon reference different Silver commits ($SILICON_SILVER_REF and $CARBON_SILVER_REF)" && exit 1 ; fi
-      - name: Create image tag
+      - name: Create image tag and labels
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 
@@ -46,6 +46,15 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
           echo "IMAGE_TAG=$IMAGE_ID:$VERSION" >> $GITHUB_ENV
+          # image labels are new-line separated key value pairs (according to https://specs.opencontainers.org/image-spec/annotations/)
+          CREATED_LABEL="org.opencontainers.image.created=$(date --rfc-3339=seconds)"
+          AUTHORS_LABEL="org.opencontainers.image.authors=Viper Project (https://viper.ethz.ch)"
+          URL_LABEL="org.opencontainers.image.url=https://github.com/viperproject/gobra/pkgs/container/gobra"
+          SOURCE_LABEL="org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}"
+          REVISION_LABEL="org.opencontainers.image.revision=${{ github.sha }}"
+          LICENSE_LABEL="org.opencontainers.image.licenses=MPL-2.0"
+          DESCRIPTION_LABEL="org.opencontainers.image.description=Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}"
+          echo "IMAGE_LABELS=CREATED_LABEL\nAUTHORS_LABEL\nURL_LABEL\nSOURCE_LABEL\nREVISION_LABEL\nLICENSE_LABEL\nDESCRIPTION_LABEL" >> $GITHUB_ENV
 
       # used to enable Docker caching (see https://github.com/docker/build-push-action)
       - name: Set up Docker Buildx
@@ -60,7 +69,7 @@ jobs:
           target: build # only build up to and including stage 'build'
           file: workflow-container/Dockerfile
           tags: ${{ env.IMAGE_TAG }}
-          labels: "runnumber=${{ github.run_id }}"
+          labels: ${{ env.IMAGE_LABELS }}
           push: false
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
@@ -173,7 +182,7 @@ jobs:
           load: true # make the built image available in docker (locally)
           file: workflow-container/Dockerfile
           tags: ${{ env.IMAGE_TAG }}
-          labels: "runnumber=${{ github.run_id }}"
+          labels: ${{ env.IMAGE_LABELS }}
           push: false
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
@@ -202,7 +211,7 @@ jobs:
           echo "SHOULD_DEPLOY=$SHOULD_DEPLOY" >> $GITHUB_ENV
 
       - name: Login to Github Packages
-        if: env.SHOULD_DEPLOY == 'true'
+        # if: env.SHOULD_DEPLOY == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -210,13 +219,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push entire image
-        if: env.SHOULD_DEPLOY == 'true'
+        # if: env.SHOULD_DEPLOY == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .
           file: workflow-container/Dockerfile
           tags: ${{ env.IMAGE_TAG }}
-          labels: "runnumber=${{ github.run_id }}"
+          labels: ${{ env.IMAGE_LABELS }}
           push: true
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,12 +94,7 @@ jobs:
           docker run \
             --mount type=volume,dst=/build/gobra/sync,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/sync \
             ${{ env.IMAGE_TAG }} \
-            /bin/sh -c "echo 'Test'"
-          
-          # docker run \
-          #  --mount type=volume,dst=/build/gobra/sync,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/sync \
-          #  ${{ env.IMAGE_TAG }} \
-          #  /bin/sh -c "$(cat .github/test-and-measure-ram.sh)"
+            /bin/sh -c "$(cat .github/test-and-measure-ram.sh)"
 
       - name: Get max RAM usage by Java and Z3
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,7 +82,12 @@ jobs:
           docker run \
             --mount type=volume,dst=/build/gobra/sync,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/sync \
             ${{ env.IMAGE_TAG }} \
-            /bin/sh -c "$(cat .github/test-and-measure-ram.sh)"
+            /bin/sh -c "echo 'Test'"
+          
+          # docker run \
+          #  --mount type=volume,dst=/build/gobra/sync,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/sync \
+          #  ${{ env.IMAGE_TAG }} \
+          #  /bin/sh -c "$(cat .github/test-and-measure-ram.sh)"
 
       - name: Get max RAM usage by Java and Z3
         if: ${{ always() }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,12 +18,12 @@ jobs:
       IMAGE_NAME: gobra
       # image labels are new-line separated key value pairs (according to https://specs.opencontainers.org/image-spec/annotations/):
       IMAGE_LABELS: |
-        org.opencontainers.image.authors="Viper Project (https://viper.ethz.ch)"
-        org.opencontainers.image.url="https://github.com/viperproject/gobra/pkgs/container/gobra"
-        org.opencontainers.image.source="${{ github.server_url }}/${{ github.repository }}"
-        org.opencontainers.image.revision="${{ github.sha }}"
-        org.opencontainers.image.licenses="MPL-2.0"
-        org.opencontainers.image.description="Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}"
+        org.opencontainers.image.authors=Viper Project <https://viper.ethz.ch>
+        org.opencontainers.image.url=https://github.com/viperproject/gobra/pkgs/container/gobra
+        org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+        org.opencontainers.image.revision=${{ github.sha }}
+        org.opencontainers.image.licenses=MPL-2.0
+        org.opencontainers.image.description=Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}
       CONCLUSION_SUCCESS: "success"
       CONCLUSION_FAILURE: "failure"
       # Output levels according to severity.
@@ -62,7 +62,7 @@ jobs:
 
       - name: Create image creation label
         run: |
-          CREATED_LABEL="org.opencontainers.image.created=\"$(date --rfc-3339=seconds)\""
+          CREATED_LABEL="org.opencontainers.image.created=$(date --rfc-3339=seconds)"
           echo "CREATED_LABEL=$CREATED_LABEL" >> $GITHUB_ENV
 
       - name: Create image metadata

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,12 @@ on:
   push: # run this workflow on every push
   pull_request: # run this workflow on every pull_request
 
-env:
-  IMAGE_NAME: gobra
-
 jobs:
   # there is a single job to avoid copying the built docker image from one job to the other
   build-test-deploy-container:
     runs-on: ubuntu-latest
     env:
-      IMAGE_ID: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+      IMAGE_ID: ghcr.io/${{ github.repository_owner }}/gobra
       # image labels are new-line separated key value pairs (according to https://specs.opencontainers.org/image-spec/annotations/):
       IMAGE_LABELS: |
         org.opencontainers.image.authors=Viper Project <https://viper.ethz.ch>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,6 +65,7 @@ jobs:
           echo "CREATED_LABEL=$CREATED_LABEL" >> $GITHUB_ENV
 
       - name: Build image up to including stage 'build'
+        id: image-build
         # note that the action's name is misleading: this step does NOT push
         uses: docker/build-push-action@v5
         with:
@@ -80,6 +81,9 @@ jobs:
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
+
+      - name: Print metadata
+        run: echo ${{ steps.image-build.outputs.metadata }}
 
       - name: Execute all tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,13 +60,13 @@ jobs:
           labels: |
             ${{ env.IMAGE_LABELS }}
             ${{ env.CREATED_LABEL }}
-          tags:
+          tags: |
             type=schedule
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            # these are the default options so far. We additionally add the commit hash:
             type=sha
+          # the first 4 tags correspond to the default options. We additionally add the commit hash
 
       - name: Build image up to including stage 'build'
         id: image-build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: gobra
+      # image labels are new-line separated key value pairs (according to https://specs.opencontainers.org/image-spec/annotations/):
       IMAGE_LABELS: |
         org.opencontainers.image.authors="Viper Project (https://viper.ethz.ch)"
         org.opencontainers.image.url="https://github.com/viperproject/gobra/pkgs/container/gobra"
@@ -40,7 +41,7 @@ jobs:
           SILICON_SILVER_REF=$(git -C viperserver/silicon/silver rev-parse HEAD) && \
           CARBON_SILVER_REF=$(git -C viperserver/carbon/silver rev-parse HEAD) && \
           if [ "$SILICON_SILVER_REF" != "$CARBON_SILVER_REF" ]; then echo "Silicon and Carbon reference different Silver commits ($SILICON_SILVER_REF and $CARBON_SILVER_REF)" && exit 1 ; fi
-      - name: Create image tag and labels
+      - name: Create image tag
         run: |
           IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
 
@@ -53,20 +54,15 @@ jobs:
           # Use Docker `latest` tag convention
           [ "$VERSION" == "master" ] && VERSION=latest
           echo "IMAGE_TAG=$IMAGE_ID:$VERSION" >> $GITHUB_ENV
-          # image labels are new-line separated key value pairs (according to https://specs.opencontainers.org/image-spec/annotations/)
-          CREATED_LABEL="org.opencontainers.image.created=$(date --rfc-3339=seconds)"
-          # AUTHORS_LABEL="org.opencontainers.image.authors=Viper Project (https://viper.ethz.ch)"
-          # URL_LABEL="org.opencontainers.image.url=https://github.com/viperproject/gobra/pkgs/container/gobra"
-          # SOURCE_LABEL="org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}"
-          # REVISION_LABEL="org.opencontainers.image.revision=${{ github.sha }}"
-          # LICENSE_LABEL="org.opencontainers.image.licenses=MPL-2.0"
-          # DESCRIPTION_LABEL="org.opencontainers.image.description=Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}"
-          # echo "IMAGE_LABELS=$CREATED_LABEL\n$AUTHORS_LABEL\n$URL_LABEL\n$SOURCE_LABEL\n$REVISION_LABEL\n$LICENSE_LABEL\n$DESCRIPTION_LABEL" >> $GITHUB_ENV
-          echo "CREATED_LABEL=$CREATED_LABEL" >> $GITHUB_ENV
 
       # used to enable Docker caching (see https://github.com/docker/build-push-action)
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Create image creation label
+        run: |
+          CREATED_LABEL="org.opencontainers.image.created=\"$(date --rfc-3339=seconds)\""
+          echo "CREATED_LABEL=$CREATED_LABEL" >> $GITHUB_ENV
 
       - name: Build image up to including stage 'build'
         # note that the action's name is misleading: this step does NOT push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
           push: false
+          provenance: false # without this, GH displays 2 architecture (unknown/unknown) and omits labels
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
@@ -207,6 +208,7 @@ jobs:
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
           push: false
+          provenance: false # without this, GH displays 2 architecture (unknown/unknown) and omits labels
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
@@ -250,6 +252,7 @@ jobs:
           tags: ${{ steps.image-metadata.outputs.tags }}
           labels: ${{ steps.image-metadata.outputs.labels }}
           push: true
+          provenance: false # without this, GH displays 2 architecture (unknown/unknown) and omits labels
           # use GitHub cache:
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,8 +90,8 @@ jobs:
           cache-from: type=gha, scope=${{ github.workflow }}
           cache-to: type=gha, scope=${{ github.workflow }}
 
-      - name: Print metadata
-        run: echo ${{ steps.image-build.outputs.metadata }}
+      # - name: Print metadata
+      #   run: echo ${{ steps.image-build.outputs.metadata }}
 
       - name: Execute all tests
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,12 +60,15 @@ jobs:
             ${{ env.IMAGE_LABELS }}
             ${{ env.CREATED_LABEL }}
           tags: |
+            # the first 4 tags correspond to the default options
             type=schedule
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
+            # use (short) commit hash as tag:
             type=sha
-          # the first 4 tags correspond to the default options. We additionally add the commit hash
+            # set latest tag for default branch:
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Get first tag
         run: echo "IMAGE_TAG=$(echo "${{ steps.image-metadata.outputs.tags }}" | head -1)" >> $GITHUB_ENV

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           REVISION_LABEL="org.opencontainers.image.revision=${{ github.sha }}"
           LICENSE_LABEL="org.opencontainers.image.licenses=MPL-2.0"
           DESCRIPTION_LABEL="org.opencontainers.image.description=Gobra image for revision ${{ github.sha }} built by workflow run ${{ github.run_id }}"
-          echo "IMAGE_LABELS=CREATED_LABEL\nAUTHORS_LABEL\nURL_LABEL\nSOURCE_LABEL\nREVISION_LABEL\nLICENSE_LABEL\nDESCRIPTION_LABEL" >> $GITHUB_ENV
+          echo "IMAGE_LABELS=$CREATED_LABEL\n$AUTHORS_LABEL\n$URL_LABEL\n$SOURCE_LABEL\n$REVISION_LABEL\n$LICENSE_LABEL\n$DESCRIPTION_LABEL" >> $GITHUB_ENV
 
       # used to enable Docker caching (see https://github.com/docker/build-push-action)
       - name: Set up Docker Buildx

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -224,7 +224,7 @@ jobs:
           echo "SHOULD_DEPLOY=$SHOULD_DEPLOY" >> $GITHUB_ENV
 
       - name: Login to Github Packages
-        # if: env.SHOULD_DEPLOY == 'true'
+        if: env.SHOULD_DEPLOY == 'true'
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -232,7 +232,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push entire image
-        # if: env.SHOULD_DEPLOY == 'true'
+        if: env.SHOULD_DEPLOY == 'true'
         uses: docker/build-push-action@v5
         with:
           context: .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: gobra
+      IMAGE_ID: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
       # image labels are new-line separated key value pairs (according to https://specs.opencontainers.org/image-spec/annotations/):
       IMAGE_LABELS: |
         org.opencontainers.image.authors=Viper Project <https://viper.ethz.ch>
@@ -41,20 +42,6 @@ jobs:
           SILICON_SILVER_REF=$(git -C viperserver/silicon/silver rev-parse HEAD) && \
           CARBON_SILVER_REF=$(git -C viperserver/carbon/silver rev-parse HEAD) && \
           if [ "$SILICON_SILVER_REF" != "$CARBON_SILVER_REF" ]; then echo "Silicon and Carbon reference different Silver commits ($SILICON_SILVER_REF and $CARBON_SILVER_REF)" && exit 1 ; fi
-      - name: Create image tag
-        run: |
-          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
-
-          # Change all uppercase to lowercase
-          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
-          # Strip git ref prefix from version
-          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
-          # Strip "v" prefix from tag name
-          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v\.?//')
-          # Use Docker `latest` tag convention
-          [ "$VERSION" == "master" ] && VERSION=latest
-          echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_ENV
-          echo "IMAGE_TAG=$IMAGE_ID:$VERSION" >> $GITHUB_ENV
 
       # used to enable Docker caching (see https://github.com/docker/build-push-action)
       - name: Set up Docker Buildx
@@ -73,6 +60,13 @@ jobs:
           labels: |
             ${{ env.IMAGE_LABELS }}
             ${{ env.CREATED_LABEL }}
+          tags:
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            # these are the default options so far. We additionally add the commit hash:
+            type=sha
 
       - name: Build image up to including stage 'build'
         id: image-build
@@ -100,12 +94,12 @@ jobs:
           mkdir -p $PWD/sync
           docker run \
             --mount type=volume,dst=/build/gobra/sync,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/sync \
-            ${{ env.IMAGE_TAG }} \
+            ${{ steps.image-metadata.outputs.tags[0] }} \
             /bin/sh -c "echo 'Test'"
           
           # docker run \
           #  --mount type=volume,dst=/build/gobra/sync,volume-driver=local,volume-opt=type=none,volume-opt=o=bind,volume-opt=device=$PWD/sync \
-          #  ${{ env.IMAGE_TAG }} \
+          #  ${{ steps.image-metadata.outputs.tags[0] }} \
           #  /bin/sh -c "$(cat .github/test-and-measure-ram.sh)"
 
       - name: Get max RAM usage by Java and Z3
@@ -216,7 +210,7 @@ jobs:
       - name: Test final container by verifying a file
         run: |
           docker run \
-            ${{ env.IMAGE_TAG }} \
+            ${{ steps.image-metadata.outputs.tags[0] }} \
             -i tutorial-examples/basicAnnotations.gobra
 
       - name: Decide whether image should be deployed or not


### PR DESCRIPTION
Recently upgrading the `docker/build-push-action` action changed how published Gobra images appear ([before](https://github.com/viperproject/gobra/pkgs/container/gobra/71107123?tag=v23.02), [after](https://github.com/viperproject/gobra/pkgs/container/gobra/176513635)).
This seems to be related to multi-architecture Docker images and also manifests as an additional architecture called `unknown/unknown` (cf. [this issue](https://github.com/docker/build-push-action/issues/900)).

While the immediate workaround is fairly simple, i.e., setting `provenance: false` for this action, I took the opportunity to add several other meta-information about our images according to the [OpenContainers Annotation Spec](https://specs.opencontainers.org/image-spec/annotations/). While all labels appear in the manifest (JSON), only the description is extracted and separately rendered by GitHub, as shown [here](https://github.com/viperproject/gobra/pkgs/container/gobra/177172670?tag=package-description) (note that this image has been published for testing purposes, we in general do not publish images on branches).

Additionally, we use several tags per image, i.e., the branch name, (short) commit hash, and `latest` for the master branch.