### PR TITLE
Fix issue 828

### DIFF
--- a/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
@@ -11,6 +11,7 @@ import viper.gobra.reporting.Source.Verifier./
 import viper.silver
 import viper.silver.ast.Not
 import viper.silver.verifier.{AbstractVerificationError, errors => vprerr, reasons => vprrea}
+import viper.silver.plugin.standard.predicateinstance
 import viper.silver.plugin.standard.termination
 import viper.silver.plugin.standard.{refute => vprrefute}
 
@@ -162,6 +163,8 @@ class DefaultErrorBackTranslator(
         IfError(info) dueTo translate(reason)
       case vprerr.IfFailed(CertainSource(info), reason, _) =>
         IfError(info) dueTo translate(reason)
+      case predicateinstance.PredicateInstanceNoAccess(Source(info), reason, _) =>
+        PredicateInstanceNoAccessError(info) dueTo translate(reason)
       case termination.FunctionTerminationError(Source(info), reason, _) =>
         FunctionTerminationError(info) dueTo translate(reason)
       case termination.MethodTerminationError(Source(info), reason, _) =>

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -355,6 +355,11 @@ case class ChannelSendError(info: Source.Verifier.Info) extends VerificationErro
   override def localMessage: String = s"The send expression ${info.trySrc[PSendStmt](" ")}might fail"
 }
 
+case class PredicateInstanceNoAccessError(info: Source.Verifier.Info) extends VerificationError {
+  override def localId: String = "predicate_instance_no_access_error"
+  override def localMessage: String = "Accessing predicate instance might fail"
+}
+
 case class FunctionTerminationError(info: Source.Verifier.Info) extends VerificationError {
   override def localId: String = "pure_function_termination_error"
   override def localMessage: String = s"Pure function might not terminate"

--- a/src/main/scala/viper/gobra/translator/transformers/TerminationDomainTransformer.scala
+++ b/src/main/scala/viper/gobra/translator/transformers/TerminationDomainTransformer.scala
@@ -11,11 +11,9 @@ import viper.silicon.Silicon
 import viper.silver.ast.utility.FileLoader
 import viper.silver.{ast => vpr}
 import viper.silver.frontend.{DefaultStates, ViperAstProvider}
-import viper.silver.plugin.SilverPlugin
 import viper.silver.plugin.standard.predicateinstance.PredicateInstance.PredicateInstanceDomainName
-import viper.silver.plugin.standard.termination.{DecreasesTuple, TerminationPlugin}
+import viper.silver.plugin.standard.termination.DecreasesTuple
 import viper.silver.reporter.{NoopReporter, Reporter}
-import viper.silver.plugin.standard.predicateinstance.PredicateInstancePlugin
 import viper.silver.verifier.AbstractError
 
 // This class should be removed in the future because Viper already implements inference of

--- a/src/test/resources/regressions/issues/000828.gobra
+++ b/src/test/resources/regressions/issues/000828.gobra
@@ -1,0 +1,26 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue828
+
+type List struct {
+	next *List
+	Value int
+}
+
+pred elems(l *List) {
+    l != nil ==> (acc(l) && elems(l.next))
+}
+
+requires elems(l)
+decreases
+func foo(l *List) {
+    // omitting the following invariant results in the decreases clause becoming erroneous:
+    // invariant elems(l)
+    //:: ExpectedOutput(predicate_instance_no_access_error:permission_error)
+    decreases elems(l)
+    for l != nil {
+        unfold elems(l)
+        l = l.next
+    }
+}


### PR DESCRIPTION
This PR adds backtranslation of the (one and only) error that Viper's PredicateInstance plugin creates.

The reason is currently translated to `Permission to unknown might not suffice.` as positional information for the offending node is missing. However, this is fixed as soon [Silver PR #836](https://github.com/viperproject/silver/pull/836) got merged. I intentionally did not update the submodules and the fix introduced by this Silver PR can be propagated independently of this PR through our periodic submodule update mechansim.

Fixes #828