### PR TITLE
Fix issue 946

### DIFF
--- a/src/main/scala/viper/gobra/translator/transformers/hyper/SIFLowGuardTransformer.scala
+++ b/src/main/scala/viper/gobra/translator/transformers/hyper/SIFLowGuardTransformer.scala
@@ -480,7 +480,7 @@ trait SIFLowGuardTransformer {
       case p: Package =>
         Package(
           wand = runExp(p.wand, ctx).asInstanceOf[MagicWand],
-          proofScript = toSeqn(statement(p.proofScript, ctx)),
+          proofScript = toSeqn(runStatement(p.proofScript, ctx)),
         )(p.pos, p.info, p.errT)
     }
   }

--- a/src/test/resources/regressions/issues/000946.gobra
+++ b/src/test/resources/regressions/issues/000946.gobra
@@ -1,6 +1,8 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
+// ##(--hyperMode on)
+
 package issue000946
 
 type Struct0 struct { b []byte }

--- a/src/test/resources/regressions/issues/000946.gobra
+++ b/src/test/resources/regressions/issues/000946.gobra
@@ -1,0 +1,23 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue000946
+
+type Struct0 struct { b []byte }
+pred (s0 Struct0) Mem() { acc(s0.b) }
+
+type Struct1 struct { b []byte }
+pred (s1 Struct1) Mem() { acc(s1.b) }
+
+requires acc(s0.Mem(), 1/2)
+ensures  acc(s1.Mem(), 1/2)
+ensures  acc(s1.Mem(), 1/2) --* acc(s0.Mem(), 1/2)
+func test(s0 Struct0) (s1 Struct1) {
+    unfold acc(s0.Mem(), 1/2)
+    s1 = Struct1{s0.b}
+    fold acc(s1.Mem(), 1/2)
+    package (acc(s1.Mem(), 1/2) --* acc(s0.Mem(), 1/2)) {
+	unfold acc(s1.Mem(), 1/2)
+	fold acc(s0.Mem(), 1/2)
+    }
+}


### PR DESCRIPTION
Currently, the statements in the body of a package statement are duplicated. This is wrong, as we should only running the statements that are concerned with the same execution as the current packaging statement