### PR TITLE
errors.New

### DIFF
--- a/.github/license-check/headers/Go.txt
+++ b/.github/license-check/headers/Go.txt
@@ -1,3 +1,3 @@
-// Copyright 2009 The Go Authors. All rights reserved.
+// Copyright %regexp:\d{4}% The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in https://golang.org/LICENSE

--- a/src/main/resources/stubs/errors/errors.gobra
+++ b/src/main/resources/stubs/errors/errors.gobra
@@ -11,8 +11,8 @@
 //
 // An error e wraps another error if e's type has one of the methods
 //
-//	Unwrap() error
-//	Unwrap() []error
+//  Unwrap() error
+//  Unwrap() []error
 //
 // If e.Unwrap() returns a non-nil error w or a slice containing w,
 // then we say that e wraps w. A nil error returned from e.Unwrap()
@@ -22,7 +22,7 @@
 // An easy way to create wrapped errors is to call [fmt.Errorf] and apply
 // the %w verb to the error argument:
 //
-//	wrapsErr := fmt.Errorf("... %w ...", ..., err, ...)
+//  wrapsErr := fmt.Errorf("... %w ...", ..., err, ...)
 //
 // Successive unwrapping of an error creates a tree. The [Is] and [As]
 // functions inspect an error's tree by examining first the error
@@ -36,11 +36,11 @@
 // matches the second. It reports whether it finds a match. It should be
 // used in preference to simple equality checks:
 //
-//	if errors.Is(err, fs.ErrExist)
+//  if errors.Is(err, fs.ErrExist)
 //
 // is preferable to
 //
-//	if err == fs.ErrExist
+//  if err == fs.ErrExist
 //
 // because the former will succeed if err wraps [io/fs.ErrExist].
 //
@@ -48,16 +48,16 @@
 // assigned to its second argument, which must be a pointer. If it succeeds, it
 // performs the assignment and returns true. Otherwise, it returns false. The form
 //
-//	var perr *fs.PathError
-//	if errors.As(err, &perr) {
-//		fmt.Println(perr.Path)
-//	}
+//  var perr *fs.PathError
+//  if errors.As(err, &perr) {
+//      fmt.Println(perr.Path)
+//  }
 //
 // is preferable to
 //
-//	if perr, ok := err.(*fs.PathError); ok {
-//		fmt.Println(perr.Path)
-//	}
+//  if perr, ok := err.(*fs.PathError); ok {
+//      fmt.Println(perr.Path)
+//  }
 //
 // because the former will succeed if err wraps an [*io/fs.PathError].
 package errors
@@ -67,14 +67,14 @@ package errors
 ensures err != nil && err.ErrorMem()
 decreases
 func New(text string) (err error) {
-	err = &errorString{text}
+    err = &errorString{text}
     fold err.ErrorMem()
     return
 }
 
 // errorString is a trivial implementation of error.
 type errorString struct {
-	s string
+    s string
 }
 *errorString implements error
 
@@ -103,7 +103,7 @@ preserves e.ErrorMem()
 ensures   e.IsDuplicableMem() == old(e.IsDuplicableMem())
 decreases
 func (e *errorString) Error() string {
-	return unfolding e.ErrorMem() in e.s
+    return unfolding e.ErrorMem() in e.s
 }
 
 // ErrUnsupported indicates that a requested operation cannot be performed,
@@ -113,7 +113,7 @@ func (e *errorString) Error() string {
 // Functions and methods should not return this error but should instead
 // return an error including appropriate context that satisfies
 //
-//	errors.Is(err, errors.ErrUnsupported)
+//  errors.Is(err, errors.ErrUnsupported)
 //
 // either by directly wrapping ErrUnsupported or by implementing an [Is] method.
 //

--- a/src/main/resources/stubs/errors/errors.gobra
+++ b/src/main/resources/stubs/errors/errors.gobra
@@ -1,6 +1,6 @@
 // Copyright 2011 The Go Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
+// license that can be found in https://golang.org/LICENSE
 
 // Signatures for the public declarations in file
 // https://github.com/golang/go/blob/master/src/errors/errors.go

--- a/src/main/resources/stubs/errors/errors.gobra
+++ b/src/main/resources/stubs/errors/errors.gobra
@@ -1,0 +1,122 @@
+// Copyright 2011 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Signatures for the public declarations in file
+// https://github.com/golang/go/blob/master/src/errors/errors.go
+
+// Package errors implements functions to manipulate errors.
+//
+// The [New] function creates errors whose only content is a text message.
+//
+// An error e wraps another error if e's type has one of the methods
+//
+//	Unwrap() error
+//	Unwrap() []error
+//
+// If e.Unwrap() returns a non-nil error w or a slice containing w,
+// then we say that e wraps w. A nil error returned from e.Unwrap()
+// indicates that e does not wrap any error. It is invalid for an
+// Unwrap method to return an []error containing a nil error value.
+//
+// An easy way to create wrapped errors is to call [fmt.Errorf] and apply
+// the %w verb to the error argument:
+//
+//	wrapsErr := fmt.Errorf("... %w ...", ..., err, ...)
+//
+// Successive unwrapping of an error creates a tree. The [Is] and [As]
+// functions inspect an error's tree by examining first the error
+// itself followed by the tree of each of its children in turn
+// (pre-order, depth-first traversal).
+//
+// See https://go.dev/blog/go1.13-errors for a deeper discussion of the
+// philosophy of wrapping and when to wrap.
+//
+// [Is] examines the tree of its first argument looking for an error that
+// matches the second. It reports whether it finds a match. It should be
+// used in preference to simple equality checks:
+//
+//	if errors.Is(err, fs.ErrExist)
+//
+// is preferable to
+//
+//	if err == fs.ErrExist
+//
+// because the former will succeed if err wraps [io/fs.ErrExist].
+//
+// [As] examines the tree of its first argument looking for an error that can be
+// assigned to its second argument, which must be a pointer. If it succeeds, it
+// performs the assignment and returns true. Otherwise, it returns false. The form
+//
+//	var perr *fs.PathError
+//	if errors.As(err, &perr) {
+//		fmt.Println(perr.Path)
+//	}
+//
+// is preferable to
+//
+//	if perr, ok := err.(*fs.PathError); ok {
+//		fmt.Println(perr.Path)
+//	}
+//
+// because the former will succeed if err wraps an [*io/fs.PathError].
+package errors
+
+// New returns an error that formats as the given text.
+// Each call to New returns a distinct error value even if the text is identical.
+ensures err != nil && err.ErrorMem()
+decreases
+func New(text string) (err error) {
+	err = &errorString{text}
+    fold err.ErrorMem()
+    return
+}
+
+// errorString is a trivial implementation of error.
+type errorString struct {
+	s string
+}
+*errorString implements error
+
+pred (e *errorString) ErrorMem() {
+    acc(e, _)
+}
+
+ghost
+requires  acc(e.ErrorMem(), _)
+decreases
+pure func (e *errorString) IsDuplicableMem() bool {
+    return true
+}
+
+ghost
+preserves e.ErrorMem()
+ensures   e.IsDuplicableMem() == old(e.IsDuplicableMem())
+ensures   e.IsDuplicableMem() ==> e.ErrorMem()
+decreases
+func (e *errorString) Duplicate() {
+    unfold e.ErrorMem()
+    fold acc(e.ErrorMem(), 2/1)
+}
+
+preserves e.ErrorMem()
+ensures   e.IsDuplicableMem() == old(e.IsDuplicableMem())
+decreases
+func (e *errorString) Error() string {
+	return unfolding e.ErrorMem() in e.s
+}
+
+// ErrUnsupported indicates that a requested operation cannot be performed,
+// because it is unsupported. For example, a call to [os.Link] when using a
+// file system that does not support hard links.
+//
+// Functions and methods should not return this error but should instead
+// return an error including appropriate context that satisfies
+//
+//	errors.Is(err, errors.ErrUnsupported)
+//
+// either by directly wrapping ErrUnsupported or by implementing an [Is] method.
+//
+// Functions and methods should document the cases in which an error
+// wrapping this will be returned.
+var ErrUnsupported = New("unsupported operation")


### PR DESCRIPTION
This PR extends the `errors` package to (finally!) provide the `New` function.