### PR TITLE
Error reporting

### DIFF
--- a/src/main/scala/viper/gobra/reporting/BacktranslatingReporter.scala
+++ b/src/main/scala/viper/gobra/reporting/BacktranslatingReporter.scala
@@ -8,17 +8,17 @@ package viper.gobra.reporting
 
 import viper.gobra.frontend.Config
 import viper.gobra.reporting.BackTranslator.BackTrackInfo
-import viper.silver.reporter.{Message, Reporter => SilverReporter}
+import viper.silver.reporter.{Message, PluginAwareReporter}
 
 trait MessageBackTranslator {
   def translate(msg: Message): GobraMessage
 }
 
-case class BacktranslatingReporter(reporter: GobraReporter, backTrackInfo: BackTrackInfo, config: Config) extends SilverReporter {
+case class BacktranslatingReporter(reporter: GobraReporter, backTrackInfo: BackTrackInfo, config: Config) extends PluginAwareReporter {
   override val name: String = reporter.name
   private val msgTranslator: MessageBackTranslator = new DefaultMessageBackTranslator(backTrackInfo, config)
 
-  override def report(msg: Message): Unit = {
+  override def doReport(msg: Message): Unit = {
     reporter.report(msgTranslator.translate(msg))
   }
 }

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -185,7 +185,7 @@ case class RefuteError(info: Source.Verifier.Info) extends VerificationError {
 
   override def localId: String = "refute_error"
 
-  override def localMessage: String = "Refute statement failed. Assertion is either unreachable or it always holds."
+  override def localMessage: String = "Refute statement failed. Assertion is either unreachable or it always holds"
 }
 
 case class ExhaleError(info: Source.Verifier.Info) extends VerificationError {


### PR DESCRIPTION
This PR introduces minor changes to Gobra's error reporting infrastructure to ensure compatibility with Silver plugins. Specifically, it updates the reporting pipeline to properly integrate with Silver's `PluginAwareReporter`. This ensures that all errors are passed through the configured plugins' error transformations before being reported, eliminating confusing error messages that occurred when using `refute` statements in Gobra.

To test functionality, you can verify this function:
```
package playground

func test() {
    refute false
}
```

Gobra should produce the following output:
```
Verifying package .. - playground [14:19:01]
Gobra found 0 errors.
```

(Previously, it also printed an `Assertion failed` message originating from the `refute` statement.)

Conversely, verifying this code:
```
package playground

func test() {
    refute true
}
```

should yield the following output, correctly reporting the source of the error:
```
Verifying package .. - playground [15:50:24]
Error at: ... Refute statement failed. Assertion is either unreachable or it always holds. Assertion true definitely holds.
Gobra found 1 error.
```