### PR TITLE
Improve let-in syntax

### DIFF
--- a/src/main/antlr4/GobraParser.g4
+++ b/src/main/antlr4/GobraParser.g4
@@ -334,10 +334,14 @@ expression:
   |<assoc=right> expression IMPLIES expression #implication
   |<assoc=right> expression QMARK expression COLON expression #ternaryExpr
   | UNFOLDING predicateAccess IN expression #unfolding
-  | LET shortVarDecl IN expression #let
+  | letExpression #let
   | (FORALL | EXISTS) boundVariables COLON COLON triggers expression #quantification
   ;
 
+letExpression
+  : LET L_PAREN shortVarDecl R_PAREN IN expression
+  | LET shortVarDecl IN expression
+  ;
 
 // Added ghost statements
 statement:

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -1715,8 +1715,8 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
   }
 
   override def visitLet(ctx: LetContext): PLet = {
-    val ass = visitNode[PShortVarDecl](ctx.shortVarDecl())
-    val op = visitNode[PExpression](ctx.expression())
+    val ass = visitNode[PShortVarDecl](ctx.letExpression().shortVarDecl())
+    val op = visitNode[PExpression](ctx.letExpression().expression())
     PLet(ass, op).at(ctx)
   }
   //endregion

--- a/src/test/resources/regressions/issues/000899.gobra
+++ b/src/test/resources/regressions/issues/000899.gobra
@@ -1,0 +1,11 @@
+package issue000899
+
+var mapstrstr = map[string][]string{}
+
+preserves acc(mapstrstr)
+preserves let (val, ok := mapstrstr[str]) in acc(val) // parser error should NOT occur here
+func test(str string) 
+
+//:: ExpectedOutput(parser_error)
+preserves  */thismakesnosense // parser error should occur here
+func test_2()


### PR DESCRIPTION
This PR fixes #899. Essentially, the issue was that if we use a let-in clause, if we - at a later point - have a syntax error, Gobra would mark the let-in cause as being wrong (even if the let-in clause is correct and the error occurs later). Basically, the issue is that ANTLR generates an LL Parser and that it first tries to put as much as possible into shortVarDecl. Because IN can also be part of expression, meaning it can also be part of shortVarDecl, if there is a syntax error, the parser will put this (including the IN) into the shortVarDecl. The syntax error reported is then that the IN clause is missing. Just due to the way an LL Parser works this issue cannot really be fixed without adapting the syntax (e.g. by putting parentheses around the shortVarDecl part). However, this would break existing programs. Thus, this PR basically allows both syntaxes: For existing programs, the version without parentheses still works. For new programs or existing programs with new syntax errors, we can "opt-in" by just placing parentheses around the shortVarDecl and thus resolving the ambiguity.