### PR TITLE
Add support for new interpretation of fractional perms in pure function preconditions

### DIFF
--- a/src/main/scala/viper/gobra/backend/ViperBackends.scala
+++ b/src/main/scala/viper/gobra/backend/ViperBackends.scala
@@ -29,7 +29,6 @@ object ViperBackends {
       var options: Vector[String] = Vector.empty
       options ++= Vector("--logLevel", "ERROR")
       options ++= Vector("--disableCatchingExceptions")
-      options ++= Vector("--respectFunctionPrePermAmounts")
       if (config.conditionalizePermissions) {
         options ++= Vector("--conditionalizePermissions")
       }
@@ -52,6 +51,9 @@ object ViperBackends {
       // Gobra seems to be much slower with the new silicon axiomatization of collections.
       // For now, we stick to the old one.
       options ++= Vector("--useOldAxiomatization")
+      if (config.respectFunctionPrePermAmounts) {
+        options ++= Vector("--respectFunctionPrePermAmounts")
+      }
       if (config.assumeInjectivityOnInhale) {
         options ++= Vector("--assumeInjectivityOnInhale")
       }
@@ -82,10 +84,12 @@ object ViperBackends {
     def create(exePaths: Vector[String], config: Config)(implicit executor: GobraExecutionContext): Carbon = {
       var options: Vector[String] = Vector.empty
       // options ++= Vector("--logLevel", "ERROR")
+      if (config.respectFunctionPrePermAmounts) {
+        options ++= Vector("--respectFunctionPrePermAmounts")
+      }
       if (config.assumeInjectivityOnInhale) {
         options ++= Vector("--assumeInjectivityOnInhale")
       }
-      options ++= Vector("--respectFunctionPrePermAmounts")
       options ++= exePaths
 
       new Carbon(options)
@@ -137,7 +141,6 @@ object ViperBackends {
       var options: Vector[String] = Vector.empty
       options ++= Vector("--logLevel", "ERROR")
       options ++= Vector("--disableCatchingExceptions")
-      options ++= Vector("--respectFunctionPrePermAmounts")
       // Gobra seems to be much slower with the new silicon axiomatization of collections.
       // For now, we stick to the old one.
       options ++= Vector("--useOldAxiomatization")
@@ -157,6 +160,9 @@ object ViperBackends {
         case MCE.OnDemand => "2"
       }
       options ++= Vector(s"--exhaleMode=$mceSiliconOpt")
+      if (config.respectFunctionPrePermAmounts) {
+        options ++= Vector("--respectFunctionPrePermAmounts")
+      }
       if (config.assumeInjectivityOnInhale) {
         options ++= Vector("--assumeInjectivityOnInhale")
       }
@@ -175,7 +181,9 @@ object ViperBackends {
     override def getViperVerifierConfig(exePaths: Vector[String], config: Config): ViperVerifierConfig = {
       var options: Vector[String] = Vector.empty
       options ++= Vector("--logLevel", "ERROR")
-      options ++= Vector("--respectFunctionPrePermAmounts")
+      if (config.respectFunctionPrePermAmounts) {
+        options ++= Vector("--respectFunctionPrePermAmounts")
+      }
       if (config.assumeInjectivityOnInhale) {
         options ++= Vector("--assumeInjectivityOnInhale")
       }

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -775,11 +775,12 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     }
   }
 
-  val respectFunctionPrePermAmounts: ScallopOption[Boolean] = opt[Boolean](
+  val respectFunctionPrePermAmounts: ScallopOption[Boolean] = toggle(
     name = "respectFunctionPrePermAmounts",
-    descr = s"Respects precise permission amounts in function preconditions instead of only checking read access, as done in older versions of Gobra." +
+    descrYes = s"Respects precise permission amounts in pure function preconditions instead of only checking read access, as done in older versions of Gobra." +
       "This option should be used for verifying legacy projects written with the old interpretation of fractional permissions." +
       "New projects are encouraged to not use this flag.",
+    descrNo = s"Use the default interpretation for fractional permissions in pure function preconditions.",
     default = Some(ConfigDefaults.DefaultRespectFunctionPrePermAmounts),
     noshort = true,
   )

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -77,6 +77,7 @@ object ConfigDefaults {
   val DefaultDisableCheckTerminationPureFns: Boolean = false
   val DefaultUnsafeWildcardOptimization: Boolean = false
   val DefaultMoreJoins: MoreJoins.Mode = MoreJoins.Disabled
+  val DefaultRespectFunctionPrePermAmounts: Boolean = false
 }
 
 // More-complete exhale modes
@@ -172,7 +173,7 @@ case class Config(
                    disableCheckTerminationPureFns: Boolean = ConfigDefaults.DefaultDisableCheckTerminationPureFns,
                    unsafeWildcardOptimization: Boolean = ConfigDefaults.DefaultUnsafeWildcardOptimization,
                    moreJoins: MoreJoins.Mode = ConfigDefaults.DefaultMoreJoins,
-
+                   respectFunctionPrePermAmounts: Boolean = ConfigDefaults.DefaultRespectFunctionPrePermAmounts,
 ) {
 
   def merge(other: Config): Config = {
@@ -227,6 +228,7 @@ case class Config(
       disableCheckTerminationPureFns = disableCheckTerminationPureFns || other.disableCheckTerminationPureFns,
       unsafeWildcardOptimization = unsafeWildcardOptimization && other.unsafeWildcardOptimization,
       moreJoins = MoreJoins.merge(moreJoins, other.moreJoins),
+      respectFunctionPrePermAmounts = respectFunctionPrePermAmounts || other.respectFunctionPrePermAmounts,
     )
   }
 
@@ -285,6 +287,7 @@ case class BaseConfig(gobraDirectory: Path = ConfigDefaults.DefaultGobraDirector
                       disableCheckTerminationPureFns: Boolean = ConfigDefaults.DefaultDisableCheckTerminationPureFns,
                       unsafeWildcardOptimization: Boolean = ConfigDefaults.DefaultUnsafeWildcardOptimization,
                       moreJoins: MoreJoins.Mode = ConfigDefaults.DefaultMoreJoins,
+                      respectFunctionPrePermAmounts: Boolean = ConfigDefaults.DefaultRespectFunctionPrePermAmounts,
                      ) {
   def shouldParse: Boolean = true
   def shouldTypeCheck: Boolean = !shouldParseOnly
@@ -347,6 +350,7 @@ trait RawConfig {
     disableCheckTerminationPureFns = baseConfig.disableCheckTerminationPureFns,
     unsafeWildcardOptimization = baseConfig.unsafeWildcardOptimization,
     moreJoins = baseConfig.moreJoins,
+    respectFunctionPrePermAmounts = baseConfig.respectFunctionPrePermAmounts,
   )
 }
 
@@ -771,6 +775,15 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     }
   }
 
+  val respectFunctionPrePermAmounts: ScallopOption[Boolean] = opt[Boolean](
+    name = "respectFunctionPrePermAmounts",
+    descr = s"Respects precise permission amounts in function preconditions instead of only checking read access, as done in older versions of Gobra." +
+      "This option should be used for verifying legacy projects written with the old interpretation of fractional permissions." +
+      "New projects are encouraged to not use this flag.",
+    default = Some(ConfigDefaults.DefaultRespectFunctionPrePermAmounts),
+    noshort = true,
+  )
+
   val enableLazyImports: ScallopOption[Boolean] = opt[Boolean](
     name = Config.enableLazyImportOptionName,
     descr = s"Enforces that ${GoVerifier.name} parses depending packages only when necessary. Note that this disables certain language features such as global variables.",
@@ -1026,5 +1039,6 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     disableCheckTerminationPureFns = disableCheckTerminationPureFns(),
     unsafeWildcardOptimization = unsafeWildcardOptimization(),
     moreJoins = moreJoins(),
+    respectFunctionPrePermAmounts = respectFunctionPrePermAmounts(),
   )
 }

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -782,7 +782,7 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
     name = "respectFunctionPrePermAmounts",
     descrYes = s"Respects precise permission amounts in pure function preconditions instead of only checking read access, as done in older versions of Gobra." +
       "This option should be used for verifying legacy projects written with the old interpretation of fractional permissions." +
-      "New projects are encouraged to not use this flag.",
+      "New projects are encouraged to set this flag to false.",
     descrNo = s"Use the default interpretation for fractional permissions in pure function preconditions.",
     default = Some(ConfigDefaults.DefaultRespectFunctionPrePermAmounts),
     noshort = true,

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -77,7 +77,10 @@ object ConfigDefaults {
   val DefaultDisableCheckTerminationPureFns: Boolean = false
   val DefaultUnsafeWildcardOptimization: Boolean = false
   val DefaultMoreJoins: MoreJoins.Mode = MoreJoins.Disabled
-  val DefaultRespectFunctionPrePermAmounts: Boolean = false
+  // TODO: for the time being, we use the old semantics for fractional perms in pure function preconditions,
+  //   as our pre-existing verified codebases use those semantics. In the future, after we have ported our most
+  //   important case studies to the new semantics, we should deprecate the old one and change this default to false.
+  val DefaultRespectFunctionPrePermAmounts: Boolean = true
 }
 
 // More-complete exhale modes

--- a/src/test/scala/viper/gobra/GobraTests.scala
+++ b/src/test/scala/viper/gobra/GobraTests.scala
@@ -59,11 +59,6 @@ class GobraTests extends AbstractGobraTests with BeforeAndAfterAll {
       // termination checks in functions are currently disabled in the tests. This can be enabled in the future,
       // but requires some work to add termination measures all over the test suite.
       disableCheckTerminationPureFns = true,
-      // for the time being, we run the tests against the old semantics for fractional perms in pure function
-      // preconditions, as most tests were still written with the old semantics in mind. Furthermore, it is still
-      // more important to guarantee that there are no regressions in the old behaviour, as our pre-existing verified
-      // codebases use those semantics. In the future, we should deprecate the old semantics and change this to false.
-      respectFunctionPrePermAmounts = true,
     )
 
   override def runTests(testName: Option[String], args: Args): Status = {

--- a/src/test/scala/viper/gobra/GobraTests.scala
+++ b/src/test/scala/viper/gobra/GobraTests.scala
@@ -59,6 +59,11 @@ class GobraTests extends AbstractGobraTests with BeforeAndAfterAll {
       // termination checks in functions are currently disabled in the tests. This can be enabled in the future,
       // but requires some work to add termination measures all over the test suite.
       disableCheckTerminationPureFns = true,
+      // for the time being, we run the tests against the old semantics for fractional perms in pure function
+      // preconditions, as most tests were still written with the old semantics in mind. Furthermore, it is still
+      // more important to guarantee that there are no regressions in the old behaviour, as our pre-existing verified
+      // codebases use those semantics. In the future, we should deprecate the old semantics and change this to false.
+      respectFunctionPrePermAmounts = true,
     )
 
   override def runTests(testName: Option[String], args: Args): Status = {


### PR DESCRIPTION
Changes done in accordance to the corresponding change in Viper (https://github.com/viperproject/silver/pull/816).

The default is still Viper's old interpretation for fractional permissions because our case studies all use the old semantics, but we should switch in the future because the new interpretation leads to more concise specs. 