### PR TITLE
Slice cap operation didn't check underlyingTypes

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -2773,7 +2773,7 @@ object Desugar extends LazyLogging {
             dop <- go(op)
           } yield dop match {
             case dop : in.ArrayLit => in.IntLit(dop.length)(src)
-            case _ => dop.typ match {
+            case _ => underlyingType(dop.typ) match {
               case _: in.ArrayT => in.Length(dop)(src)
               case _: in.SliceT => in.Capacity(dop)(src)
               case t => violation(s"expected an array or slice type, but got $t")

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -527,7 +527,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
     }
 
     case PCapacity(op) => isExpr(op).out ++ {
-      exprType(op) match {
+      underlyingType(exprType(op)) match {
         case _: ArrayT | _: SliceT | _: GhostSliceT => noMessages
         case typ => error(op, s"expected an array or slice type, but got $typ")
       }

--- a/src/test/resources/regressions/features/slices/slice-cap-simple2.gobra
+++ b/src/test/resources/regressions/features/slices/slice-cap-simple2.gobra
@@ -1,0 +1,10 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+type IP []byte
+
+requires len(x) <= cap(x)
+decreases _
+pure func foo(x IP) bool


### PR DESCRIPTION
The following example fails to typecheck without an explicit typecast:
```
type IP []byte

requires len(x) <= cap(x)
decreases _
pure func foo(x IP) bool
```