### PR TITLE
Fix reserved parser keyword error reporting

### DIFF
--- a/src/main/antlr4/GobraLexer.g4
+++ b/src/main/antlr4/GobraLexer.g4
@@ -17,6 +17,7 @@ DECIMAL_FLOAT_LIT      : DECIMALS ('.'{_input.LA(1) != '.'}? DECIMALS? EXPONENT?
 // ->mode(NLSEMI) means line breaks directly after this token
 // emit a semicolon. (just like after identifiers, literals, ')}]' etc in base Go)
 
+// NOTE: if you prepend a new token, do not forget to update InformativeErrorListener.FIRST_GOBRA_TOKEN
 TRUE        : 'true' -> mode(NLSEMI);
 FALSE       : 'false' -> mode(NLSEMI);
 ASSERT      : 'assert';
@@ -94,3 +95,4 @@ WITH        : 'with';
 OPAQUE      : 'opaque' -> mode(NLSEMI);
 REVEAL      : 'reveal';
 BACKEND     : '#backend';
+// NOTE: if you append a new token, do not forget to update InformativeErrorListener.LAST_GOBRA_TOKEN

--- a/src/main/scala/viper/gobra/frontend/InformativeErrorListener.scala
+++ b/src/main/scala/viper/gobra/frontend/InformativeErrorListener.scala
@@ -21,6 +21,19 @@ import scala.collection.mutable.ListBuffer
 class InformativeErrorListener(val messages: ListBuffer[ParserError], val source: Source) extends BaseErrorListener {
 
   /**
+    * First token that Gobra introduces that is not present in Go.
+    * First refers to the order of token declarations in GobraLexer.g4
+    * as this order is preserved by ANTLR4 when generating GobraParser.java
+    */
+  private val FIRST_GOBRA_TOKEN = GobraParser.TRUE
+  /**
+    * Last token that Gobra introduces that is not present in Go.
+    * Last refers to the order of token declarations in GobraLexer.g4
+    * this order is preserved by ANTLR4 when generating GobraParser.java
+    */
+  private val LAST_GOBRA_TOKEN = GobraParser.BACKEND
+
+  /**
     *
     * @param recognizer The recognizer that encountered the error
     * @param offendingSymbol The symbol that caused the error
@@ -314,5 +327,5 @@ class InformativeErrorListener(val messages: ListBuffer[ParserError], val source
   }
 
   // All tokens reserved by gobra, but not by Go
-  val new_reserved = IntervalSet.of(GobraParser.TRUE, GobraParser.TRUSTED)
+  val new_reserved = IntervalSet.of(FIRST_GOBRA_TOKEN, LAST_GOBRA_TOKEN)
 }

--- a/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
+++ b/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
@@ -11,6 +11,7 @@ import org.scalatest.exceptions.TestFailedException
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import viper.gobra.ast.frontend._
+import viper.gobra.reporting.ParserError
 import viper.gobra.util.{Decimal, Hexadecimal}
 
 class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
@@ -2719,6 +2720,12 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
   test("Parser: should be able to parse a ghost struct ghost type declaration") {
     frontend.parseMemberOrFail("ghost type MyStruct ghost struct { Value int }") should matchPattern {
       case Vector(PExplicitGhostMember(PTypeDef(PExplicitGhostStructType(PStructType(Vector(PFieldDecls(Vector(PFieldDecl(PIdnDef("Value"), PIntType())))))), PIdnDef("MyStruct")))) =>
+    }
+  }
+
+  test("Parser: should point out that 'proof' is a reserved word") {
+    frontend.parseMember("func test(proof ProofType)") should matchPattern {
+      case Left(Vector(ParserError(msg, _))) if msg contains "Unexpected reserved word proof" =>
     }
   }
 }


### PR DESCRIPTION
This PR addresses a bug discovered by @felixlinker where our parser just reports "no viable alternative at input '(proof'
func test(proof ProofType)" for the following input, thus, making it hard to spot that `proof` is a reserved word. While our parse error listener already supports pointing out reserved words, the list of reserved words was outdated. I hope to prevent similar bugs in the future by corresponding notes in `GobraLexer.g4`.

```
package main

func test(proof ProofType)
```