### PR TITLE
Fix exception when checking whether an imported domain is identity preserving

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Implements.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Implements.scala
@@ -117,7 +117,7 @@ trait Implements { this: TypeInfoImpl =>
           // check that all types (besides `ut` itself) occurring as input or output parameter types are identity preserving
           val inAndOutParams = ut.decl.funcs.flatMap(f => f.args ++ f.result.outs)
           inAndOutParams
-            .map(param => typ(param))
+            .map(param => ut.context.typ(param))
             .filter(_ != ut) // ignore the domain itself
             .forall(typ => go(typ))
         case ut: GhostCollectionType => go(ut.elem)

--- a/src/test/resources/regressions/features/domains/implements-interface-imported-simple01.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-imported-simple01.gobra
@@ -1,0 +1,27 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// this testcase checks whether an imported domain can implement an interface
+
+package ImplementsInterfaceImportedSimple01
+
+// ##(-I ./implements-interface-imported-simple01/)
+import "foo"
+
+// the following clause should be permitted by the type-checker:
+foo.IntPair implements any
+
+func test() {
+    ghost var x any
+    x = foo.pair(1,2)
+    assert equal(x, x) // succeeds as `equal` is ghost
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+ghost
+decreases
+requires isComparable(a)
+pure func equal(a, b any) bool {
+    return a == b
+}

--- a/src/test/resources/regressions/features/domains/implements-interface-imported-simple01/foo/foo.gobra
+++ b/src/test/resources/regressions/features/domains/implements-interface-imported-simple01/foo/foo.gobra
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package foo
+
+// this package provides the domain that `implements-interface-imported-simple01.gobra` uses
+
+ghost type IntPair domain {
+    func fst(IntPair) int
+    func snd(IntPair) int
+    func pair(int, int) IntPair
+
+    axiom {
+      forall p IntPair :: {fst(p)}{snd(p)} p == pair(fst(p),snd(p))
+    } // pair
+
+    axiom {
+      forall l, r int :: {pair(l,r)} l == fst(pair(l,r)) && r == snd(pair(l,r))
+    }
+}


### PR DESCRIPTION
The added case to decide whether a domain is type identity preserving (see #860) causes a node not in tree exception when the domain is located in a different package. This PR fixes this bug.