### PR TITLE
Fix parser generation for dependers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,8 @@ lazy val server = project in file("viperserver")
 
 lazy val genParser = taskKey[Unit]("Generate Gobra's parser")
 genParser := {
-  val res: Int = ("./genparser.sh --download" !) // parentheses are not optional despite what IntelliJ suggests
+  val projectDir = baseDirectory.value
+  val res: Int = (s"${projectDir.getAbsolutePath}/genparser.sh --download" !) // parentheses are not optional despite what IntelliJ suggests
   if (res != 0) {
     sys.error(s"genparser.sh exited with the non-zero exit code $res")
   }


### PR DESCRIPTION
The relative path we are currently using in `build.sbt` does not work for projects that depend on Gobra, such as Gobra-IDE. Thus, this PR switches to using an absolute path.