### PR TITLE
Add support for converting maps to dicts

### DIFF
--- a/src/main/antlr4/GobraParser.g4
+++ b/src/main/antlr4/GobraParser.g4
@@ -115,7 +115,7 @@ optionNone: NONE L_BRACKET type_ R_BRACKET;
 
 optionGet: GET L_PAREN expression R_PAREN;
 
-sConversion: kind=(SET | SEQ | MSET) L_PAREN expression R_PAREN;
+sConversion: kind=(SET | SEQ | MSET | DICT) L_PAREN expression R_PAREN;
 
 old: OLD (L_BRACKET oldLabelUse R_BRACKET)? L_PAREN expression R_PAREN;
 

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -1219,6 +1219,8 @@ case class PMultisetConversion(exp : PExpression) extends PMultisetExp
 /* ** (Mathematical) Map expressions */
 sealed trait PMathMapExp extends PUnorderedGhostCollectionExp
 
+case class PMathMapConversion(exp : PExpression) extends PMathMapExp
+
 /**
   * Set of keys of a mathematical or actual map
   */

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -559,6 +559,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
           case PMultisetConversion(exp) => "mset" <> parens(showExpr(exp))
           case PMapKeys(exp) => "domain" <> parens(showExpr(exp))
           case PMapValues(exp) => "range" <> parens(showExpr(exp))
+          case PMathMapConversion(exp) => "dict" <> parens(showExpr(exp))
         }
       }
 

--- a/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
@@ -531,6 +531,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
     case MultisetConversion(exp) => "mset" <> parens(showExpr(exp))
     case MapKeys(exp, _) => "domain" <> parens(showExpr(exp))
     case MapValues(exp, _) => "range" <> parens(showExpr(exp))
+    case MapConversion(exp) => "dict" <> parens(showExpr(exp))
     case Conversion(typ, exp) => showType(typ) <> parens(showExpr(exp))
     case Receive(channel, _, _, _) => "<-" <+> showExpr(channel)
 

--- a/src/main/scala/viper/gobra/ast/internal/Program.scala
+++ b/src/main/scala/viper/gobra/ast/internal/Program.scala
@@ -938,6 +938,17 @@ case class MapValues(exp : Expr, expUnderlyingType: Type)(val info : Source.Pars
   }
 }
 
+/**
+ * Represents the conversion of a value of type 'map[k]v' to a mathematical map with type 'dict[k]v'
+ */
+case class MapConversion(expr: Expr)(val info: Source.Parser.Info) extends Expr {
+  override val typ : Type = expr.typ match {
+    case MapT(k, v, _) => MathMapT(k, v, Addressability.conversionResult)
+    case t => Violation.violation(s"expected a map but got $t")
+  }
+}
+
+
 case class PureFunctionCall(func: FunctionProxy, args: Vector[Expr], typ: Type, reveal: Boolean = false)(val info: Source.Parser.Info) extends Expr
 case class PureMethodCall(recv: Expr, meth: MethodProxy, args: Vector[Expr], typ: Type, reveal: Boolean = false)(val info: Source.Parser.Info) extends Expr
 case class PureClosureCall(closure: Expr, args: Vector[Expr], spec: ClosureSpec, typ: Type)(val info: Source.Parser.Info) extends Expr

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -4442,6 +4442,13 @@ object Desugar extends LazyLogging {
           t = underlyingType(e.typ)
         } yield in.MapValues(e, t)(src)
 
+        case PMathMapConversion(op) => for {
+          dop <- go(op)
+        } yield dop.typ match {
+          case _: in.MapT => in.MapConversion(dop)(src)
+          case t => violation(s"expected a map type but found $t")
+        }
+
         case PClosureImplements(closure, spec) => for {
           c <- exprD(ctx, info)(closure)
         } yield in.ClosureImplements(c, closureSpecD(ctx, info)(spec))(src)

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -1505,6 +1505,7 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
       case GobraParser.SEQ => PSequenceConversion
       case GobraParser.SET => PSetConversion
       case GobraParser.MSET => PMultisetConversion
+      case GobraParser.DICT => PMathMapConversion
     }
     conversion(exp)
   }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -222,6 +222,10 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
           case Single(_: MathMapT | _: MapT) => isExpr(exp).out
           case t => error(expr, s"expected a map, but got $t")
         }
+        case PMathMapConversion(op) => underlyingType(exprType(op)) match {
+          case Single(_: MapT) => isExpr(op).out
+          case t => error(expr, s"expected a map, but got a $t")
+        }
       }
     }
 
@@ -332,6 +336,10 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
           case Single(t: MathMapT) => SetT(t.elem)
           case Single(t: MapT) => SetT(t.elem)
           case t => violation(s"expected a map, but got $t")
+        }
+        case PMathMapConversion(op) => underlyingType(exprType(op)) match {
+          case MapT(k, v) => MathMapT(k, v)
+          case t => violation(s"expected a sequence, set, multiset or option type, but got $t")
         }
       }
     }
@@ -463,6 +471,7 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
         case PGhostCollectionUpdate(seq, clauses) => go(seq) && clauses.forall(isPureGhostColUpdClause)
         case PMapKeys(exp) => go(exp)
         case PMapValues(exp) => go(exp)
+        case PMathMapConversion(exp) => go(exp)
       }
 
       case _: PAccess | _: PPredicateAccess => !strong

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -339,7 +339,7 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
         }
         case PMathMapConversion(op) => underlyingType(exprType(op)) match {
           case MapT(k, v) => MathMapT(k, v)
-          case t => violation(s"expected a sequence, set, multiset or option type, but got $t")
+          case t => violation(s"expected a map but got $t")
         }
       }
     }

--- a/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
@@ -124,6 +124,9 @@ class MapEncoding extends LeafTypeEncoding {
             correspondingMapRange
           ), v)
         } yield res
+
+      case in.MapConversion(exp :: ctx.Map(keys, values)) =>
+        getCorrespondingMap(exp, keys, values)(ctx)
     }
   }
 

--- a/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/maps/MapEncoding.scala
@@ -59,6 +59,7 @@ class MapEncoding extends LeafTypeEncoding {
     * R[ keySet(e: map[K]V) ] -> [ e ] == null? 0 : MapDomain(getCorrespondingMap([ e ]))
     * R[ valueSet(e: map[K]V) ] -> [ e ] == null? 0 : MapRange(getCorrespondingMap([ e ]))
     * R[ k in (e: map[K]V) ] -> [ e ] == null? false : MapContains([ k ], getCorrespondingMap([ e ]))
+    * R[ dict(e: map[K]V) ] -> getCorrespondingMap([ e ])
     */
   override def expression(ctx: Context): in.Expr ==> CodeWriter[vpr.Exp] = {
     def goE(x: in.Expr): CodeWriter[vpr.Exp] = ctx.expression(x)

--- a/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/slices/SliceEncoding.scala
@@ -109,7 +109,6 @@ class SliceEncoding(arrayEmb : SharedArrayEmbedding) extends LeafTypeEncoding {
         case None => withSrc(sliceFromArray(unboxedBaseT, lowT, highT)(ctx), exp)
         case Some(maxT) => withSrc(fullSliceFromArray(unboxedBaseT, lowT, highT, maxT)(ctx), exp)
       }
-
       case n@in.Slice(base :: ctx.*(t: in.ArrayT), low, high, max, _) =>
         val baseInfo = base.info
         val derefBase = in.Deref(base, in.PointerT(t, t.addressability))(baseInfo)

--- a/src/test/resources/regressions/features/maps/math-maps-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/math-maps-simple1.gobra
@@ -33,3 +33,13 @@ func test1() {
 	// mathematical map equality
 	assert m1 != m2
 }
+
+// tests conversions from actual maps to dictionaries
+requires acc(m)
+requires 5 in domain(m)
+requires !(8 in domain(m))
+func test2(m map[int]int) {
+	ghost var y = dict(m)
+	assert 5 in domain(y)
+	assert !(8 in domain(m))
+}


### PR DESCRIPTION
In a recent conversation with @ThomasMayerl and @rayman2000, we realized that introducing ghost pure functions that convert from maps to dictionaries and from slices to sequences is still an unfortunate rite of passage for any user of Gobra. This PR addresses the former, which is impossible to fully implement as a pure function using the current syntax of Gobra, as we do not have a good way of iterating through maps without using loops. In addition, this conversion can be implemented super concisely and efficiently in Gobra already, due to the way maps are encoded.

I considered also implementing the conversion from slices to ghost collections, including seqs, sets and msets, but I don't have time atm