### PR TITLE
Fix issue #781

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -219,7 +219,7 @@ class Gobra extends GoVerifier with GoIdeVerifier {
           inFileConfig <- new ScallopGobraConfig(args, isInputOptional = true, skipIncludeDirChecks = true).config
           resolvedConfig = inFileConfig.copy(includeDirs = inFileConfig.includeDirs.map(
             // it's important to convert includeDir to a string first as `path` might be a ZipPath and `includeDir` might not
-            includeDir => Paths.get(input.name).getParent.resolve(includeDir.toString)))
+            includeDir => Paths.get(input.name).toAbsolutePath.getParent.resolve(includeDir.toString)))
         } yield Some(resolvedConfig)
       }
     })

--- a/src/main/scala/viper/gobra/frontend/Source.scala
+++ b/src/main/scala/viper/gobra/frontend/Source.scala
@@ -65,7 +65,7 @@ object Source {
      * A unique identifier for packages
      */
     val packageId: String = {
-      val prefix = uniquePath(TransformableSource(src).toPath.getParent, projectRoot).toString
+      val prefix = uniquePath(TransformableSource(src).toPath.toAbsolutePath.getParent, projectRoot).toString
       if(prefix.nonEmpty) {
         // The - is enough to unambiguously separate the prefix from the package name, since it can't occur in the package name
         // per Go's spec (https://go.dev/ref/spec#Package_clause)


### PR DESCRIPTION
Executing `Paths.get(filename).getParent` fails if `filename` is a relative path in the current folder (and thus does not have any path component besides the filename itself).

Please let me know if you have a great idea for a test case as we would need to invoke Gobra relative to a folder containing a Gobra file such that we can provide a path to the Gobra file without any path component.

Fixes #781 