### PR TITLE
Improves Error Messages for Assignments

### DIFF
--- a/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
@@ -6,8 +6,7 @@
 
 package viper.gobra.reporting
 
-import viper.gobra.reporting.Source.{AutoImplProofAnnotation, CertainSource, CertainSynthesized, ImportPreNotEstablished, MainPreNotEstablished, OverflowCheckAnnotation, ReceiverNotNilCheckAnnotation, InsufficientPermissionToRangeExpressionAnnotation, LoopInvariantNotEstablishedAnnotation}
-
+import viper.gobra.reporting.Source.{AutoImplProofAnnotation, CertainSource, CertainSynthesized, ImportPreNotEstablished, InsufficientPermissionToRangeExpressionAnnotation, LoopInvariantNotEstablishedAnnotation, MainPreNotEstablished, OverflowCheckAnnotation, OverwriteErrorAnnotation, ReceiverNotNilCheckAnnotation}
 import viper.gobra.reporting.Source.Verifier./
 import viper.silver
 import viper.silver.ast.Not
@@ -163,6 +162,8 @@ class DefaultErrorBackTranslator(
     }
 
     val transformAnnotatedError: VerificationError => VerificationError = x => x.info match {
+      case _ / (an: OverwriteErrorAnnotation) => an(x)
+
       case _ / OverflowCheckAnnotation =>
         x.reasons.foldLeft(OverflowError(x.info): VerificationError){ case (err, reason) => err dueTo reason }
 

--- a/src/main/scala/viper/gobra/reporting/Source.scala
+++ b/src/main/scala/viper/gobra/reporting/Source.scala
@@ -33,6 +33,16 @@ object Source {
   case class NoPermissionToRangeExpressionAnnotation() extends Annotation
   case class InsufficientPermissionToRangeExpressionAnnotation() extends Annotation
   case class AutoImplProofAnnotation(subT: String, superT: String) extends Annotation
+  class OverwriteErrorAnnotation(
+                                  newError: VerificationError => VerificationError,
+                                  attachReasons: Boolean = true
+                                ) extends Annotation {
+    def apply(err: VerificationError): VerificationError = {
+      if (attachReasons) {
+        err.reasons.foldLeft(newError(err)){ case (err, reason) => err dueTo reason }
+      } else newError(err)
+    }
+  }
 
   object Parser {
 

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -161,6 +161,11 @@ case class CallError(info: Source.Verifier.Info) extends VerificationError {
   override def localMessage: String = "Call might fail"
 }
 
+case class LoadError(info: Source.Verifier.Info) extends VerificationError {
+  override def localId: String = "load_error"
+  override def localMessage: String = "Reading might fail"
+}
+
 case class PostconditionError(info: Source.Verifier.Info) extends VerificationError {
   override def localId: String = "postcondition_error"
   override def localMessage: String = "Postcondition might not hold"

--- a/src/main/scala/viper/gobra/translator/encodings/arrays/ArrayEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/arrays/ArrayEncoding.scala
@@ -8,7 +8,7 @@ package viper.gobra.translator.encodings.arrays
 
 import org.bitbucket.inkytonik.kiama.==>
 import viper.gobra.ast.{internal => in}
-import viper.gobra.reporting.Source
+import viper.gobra.reporting.{LoadError, InsufficientPermissionError, Source}
 import viper.gobra.theory.Addressability
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.Names
@@ -230,7 +230,11 @@ class ArrayEncoding extends TypeEncoding with SharedArrayEmbedding {
       val (pos, info, errT) = loc.vprMeta
       for {
         arg <- ctx.reference(loc)
-      } yield conversionFunc(Vector(arg), cptParam(len, t)(ctx))(pos, info, errT)(ctx)
+        res <- funcAppPrecondition(
+          conversionFunc(Vector(arg), cptParam(len, t)(ctx))(pos, info, errT)(ctx),
+          { case (info, _) => LoadError(info) dueTo InsufficientPermissionError(info) }
+        )
+      } yield res
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -10,7 +10,7 @@ import org.bitbucket.inkytonik.kiama.==>
 import viper.gobra.ast.{internal => in}
 import viper.gobra.ast.internal.theory.Comparability
 import viper.gobra.reporting.BackTranslator.{ErrorTransformer, RichErrorMessage}
-import viper.gobra.reporting.{DefaultErrorBackTranslator, LoopInvariantNotWellFormedError, MethodContractNotWellFormedError, NoPermissionToRangeExpressionError, Source}
+import viper.gobra.reporting.{AssignmentError, DefaultErrorBackTranslator, LoopInvariantNotWellFormedError, MethodContractNotWellFormedError, NoPermissionToRangeExpressionError, Source}
 import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.library.Generator
 import viper.gobra.translator.context.Context
@@ -175,7 +175,7 @@ trait TypeEncoding extends Generator {
         for {
           footprint <- addressFootprint(ctx)(loc, in.FullPerm(loc.info))
           eq <- ctx.equal(loc, rhs)(src)
-          _ <- write(vpr.Exhale(footprint)(pos, info, errT))
+          _ <- exhaleWithDefaultReason(footprint, AssignmentError)
           inhale = vpr.Inhale(vpr.And(footprint, eq)(pos, info, errT))(pos, info, errT)
         } yield inhale
       )

--- a/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
+++ b/src/main/scala/viper/gobra/translator/util/ViperWriter.scala
@@ -408,6 +408,16 @@ object ViperWriter {
       }
     }
 
+    /* Can be used in expressions. */
+    def funcAppPrecondition(call: vpr.FuncApp, reasonT: (Source.Verifier.Info, ErrorReason) => VerificationError): Writer[vpr.Exp] = {
+      for {
+        _ <- errorT({
+          case e@vprerr.PreconditionInAppFalse(Source(info), reason, _) if e causedBy call =>
+            reasonT(info, reason)
+        })
+      } yield call
+    }
+
     /* Emits Viper statements. */
     def assert(cond: vpr.Exp, reasonT: (Source.Verifier.Info, ErrorReason) => VerificationError): Writer[Unit] = {
       val res = vpr.Assert(cond)(cond.pos, cond.info, cond.errT)

--- a/src/test/resources/regressions/issues/000745.gobra
+++ b/src/test/resources/regressions/issues/000745.gobra
@@ -1,0 +1,32 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue000745
+
+func assignment() int {
+    var x@, y [10]int
+    exhale acc(&x)
+    //:: ExpectedOutput(assignment_error:permission_error)
+    x = y
+}
+
+func load0() int {
+    var x@, y int
+    exhale acc(&x)
+    //:: ExpectedOutput(assignment_error:permission_error)
+    y = x
+}
+
+func load1() int {
+    var x@, y struct{ f,g int }
+    exhale acc(&x)
+    //:: ExpectedOutput(assignment_error:permission_error)
+    y = x
+}
+
+func load2() int {
+    var x@, y [10]int
+    exhale acc(&x)
+    //:: ExpectedOutput(load_error:permission_error)
+    y = x
+}


### PR DESCRIPTION
Check #745 for an example. As shown by the added file, the error messages are not perfect: 

The following snippet causes an assignment error,
```
var @x, y int
exhale acc(&x)
y = x
```
whereas the next snippet causes a load error,
```
var @x, y [5]int
exhale acc(&x)
y = x
```

The issue is caused by how Viper reports errors. The first snippets encodes to a field access whereas the second snippets encodes to a call. The call error is swapped with a load error. The field access error is a reason and not an error, so it cannot be swapped easily. 

Solutions are:

- To encode the first snippet also as a call
- To introduce reasons that can overwrite errors

Both solutions have drawbacks. The call encoding adds more complexity, which from my experience scales poorely for expressions that are all over the place. Overwriting reasons is rather error prone. Consider the encoding of `x = y`, which encodes `x` the same as `y = x`. If we overwrite errors, either both cause the same error message, i.e. a read/load error, or we need to remove the overwriting reasons somehow in one of the cases.

Long story short, in my opinion, the changes described above are not worth it. If we want these improvement, I am in favor of merging this PR and creating a new issue.
