### PR TITLE
Derive ... by ...

### DIFF
--- a/src/main/antlr4/GobraLexer.g4
+++ b/src/main/antlr4/GobraLexer.g4
@@ -25,6 +25,8 @@ REFUTE      : 'refute';
 ASSUME      : 'assume';
 INHALE      : 'inhale';
 EXHALE      : 'exhale';
+DERIVE      : 'derive';
+BY          : 'by';
 PRE         : 'requires';
 PRESERVES   : 'preserves';
 POST        : 'ensures';

--- a/src/main/antlr4/GobraParser.g4
+++ b/src/main/antlr4/GobraParser.g4
@@ -66,6 +66,7 @@ ghostStatement:
   GHOST statement  #explicitGhostStatement
   | fold_stmt=(FOLD | UNFOLD) predicateAccess #foldStatement
   | kind=(ASSUME | ASSERT | REFUTE | INHALE | EXHALE) expression #proofStatement
+  | DERIVE expression BY block #deriveStatement
   | matchStmt #matchStmt_
   | OPEN_DUP_SINV #pkgInvStatement
   ;

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -975,6 +975,8 @@ case class PExplicitGhostStatement(actual: PStatement) extends PGhostStatement w
 
 case class PAssert(exp: PExpression) extends PGhostStatement
 
+case class PDeriveStmt(exp: PExpression, block: PBlock) extends PGhostStatement
+
 case class PRefute(exp: PExpression) extends PGhostStatement
 
 case class PAssume(exp: PExpression) extends PGhostStatement

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -307,6 +307,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
     case statement: PGhostStatement => statement match {
       case PExplicitGhostStatement(actual) => "ghost" <+> showStmt(actual)
       case PAssert(exp) => "assert" <+> showExpr(exp)
+      case PDeriveStmt(exp, block) => "derive" <+> showExpr(exp) <+> "by" <+> showStmt(block)
       case PRefute(exp) => "refute" <+> showExpr(exp)
       case PAssume(exp) => "assume" <+> showExpr(exp)
       case PExhale(exp) => "exhale" <+> showExpr(exp)

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -2214,7 +2214,7 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
   }
 
   /**
-    * Visist the production
+    * Visit the production
     * fold_stmt=(FOLD | UNFOLD) predicateAccess
     *     */
   override def visitFoldStatement(ctx: FoldStatementContext): PGhostStatement = super.visitFoldStatement(ctx) match {
@@ -2245,6 +2245,14 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
       case "inhale" => PInhale(expr)
       case "exhale" => PExhale(expr)
     }
+  }
+
+  /**
+    * Visits the production
+    * DERIVE expression BY block #deriveStatement
+    */
+  override def visitDeriveStatement(ctx: DeriveStatementContext): PGhostStatement = super.visitDeriveStatement(ctx) match {
+    case Vector("derive", expr: PExpression, "by", block: PBlock) => PDeriveStmt(expr, block)
   }
 
   override def visitStatementWithSpec(ctx: StatementWithSpecContext): PStatement = super.visitStatementWithSpec(ctx) match {

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
@@ -93,6 +93,7 @@ trait StmtTyping extends BaseTyping { this: TypeInfoImpl =>
 
     case n: PIfStmt => n.ifs.flatMap(ic =>
       isExpr(ic.condition).out ++
+        isPureExpr(ic.condition) ++
         comparableTypes.errors(exprType(ic.condition), BooleanT)(ic)
     )
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
@@ -8,6 +8,7 @@ package viper.gobra.frontend.info.implementation.typing.ghost
 
 import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error}
 import viper.gobra.ast.frontend.{PClosureImplProof, AstPattern => ap, _}
+import viper.gobra.frontend.info.base.Type.BooleanT
 import viper.gobra.frontend.info.base.{SymbolTable => st}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.frontend.info.implementation.typing.BaseTyping
@@ -23,6 +24,10 @@ trait GhostStmtTyping extends BaseTyping { this: TypeInfoImpl =>
     case PInhale(exp) => assignableToSpec(exp)
     case PFold(acc) => wellDefFoldable(acc)
     case PUnfold(acc) => wellDefFoldable(acc)
+    case PDeriveStmt(exp, _) =>
+      isExpr(exp).out ++
+        isPureExpr(exp) ++
+        comparableTypes.errors(exprType(exp), BooleanT)(exp)
     case POpenDupPkgInv() =>
       val occursInInitMember = isEnclosingMayInit(stmt)
       error(stmt, "Opening the package invariant in a function that may execute during initialization is not allowed.", occursInInitMember)

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -181,6 +181,11 @@ case class AssertError(info: Source.Verifier.Info) extends VerificationError {
   override def localMessage: String = "Assert might fail"
 }
 
+case class DeriveError(info: Source.Verifier.Info) extends VerificationError {
+  override def localId: String = "derive_error"
+  override def localMessage: String = "Derive statement failed. The body might not derive a contradiction after assuming the negated expression"
+}
+
 case class RefuteError(info: Source.Verifier.Info) extends VerificationError {
 
   override def localId: String = "refute_error"

--- a/src/test/resources/regressions/features/derive/derive-fail-01.gobra
+++ b/src/test/resources/regressions/features/derive/derive-fail-01.gobra
@@ -1,0 +1,13 @@
+package derivefail01
+
+func foo(x, y int) {
+    //:: ExpectedOutput(assert_error:assertion_error)
+    derive false by {
+        mylemma(x, y)
+    }
+}
+
+ghost
+ensures x <= y
+decreases
+func mylemma(x, y int)

--- a/src/test/resources/regressions/features/derive/derive-fail-02.gobra
+++ b/src/test/resources/regressions/features/derive/derive-fail-02.gobra
@@ -1,0 +1,6 @@
+package derivefail02
+
+func foo(x *int) {
+    //:: ExpectedOutput(type_error)
+    derive acc(x) by {}
+}

--- a/src/test/resources/regressions/features/derive/derive-simple-01.gobra
+++ b/src/test/resources/regressions/features/derive/derive-simple-01.gobra
@@ -1,0 +1,17 @@
+package derivesimple01
+
+func foo(x, y int) {
+    derive x <= y by {
+        mylemma(x, y)
+    }
+
+    assert x <= y
+
+    //:: ExpectedOutput(assert_error:assertion_error)
+    assert false
+}
+
+ghost
+ensures x <= y
+decreases
+func mylemma(x, y int)

--- a/src/test/resources/regressions/issues/000969.gobra
+++ b/src/test/resources/regressions/issues/000969.gobra
@@ -1,0 +1,8 @@
+package issue969
+
+func foo(x *int) {
+    //:: ExpectedOutput(type_error)
+    ghost if acc(x) {
+
+    }
+}


### PR DESCRIPTION
Introduces a new statement `derive <cond> by <block>` to derive `cond` by performing a proof by contradiction. This is particularly useful in connection with opaque functions as their body is revealed within `block` without spilling to the rest of the method as the branch evaluating `block` results in a contradiction and is, thus, killed.