### PR TITLE
Fix incompletness with conversions to and from strings

### DIFF
--- a/src/test/resources/regressions/features/conversion/conversion-simple01.gobra
+++ b/src/test/resources/regressions/features/conversion/conversion-simple01.gobra
@@ -5,3 +5,15 @@ package main
 
 ensures res == int64(i)
 func to64(i int8) (res int64)
+
+func stringToByteSlConversion() {
+	key := []byte("dummy key xxxxxx")
+	assert acc(&key[0])
+	assert len(key) > 0
+}
+
+func byteSlToStringConversion() {
+	keyBytes := []byte{'a', 'b', 'c'}
+	key := string(keyBytes)
+	assert 0 < len(key)
+}


### PR DESCRIPTION
@bruggerl found that the following snippet fails to verify:

```go
key := []byte("dummy key xxxxxx")
assert len(key) > 0
```

Conversely, Gobra also fails to verify the following:
```go
func byteSlToStringConversion() {
	keyBytes := []byte{'a', 'b', 'c'}
	key := string(keyBytes)
	assert 0 < len(key)
}
```
This is caused by the lack of any postconditions for the effectful conversions relating the length of the original slice/string with the length of the resulting string/slice. This Pr adds the necessary postconditions to the conversion operations.