### PR TITLE
Relative Paths in Generated Parser

### DIFF
--- a/genparser.sh
+++ b/genparser.sh
@@ -39,5 +39,11 @@ java -jar "$ANTLR4_PATH" "$SCRIPT_DIR"/src/main/antlr4/GobraLexer.g4 -package vi
 echo -e "${GREEN}Generating the parser:${RESET}"
 java -jar "$ANTLR4_PATH" "$SCRIPT_DIR"/src/main/antlr4/GobraParser.g4 -package viper.gobra.frontend -visitor -no-listener || { echo -e "${RED}Error while generating the parser.${RESET}"; exit 3; }
 
+echo -e "${GREEN}Making path in comments relative:${RESET}"
+sed -i '' 's/\/\/ Generated from .*src\/main\/antlr4\/GobraLexer\.g4/\/\/ Generated from src\/main\/antlr4\/GobraLexer\.g4/g' "$SCRIPT_DIR"/src/main/antlr4/GobraLexer.java
+sed -i '' 's/\/\/ Generated from .*src\/main\/antlr4\/GobraParser\.g4/\/\/ Generated from src\/main\/antlr4\/GobraParser\.g4/g' "$SCRIPT_DIR"/src/main/antlr4/GobraParser.java
+sed -i '' 's/\/\/ Generated from .*src\/main\/antlr4\/GobraParser\.g4/\/\/ Generated from src\/main\/antlr4\/GobraParser\.g4/g' "$SCRIPT_DIR"/src/main/antlr4/GobraParserBaseVisitor.java
+sed -i '' 's/\/\/ Generated from .*src\/main\/antlr4\/GobraParser\.g4/\/\/ Generated from src\/main\/antlr4\/GobraParser\.g4/g' "$SCRIPT_DIR"/src/main/antlr4/GobraParserVisitor.java
+
 echo -e "${GREEN}Moving the generated files:${RESET}"
 mv -v "$SCRIPT_DIR"/src/main/antlr4/*.java "$SCRIPT_DIR"/src/main/java/viper/gobra/frontend/

--- a/src/main/java/viper/gobra/frontend/GobraLexer.java
+++ b/src/main/java/viper/gobra/frontend/GobraLexer.java
@@ -1,4 +1,4 @@
-// Generated from /Users/joao/code/gobra/src/main/antlr4/GobraLexer.g4 by ANTLR 4.13.1
+// Generated from src/main/antlr4/GobraLexer.g4 by ANTLR 4.13.1
 package viper.gobra.frontend;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.CharStream;

--- a/src/main/java/viper/gobra/frontend/GobraParser.java
+++ b/src/main/java/viper/gobra/frontend/GobraParser.java
@@ -1,4 +1,4 @@
-// Generated from /Users/joao/code/gobra/src/main/antlr4/GobraParser.g4 by ANTLR 4.13.1
+// Generated from src/main/antlr4/GobraParser.g4 by ANTLR 4.13.1
 package viper.gobra.frontend;
 import org.antlr.v4.runtime.atn.*;
 import org.antlr.v4.runtime.dfa.DFA;

--- a/src/main/java/viper/gobra/frontend/GobraParserBaseVisitor.java
+++ b/src/main/java/viper/gobra/frontend/GobraParserBaseVisitor.java
@@ -1,4 +1,4 @@
-// Generated from /Users/joao/code/gobra/src/main/antlr4/GobraParser.g4 by ANTLR 4.13.1
+// Generated from src/main/antlr4/GobraParser.g4 by ANTLR 4.13.1
 package viper.gobra.frontend;
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
 

--- a/src/main/java/viper/gobra/frontend/GobraParserVisitor.java
+++ b/src/main/java/viper/gobra/frontend/GobraParserVisitor.java
@@ -1,4 +1,4 @@
-// Generated from /Users/joao/code/gobra/src/main/antlr4/GobraParser.g4 by ANTLR 4.13.1
+// Generated from src/main/antlr4/GobraParser.g4 by ANTLR 4.13.1
 package viper.gobra.frontend;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 


### PR DESCRIPTION
Adapts `genparser.sh` to turn absolute paths into relative ones in the generated parser files