### PR TITLE
Add support for indexing strings

### DIFF
--- a/src/main/scala/viper/gobra/ast/internal/Program.scala
+++ b/src/main/scala/viper/gobra/ast/internal/Program.scala
@@ -766,6 +766,7 @@ case class IndexedExp(base : Expr, index : Expr, baseUnderlyingType: Type)(val i
     case t: SliceT => t.elems
     case t: MapT => t.values
     case t: MathMapT => t.values
+    case _: StringT => IntT(Addressability.Exclusive, TypeBounds.Byte)
     case t => Violation.violation(s"expected an array, map or sequence type, but got $t")
   }
 }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -6,11 +6,12 @@
 
 package viper.gobra.frontend.info.implementation.typing
 
+import org.bitbucket.inkytonik.kiama.util.Message
 import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, check, error, noMessages}
 import viper.gobra.ast.frontend.{AstPattern => ap, _}
-import viper.gobra.frontend.info.base.{SymbolTable => st}
 import viper.gobra.frontend.info.base.SymbolTable.{AdtDestructor, AdtDiscriminator, GlobalVariable, SingleConstant}
-import viper.gobra.frontend.info.base.Type.{PointerT, _}
+import viper.gobra.frontend.info.base.Type._
+import viper.gobra.frontend.info.base.{SymbolTable => st}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.util.TypeBounds.{BoundedIntegerKind, UnboundedInteger}
 import viper.gobra.util.{Constants, TypeBounds, Violation}
@@ -20,7 +21,6 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
   import viper.gobra.util.Violation._
 
   val INT_TYPE: Type = IntT(config.typeBounds.Int)
-  val UINT_TYPE: Type = IntT(config.typeBounds.UInt)
   val UNTYPED_INT_CONST: Type = IntT(config.typeBounds.UntypedConst)
   // default type of unbounded integer constant expressions when they must have a type
   val DEFAULT_INTEGER_TYPE: Type = INT_TYPE
@@ -362,7 +362,11 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
               noMessages
 
             case (StringT, IntT(_)) =>
-              error(n, "Indexing a string is currently not supported")
+              for {
+                cBase <- stringConstantEvaluation(n.base)
+                cIdx <- intConstantEvaluation(n.index)
+                if cIdx < 0 || cBase.length <= cIdx
+              } yield Message(n, s"$cIdx is not a valid index of string $cBase.")
 
             case (MapT(key, _), underlyingIdxType) =>
               // Assignability in Go is a property between a value and and a type. In Gobra, we model this as a relation
@@ -742,6 +746,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
           case (SliceT(elem), IntT(_)) => elem
           case (GhostSliceT(elem), IntT(_)) => elem
           case (VariadicT(elem), IntT(_)) => elem
+          case (StringT, IntT(_)) => IntT(TypeBounds.Byte)
           case (MapT(key, elem), underlyingIdxType) if assignableTo(idxType, key, mayInit) || assignableTo(underlyingIdxType, key, mayInit) =>
             InternalSingleMulti(elem, InternalTupleT(Vector(elem, BooleanT)))
           case (MathMapT(key, elem), underlyingIdxType) if assignableTo(idxType, key, mayInit) || assignableTo(underlyingIdxType, key, mayInit) =>

--- a/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
@@ -81,6 +81,12 @@ class StringEncoding extends LeafTypeEncoding {
       case conv@in.Conversion(in.StringT(_), expr :: ctx.Slice(in.IntT(_, TypeBounds.Byte))) =>
         val (pos, info, errT) = conv.vprMeta
         for { e <- goE(expr) } yield byteSliceToStr(e)(ctx)(pos, info, errT)
+      case e@in.IndexedExp(base, index, _: in.StringT) =>
+        val (pos, info, errT) = e.vprMeta
+        for {
+          baseExp <- goE(base)
+          indexExp <- goE(index)
+        } yield stringIndex(baseExp, indexExp)(ctx)(pos, info, errT)
     }
   }
 
@@ -92,6 +98,7 @@ class StringEncoding extends LeafTypeEncoding {
     *     var s []byte
     *     inhale forall i Int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i])
     *     inhale len(s) == len(str) // (*)
+    *     inhale forall i Int :: { &s[i] }{ str[i] } 0 <= i && i < len(s) ==> str[i] == s[i]
     *     target = s
     *   ]
     * Note that (*) is correct because the len() function returns the number of bytes in a string.
@@ -101,7 +108,7 @@ class StringEncoding extends LeafTypeEncoding {
     def goA(x: in.Assertion): CodeWriter[vpr.Exp] = ctx.assertion(x)
 
     default(super.statement(ctx)) {
-      case conv@in.EffectfulConversion(target, in.SliceT(in.IntT(_, TypeBounds.Byte), _), e) =>
+      case conv@in.EffectfulConversion(target, in.SliceT(in.IntT(_, TypeBounds.Byte), _), e :: ctx.String()) =>
         // the argument of type string is not used in the viper encoding. May change in the future to be able to prove more
         // interesting properties
         val (pos, info, errT) = conv.vprMeta
@@ -124,6 +131,24 @@ class StringEncoding extends LeafTypeEncoding {
             in.Length(e)(conv.info),
           )(conv.info)
         )(conv.info)
+        val post3 = in.SepForall(
+          vars = Vector(qtfVar),
+          triggers = Vector(
+            in.Trigger(Vector(in.Ref(in.IndexedExp(slice, qtfVar, sliceT)(conv.info))(conv.info)))(conv.info),
+            in.Trigger(Vector(in.IndexedExp(e, qtfVar, in.StringT(Addressability.Exclusive))(conv.info)))(conv.info)
+          ),
+          body = in.Implication(
+            in.And(
+              in.AtMostCmp(in.IntLit(BigInt(0))(conv.info), qtfVar)(conv.info),
+              in.LessCmp(qtfVar, in.Length(slice)(conv.info))(conv.info))(conv.info),
+            in.ExprAssertion(
+              in.EqCmp(
+                in.IndexedExp(e, qtfVar, in.StringT(Addressability.Exclusive))(conv.info),
+                in.IndexedExp(slice, qtfVar, sliceT)(conv.info)
+              )(conv.info)
+            )(conv.info)
+          )(conv.info)
+        )(conv.info)
 
         seqn(
           for {
@@ -132,6 +157,8 @@ class StringEncoding extends LeafTypeEncoding {
             _ <- write(vpr.Inhale(vprPost1)(pos, info, errT))
             vprPost2 <- goA(post2)
             _ <- write(vpr.Inhale(vprPost2)(pos, info, errT))
+            vprPost3 <- goA(post3)
+            _ <- write(vpr.Inhale(vprPost3)(pos, info, errT))
             ass <- ctx.assignment(in.Assignee.Var(target), slice)(conv)
           } yield ass
         )
@@ -143,6 +170,7 @@ class StringEncoding extends LeafTypeEncoding {
       addMemberFn(genDomain())
       if (strSliceIsUsed) { addMemberFn(strSlice) }
       byteSliceToStrFuncGenerator.finalize(addMemberFn)
+      stringIndexFuncGenerator.finalize(addMemberFn)
     }
   }
   private var isUsed: Boolean = false
@@ -285,6 +313,7 @@ class StringEncoding extends LeafTypeEncoding {
   /** Generates the function
     *   requires forall i int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i], _)
     *   ensures  len(s) == len(res) // (*)
+    *   ensures  forall i int :: { res[i] }{ &s[i] } 0 <= i && i < len(s) ==> res[i] == s[i]
     *   decreases _
     *   pure func byteSliceToStrFunc(s []byte) (res string)
     * Note that (*) is correct because the function len() returns the number of bytes in a string.
@@ -306,10 +335,28 @@ class StringEncoding extends LeafTypeEncoding {
           in.Access(in.Accessible.Address(in.IndexedExp(param, qtfVar, paramT)(info)), in.WildcardPerm(info))(info)
         )(info)
       )(info)
-      val post = in.ExprAssertion(
+      val post1 = in.ExprAssertion(
         in.EqCmp(
           in.Length(param)(info),
           in.Length(res)(info),
+        )(info)
+      )(info)
+      val post2 = in.SepForall(
+        vars = Vector(qtfVar),
+        triggers = Vector(
+          in.Trigger(Vector(in.Ref(in.IndexedExp(param, qtfVar, paramT)(info))(info)))(info),
+          in.Trigger(Vector(in.IndexedExp(res, qtfVar, in.StringT(Addressability.Exclusive))(info)))(info)
+        ),
+        body = in.Implication(
+          in.And(
+            in.AtMostCmp(in.IntLit(BigInt(0))(info), qtfVar)(info),
+            in.LessCmp(qtfVar, in.Length(param)(info))(info))(info),
+          in.ExprAssertion(
+            in.EqCmp(
+              in.IndexedExp(res, qtfVar, in.StringT(Addressability.Exclusive))(info),
+              in.IndexedExp(param, qtfVar, paramT)(info)
+            )(info)
+          )(info)
         )(info)
       )(info)
 
@@ -318,7 +365,7 @@ class StringEncoding extends LeafTypeEncoding {
         args = Vector(param),
         results = Vector(res),
         pres = Vector(pre),
-        posts = Vector(post),
+        posts = Vector(post1, post2),
         terminationMeasures = Vector(in.NonItfMethodWildcardMeasure(None)(info)),
         backendAnnotations = Vector.empty,
         body = None,
@@ -331,4 +378,47 @@ class StringEncoding extends LeafTypeEncoding {
 
   private def byteSliceToStr(slice: vpr.Exp)(ctx: Context)(pos: vpr.Position, info: vpr.Info, errT: vpr.ErrorTrafo): vpr.FuncApp =
     byteSliceToStrFuncGenerator(Vector(slice), ())(pos, info, errT)(ctx)
+
+  /**
+   * Generates the function
+   *    requires 0 <= i && i < len(s)
+   *    decreases _
+   *    pure func stringIndexFunc(s []byte, i int) (res byte)
+   */
+  private val stringIndexFuncName: String = "stringIndexFunc"
+  private val stringIndexFuncGenerator: FunctionGenerator[Unit] = new FunctionGenerator[Unit] {
+    override def genFunction(@unused x: Unit)(ctx: Context): vpr.Function = {
+      val info = Source.Parser.Internal
+      val param1T = in.StringT(Addressability.Exclusive)
+      val param1 = in.Parameter.In("s", param1T)(info)
+      val param2T = in.IntT(Addressability.Exclusive, TypeBounds.DefaultInt)
+      val param2 = in.Parameter.In("i", param2T)(info)
+      val resT = in.IntT(Addressability.Exclusive, TypeBounds.Byte)
+      val res = in.Parameter.Out("res", resT)(info)
+      val pre = in.ExprAssertion(
+        in.And(
+          in.AtMostCmp(in.IntLit(BigInt(0))(info), param2)(info),
+          in.LessCmp(param2, in.Length(param1)(info))(info)
+        )(info)
+      )(info)
+
+      val func: in.PureFunction = in.PureFunction(
+        name = in.FunctionProxy(stringIndexFuncName)(info),
+        args = Vector(param1, param2),
+        results = Vector(res),
+        pres = Vector(pre),
+        posts = Vector.empty,
+        terminationMeasures = Vector(in.NonItfMethodWildcardMeasure(None)(info)),
+        backendAnnotations = Vector.empty,
+        body = None,
+        isOpaque = false
+      )(info)
+      val translatedFunc = ctx.function(func)
+      translatedFunc.res
+    }
+  }
+
+  private def stringIndex(str: vpr.Exp, idx: vpr.Exp)(ctx: Context)(pos: vpr.Position, info: vpr.Info, errT: vpr.ErrorTrafo): vpr.FuncApp =
+    stringIndexFuncGenerator(Vector(str, idx), ())(pos, info, errT)(ctx)
+
 }

--- a/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/StringEncoding.scala
@@ -383,7 +383,7 @@ class StringEncoding extends LeafTypeEncoding {
    * Generates the function
    *    requires 0 <= i && i < len(s)
    *    decreases _
-   *    pure func stringIndexFunc(s []byte, i int) (res byte)
+   *    pure func stringIndexFunc(s string, i int) (res byte)
    */
   private val stringIndexFuncName: String = "stringIndexFunc"
   private val stringIndexFuncGenerator: FunctionGenerator[Unit] = new FunctionGenerator[Unit] {

--- a/src/test/resources/regressions/features/strings/strings-fail0.gobra
+++ b/src/test/resources/regressions/features/strings/strings-fail0.gobra
@@ -30,3 +30,10 @@ func orderStringLit3() {
 	//:: ExpectedOutput(assert_error)
 	assert "a" > "bb"
 }
+
+decreases
+func indexOutOfBounds(s string) {
+	// s is not guaranteed to have at least one element.
+	//:: ExpectedOutput(precondition_error)
+	assert s[0] == s[0]
+}

--- a/src/test/resources/regressions/features/strings/strings0.gobra
+++ b/src/test/resources/regressions/features/strings/strings0.gobra
@@ -63,3 +63,18 @@ func comp(s1, s2 string) int {
 		return 1
 	}
 }
+
+requires 0 < len(s)
+decreases
+func convStringBytesIndexing(s string) {
+	sl := []byte(s)
+	assert sl[0] == s[0]
+}
+
+requires 0 < len(s)
+requires acc(s)
+decreases
+func convBytesStringIndexing(s []byte) {
+	str := string(s)
+	assert str[0] == s[0]
+}

--- a/src/test/resources/regressions/issues/000831.gobra
+++ b/src/test/resources/regressions/issues/000831.gobra
@@ -1,0 +1,23 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue000883
+
+// ##(--hyperMode on)
+
+// Converting a literal string to a []byte yields a slice with low length and low contents.
+ensures acc(res)
+ensures low(len(res))
+ensures forall i int :: { res[i] } 0 <= i && i < len(res) && low(i) ==> low(res[i])
+func test1() (res []byte) {
+	res := []byte("test")
+}
+
+// Converting a low string to a []byte yields a slice with low length and low contents.
+requires low(s)
+ensures  acc(res)
+ensures  low(len(res))
+ensures  forall i int :: { res[i] } 0 <= i && i < len(res) && low(i) ==> low(res[i])
+func test2(s string) (res []byte) {
+	res := []byte(s)
+}


### PR DESCRIPTION
This PR:
- Adds support for indexing strings (e.g., `"hello"[1]`)
- Relates the contents of a string `s` with the contents of a slice obtained with `[]byte(s)`. This fixes issue #831.
- Relates the contents of a slice `s` with the contents of the string `string(s)`. This **partially** addresses issue #832 (see my comment there).

At the moment, violating the precondition of an indexing operation (i.e., passing an invalid index to a string) leads to a bad error message, similar to `precondition of unknown may not hold`. This is similar to other parts of our encoding, where we are not able to generate good error messages when the precondition of a function internal to our encoding may not hold. PR https://github.com/viperproject/silver/pull/815 will hopefully allow us to fix that by attaching an error message to the precondition directly in the encoding.