### PR TITLE
Domains under interface

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Implements.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Implements.scala
@@ -113,6 +113,7 @@ trait Implements { this: TypeInfoImpl =>
         case ut: Type.OptionT => go(ut.elem)
         case ut: Type.AdtT =>
           ut.clauses.forall(_.fields.forall(f => go(f._2)))
+        case _: Type.DomainT => true
         case ut: GhostCollectionType => go(ut.elem)
         case _: Type.InterfaceT => true
         case _ => false

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Implements.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Implements.scala
@@ -102,7 +102,7 @@ trait Implements { this: TypeInfoImpl =>
       def go(subT: Type): Boolean = isIdentityPreservingType(subT, encounteredTypes + t)
       underlyingType(t) match {
         case Type.NilType | Type.BooleanT | _: Type.IntT | Type.StringT => true
-        case ut: Type.PointerT => go(ut.elem)
+        case _: Type.PointerT => true
         case ut: Type.StructT =>
           // a struct with ghost fields or ghost embeddings is not identity preserving.
           // E.g., for `type S struct { val int, ghost gval int }`, `S{0, 0} == S{0, 42}` holds in Go (after erasing the ghost fields).

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -420,7 +420,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
         case (bt, lt, ht, ct) => error(n, s"invalid slice with base $bt and indexes $lt, $ht, and $ct")
       })
 
-    case n@PTypeAssertion(base, typ) =>
+    case PTypeAssertion(base, typ) =>
       isExpr(base).out ++ isType(typ).out ++ {
         val baseT = exprType(base)
         underlyingType(baseT) match {
@@ -431,14 +431,14 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
         }
       }
 
-    case n@PReceive(e) => isExpr(e).out ++ (exprType(e) match {
+    case PReceive(e) => isExpr(e).out ++ (exprType(e) match {
       case ChannelT(_, ChannelModus.Bi | ChannelModus.Recv) => noMessages
       case t => error(e, s"expected receive-permitting channel but got $t")
     })
 
-    case n@PReference(e) => isExpr(e).out ++ effAddressable.errors(e)(e)
+    case PReference(e) => isExpr(e).out ++ effAddressable.errors(e)(e)
 
-    case n@PNegation(e) => isExpr(e).out ++ assignableTo.errors(exprType(e), BooleanT)(e)
+    case PNegation(e) => isExpr(e).out ++ assignableTo.errors(exprType(e), BooleanT)(e)
 
     case n: PBinaryExp[_,_] =>
         (n, exprOrTypeType(n.left), exprOrTypeType(n.right)) match {

--- a/src/test/resources/regressions/features/domains/implements-interface-fail01.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-fail01.gobra
@@ -1,0 +1,36 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// this testcase checks that a ghost value of a type implementing an interface
+// cannot be passed to a non-ghost context
+
+package ImplementsInterfaceFail01
+
+ghost type intPair domain {
+    func fst(intPair) int
+    func snd(intPair) int
+    func pair(int, int) intPair
+
+    axiom {
+      forall p intPair :: {fst(p)}{snd(p)} p == pair(fst(p),snd(p))
+    } // pair
+
+    axiom {
+      forall l, r int :: {pair(l,r)} l == fst(pair(l,r)) && r == snd(pair(l,r))
+    }
+}
+
+// the following clause should be permitted by the type-checker:
+intPair implements any
+
+func test() {
+    x := pair(1,2)
+    //:: ExpectedOutput(type_error)
+    assert equal(x, x) // fails as `equal` is actual
+}
+
+decreases
+requires isComparable(a)
+pure func equal(a, b any) bool {
+    return a == b
+}

--- a/src/test/resources/regressions/features/domains/implements-interface-fail01.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-fail01.gobra
@@ -23,14 +23,24 @@ ghost type intPair domain {
 // the following clause should be permitted by the type-checker:
 intPair implements any
 
-func test() {
+func test() (res bool) {
     x := pair(1,2)
     //:: ExpectedOutput(type_error)
-    assert equal(x, x) // fails as `equal` is actual
+    tmp := equalImpure(x, x) // cannot assign ghost argument to a non-ghost parameter
+    assert equalPure(x, x) // fine as we allow calling pure functions with ghost arguments by implicitly treating the callee as being ghost
+    //:: ExpectedOutput(type_error)
+    res = equalPure(x, x) // cannot assign implicitly ghost result to a non-ghost variable
+    return
 }
 
 decreases
 requires isComparable(a)
-pure func equal(a, b any) bool {
+func equalImpure(a, b any) bool {
+    return a == b
+}
+
+decreases
+requires isComparable(a)
+pure func equalPure(a, b any) bool {
     return a == b
 }

--- a/src/test/resources/regressions/features/domains/implements-interface-fail02.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-fail02.gobra
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// this testcase checks that a domain is not deemed identity preserving if a non-identity preserving type
+// show up as a parameter type in one of its domain functions.
+
+package ImplementsInterfaceFail02
+
+// `NonIdentityPreservingStruct` is not identity preserving as it contains a ghost field
+type NonIdentityPreservingStruct struct {
+    a int
+    ghost g int
+}
+
+ghost type MyDomain domain {
+    func constructor(NonIdentityPreservingStruct) int
+}
+
+//:: ExpectedOutput(type_error)
+MyDomain implements any // should fail as `MyDomain` uses a non-identity preserving type as a parameter type

--- a/src/test/resources/regressions/features/domains/implements-interface-fail03.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-fail03.gobra
@@ -1,9 +1,10 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-// this testcase checks whether a domain can implement a non-empty interface
+// this testcase checks that a domain cannot implement an interface containing actual functions by defining actual
+// methods (complementing `implements-interface-simple02.gobra`).
 
-package ImplementsInterfaceSimple02
+package ImplementsInterfaceFail03
 
 ghost type intPair domain {
     func fst(intPair) int
@@ -20,25 +21,23 @@ ghost type intPair domain {
 }
 
 type Equality interface {
-    ghost
     pure hash() int
 
-    ghost
     isEqual(other Equality) bool
 }
 
 // the following clause should be permitted by the type-checker as intPair implements the interface:
 intPair implements Equality
 
-ghost
 decreases
-pure func (i intPair) hash() int {
+//:: ExpectedOutput(type_error)
+pure func (i intPair) hash() int { // receiver cannot be ghost
     return 42 // best implementation of a hash function
 }
 
-ghost
 decreases
-func (i intPair) isEqual(other Equality) bool {
+//:: ExpectedOutput(type_error)
+func (i intPair) isEqual(other Equality) bool { // receiver cannot be ghost & ghost result cannot be assigned to actual result
     if typeOf(other) == intPair {
         return fst(i) == fst(other.(intPair)) && snd(i) == snd(other.(intPair))
     }
@@ -49,6 +48,4 @@ func test() {
     ghost var x Equality
     x = pair(1,2)
     assert x.hash() == 42
-    //:: ExpectedOutput(assert_error:assertion_error)
-    assert false
 }

--- a/src/test/resources/regressions/features/domains/implements-interface-fail04.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-fail04.gobra
@@ -1,9 +1,10 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-// this testcase checks whether a domain can implement a non-empty interface
+// this testcase checks that a domain cannot implement an interface containing actual functions by defining ghost
+// methods (complementing `implements-interface-simple02.gobra`).
 
-package ImplementsInterfaceSimple02
+package ImplementsInterfaceFail04
 
 ghost type intPair domain {
     func fst(intPair) int
@@ -20,15 +21,13 @@ ghost type intPair domain {
 }
 
 type Equality interface {
-    ghost
     pure hash() int
 
-    ghost
     isEqual(other Equality) bool
 }
 
-// the following clause should be permitted by the type-checker as intPair implements the interface:
-intPair implements Equality
+//:: ExpectedOutput(type_error)
+intPair implements Equality // fails as the ghostness of the implementation does not match the interface
 
 ghost
 decreases
@@ -40,15 +39,15 @@ ghost
 decreases
 func (i intPair) isEqual(other Equality) bool {
     if typeOf(other) == intPair {
-        return fst(i) == fst(other.(intPair)) && snd(i) == snd(other.(intPair))
+        //:: ExpectedOutput(type_error)
+        return fst(i) == fst(other.(intPair)) && snd(i) == snd(other.(intPair)) // `other` cannot be cast to `intPair`
     }
     return false
 }
 
 func test() {
-    ghost var x Equality
-    x = pair(1,2)
+    var x Equality
+    //:: ExpectedOutput(type_error)
+    x = pair(1,2) // `pair` does not implement `Equality`
     assert x.hash() == 42
-    //:: ExpectedOutput(assert_error:assertion_error)
-    assert false
 }

--- a/src/test/resources/regressions/features/domains/implements-interface-simple01.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-simple01.gobra
@@ -1,0 +1,37 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// this testcase checks whether a domain can implement an interface
+
+package ImplementsInterfaceSimple01
+
+ghost type intPair domain {
+    func fst(intPair) int
+    func snd(intPair) int
+    func pair(int, int) intPair
+
+    axiom {
+      forall p intPair :: {fst(p)}{snd(p)} p == pair(fst(p),snd(p))
+    } // pair
+
+    axiom {
+      forall l, r int :: {pair(l,r)} l == fst(pair(l,r)) && r == snd(pair(l,r))
+    }
+}
+
+// the following clause should be permitted by the type-checker:
+intPair implements any
+
+func test() {
+    x := pair(1,2)
+    assert equal(x, x) // succeeds as `equal` is ghost
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+ghost
+decreases
+requires isComparable(a)
+pure func equal(a, b any) bool {
+    return a == b
+}

--- a/src/test/resources/regressions/features/domains/implements-interface-simple01.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-simple01.gobra
@@ -23,7 +23,8 @@ ghost type intPair domain {
 intPair implements any
 
 func test() {
-    x := pair(1,2)
+    ghost var x any
+    x = pair(1,2)
     assert equal(x, x) // succeeds as `equal` is ghost
     //:: ExpectedOutput(assert_error:assertion_error)
     assert false

--- a/src/test/resources/regressions/features/domains/implements-interface-simple02.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-simple02.gobra
@@ -1,0 +1,53 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// this testcase checks whether a domain can implement a non-empty interface
+
+package ImplementsInterfaceSimple01
+
+ghost type intPair domain {
+    func fst(intPair) int
+    func snd(intPair) int
+    func pair(int, int) intPair
+
+    axiom {
+      forall p intPair :: {fst(p)}{snd(p)} p == pair(fst(p),snd(p))
+    } // pair
+
+    axiom {
+      forall l, r int :: {pair(l,r)} l == fst(pair(l,r)) && r == snd(pair(l,r))
+    }
+}
+
+type Equality interface {
+    ghost
+    pure hash() int
+
+    ghost
+    isEqual(other Equality) bool
+}
+
+// the following clause should be permitted by the type-checker as intPair implements the interface:
+intPair implements Equality
+
+ghost
+decreases
+pure func (i intPair) hash() int {
+    return 42 // best implementation of a hash function
+}
+
+ghost
+decreases
+func (i intPair) isEqual(other Equality) bool {
+    if typeOf(other) == intPair {
+        return fst(i) == fst(other.(intPair)) && snd(i) == snd(other.(intPair))
+    }
+    return false
+}
+
+func test() {
+    x := pair(1,2)
+    assert x.hash() == 42
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}


### PR DESCRIPTION
This PR allows domains to implement an interface (see `Implements.scala`).
A domain is identity preserving only if all types that show up as input or output parameters of domain functions of this domain are identity preserving.

PS: the motivation for this PR is that I want to implement a ghost interface for various types, one of them being a domain.