### PR TITLE
Generate cleaner output

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -133,7 +133,7 @@ trait GoVerifier extends StrictLogging {
 
     // Print warnings
     if(warningCount > 0) {
-      logger.info(s"$name has found $warningCount warning(s)")
+      logger.debug(s"$name has found $warningCount warning(s)")
     }
 
     // Print errors

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -70,13 +70,16 @@ trait GoVerifier extends StrictLogging {
     // by some signal.
     Runtime.getRuntime.addShutdownHook(new Thread() {
       override def run(): Unit = {
-        val statsFile = config.gobraDirectory.resolve("stats.json").toFile
-        logger.info("Writing report to " + statsFile.getPath)
-        val wroteFile = statsCollector.writeJsonReportToFile(statsFile)
-        if (!wroteFile) {
-          logger.error(s"Could not write to the file $statsFile. Check whether the permissions to the file allow writing to it.")
+        config.gobraDirectory match {
+          case Some(path) =>
+            val statsFile = path.resolve("stats.json").toFile
+            logger.info("Writing report to " + statsFile.getPath)
+            val wroteFile = statsCollector.writeJsonReportToFile(statsFile)
+            if (!wroteFile) {
+              logger.error(s"Could not write to the file $statsFile. Check whether the permissions to the file allow writing to it.")
+            }
+          case _ =>
         }
-
         // Report timeouts that were not previously reported
         statsCollector.getTimeoutErrorsForNonFinishedTasks.foreach(err => logger.error(err.formattedMessage))
       }

--- a/src/main/scala/viper/gobra/frontend/Config.scala
+++ b/src/main/scala/viper/gobra/frontend/Config.scala
@@ -60,7 +60,8 @@ object ConfigDefaults {
   // or when the goal is to gradually verify part of a package without having to provide an explicit list of the files
   // to verify.
   val DefaultOnlyFilesWithHeader: Boolean = false
-  lazy val DefaultGobraDirectory: Path = Path.of(".gobra")
+  // In the past, the default Gobra directory used to be Path.of(".gobra")
+  lazy val DefaultGobraDirectory: Option[Path] = None
   val DefaultTaskName: String = "gobra-task"
   val DefaultAssumeInjectivityOnInhale: Boolean = true
   val DefaultParallelizeBranches: Boolean = false
@@ -117,7 +118,7 @@ object MoreJoins {
 }
 
 case class Config(
-                   gobraDirectory: Path = ConfigDefaults.DefaultGobraDirectory,
+                   gobraDirectory: Option[Path] = ConfigDefaults.DefaultGobraDirectory,
                    // Used as an identifier of a verification task, ideally it shouldn't change between verifications
                    // because it is used as a caching key. Additionally it should be unique when using the StatsCollector
                    taskName: String = ConfigDefaults.DefaultTaskName,
@@ -261,7 +262,7 @@ object Config {
 }
 
 // have a look at `Config` to see an inline description of some of these parameters
-case class BaseConfig(gobraDirectory: Path = ConfigDefaults.DefaultGobraDirectory,
+case class BaseConfig(gobraDirectory: Option[Path] = ConfigDefaults.DefaultGobraDirectory,
                       moduleName: String = ConfigDefaults.DefaultModuleName,
                       includeDirs: Vector[Path] = ConfigDefaults.DefaultIncludeDirs.map(_.toPath).toVector,
                       reporter: GobraReporter = ConfigDefaults.DefaultReporter,
@@ -561,7 +562,7 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
   val gobraDirectory: ScallopOption[Path] = opt[Path](
     name = "gobraDirectory",
     descr = "Output directory for Gobra",
-    default = Some(ConfigDefaults.DefaultGobraDirectory),
+    default = ConfigDefaults.DefaultGobraDirectory,
     short = 'g'
   )(singleArgConverter(arg => Path.of(arg)))
 
@@ -1038,7 +1039,7 @@ class ScallopGobraConfig(arguments: Seq[String], isInputOptional: Boolean = fals
   )
 
   private def baseConfig(isolate: List[(Path, List[Int])]): BaseConfig = BaseConfig(
-    gobraDirectory = gobraDirectory(),
+    gobraDirectory = gobraDirectory.toOption,
     moduleName = module(),
     includeDirs = includeDirs,
     reporter = FileWriterReporter(

--- a/src/main/scala/viper/gobra/translator/encodings/closures/ClosureDomainEncoder.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/closures/ClosureDomainEncoder.scala
@@ -20,11 +20,9 @@ class ClosureDomainEncoder(specs: ClosureSpecsEncoder) {
 
   private var domainNeeded: Boolean = false
   lazy val vprType: vpr.DomainType = {
-    println("Use of closures detected: Closures are an experimental feature and may exhibit bugs.")
     domainNeeded = true
     vpr.DomainType(Names.closureDomain, Map.empty)(Vector.empty)
   }
-
 
   /** Encoding of the Closure domain. This is used to represent variables with function types. It looks as follows:
     *


### PR DESCRIPTION
Currently, the Gobra output contains noise that is totally unnecessary:
1. the option `--gobraDirectory` is almost never used. More often than that, people do not inspect the results of the file. To make matters worse, the default tends to lead to errors related to permissions to create/modify pre-existing directories. Thus, one usually finds the following two unnecessary lines in every execution of Gobra:
```
[info] Writing report to .gobra/stats.json
[info] Could not write to the file .gobra/stats.json. Check whether the permissions to the file allow writing to it.
```

Solution: unless explicitly instructed, Gobra does not generate such a file.

2. Gobra reports a warnings, but not the contents of the warnings themselves. This is rather confusing to users. In addition, these warnings are imprecise, and often report dependencies on unverified packages even though the packages **are** verified.

Solution: for now, I changed the debug level of the message. Nonetheless, I'm keen on completely dropping these kinds of messages from the system. What do you think, @ArquintL?

3. The message "Closures in Gobra are experimental and ..." is just annoying. Gobra is an experimental tool, and emphasizing that only closures are experimental might give the wrong impression.

Solution: I finally dropped it 🎉 
