### PR TITLE
Fix error obtained when importing `sync` with flag --noassumeInjectivityOnInhale

### DIFF
--- a/src/main/resources/stubs/sync/waitgroup.gobra
+++ b/src/main/resources/stubs/sync/waitgroup.gobra
@@ -7,7 +7,10 @@ package sync
 // Definition according to https://github.com/golang/go/blob/master/src/sync/waitgroup.go
 type WaitGroup struct {
 	// noCopy noCopy
-	state1 [3]uint32
+	// state1 [3]uint32
+	state1_0 uint32
+	state1_1 uint32
+	state1_2 uint32
 }
 
 pred (wg *WaitGroup) WaitGroupP()

--- a/src/test/resources/regressions/features/stubs/stubs3.gobra
+++ b/src/test/resources/regressions/features/stubs/stubs3.gobra
@@ -1,0 +1,11 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// ##(--noassumeInjectivityOnInhale)
+
+package main
+
+// tests that the contracts provided in sync are valid when the flag
+// --noassumeInjectivityOnInhale is passed.
+
+import "sync"


### PR DESCRIPTION
Currently, we get an error when we import `sync` in a package that we try to verify with --noassumeInjectivityOnInhale:
```
Error at: <stubs/sync/waitgroup.gobra:24:10> Method contract is not well-formed. 
Quantified resource g might not be injective.
```

The fix is to split the array in the definition of WaitGroup to avoid generating the ill-formed qtfier at the encoding level. The actual choice of private fields does not matter and ideally, we would have been able to make this type completely opaque, but that is currently not possible in gobra 