### PR TITLE
Fix issue 883

### DIFF
--- a/src/main/scala/viper/gobra/translator/transformers/hyper/SIFLowGuardTransformer.scala
+++ b/src/main/scala/viper/gobra/translator/transformers/hyper/SIFLowGuardTransformer.scala
@@ -273,7 +273,7 @@ trait SIFLowGuardTransformer {
 
         case u: Unfolding =>
           Unfolding(runExp(u.acc, ctx.major).asInstanceOf[PredicateAccessPredicate],
-            Unfolding(runExp(u.acc, ctx.major).asInstanceOf[PredicateAccessPredicate], go(u.body, isPositive))(u.pos, u.info, u.errT)
+            Unfolding(runExp(u.acc, ctx.minor).asInstanceOf[PredicateAccessPredicate], go(u.body, isPositive))(u.pos, u.info, u.errT)
           )(u.pos, u.info, u.errT)
 
         case e => throw new IllegalArgumentException(

--- a/src/test/resources/regressions/issues/000883.gobra
+++ b/src/test/resources/regressions/issues/000883.gobra
@@ -1,0 +1,35 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue000883
+
+// ##(--hyperMode on)
+
+// Test 1: Unfolding works properly in the body of impure funcs
+pred IsLow(x int) {
+	low(x) && x >= 0
+}
+
+requires IsLow(x)
+func test1(x int) {
+	assert unfolding IsLow(x) in x >= 0
+}
+
+// Test 2: Unfolding works properly in the specs of impure funcs
+pred Mem(x *int) {
+	acc(x)
+}
+
+requires Mem(x)
+requires unfolding Mem(x) in low(*x)
+func test2(x *int)
+
+// Test 3: Unfolding works properly in the body of predicates
+pred Byte1(b []int) {
+	acc(&b[0])
+}
+
+pred Pred21(b []int) {
+	Byte1(b) &&
+	unfolding Byte1(b) in low(b[0])
+}


### PR DESCRIPTION
This was clearly caused by a typo in the translation of `unfolding` expressions.