### PR TITLE
Fix error position when output parameters are used in the postcondition of pure functions and methods

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -3974,7 +3974,9 @@ object Desugar extends LazyLogging {
     def varD(ctx: FunctionContext, info: TypeInfo)(id: PIdnNode): in.Expr = {
       require(info.regular(id).isInstanceOf[st.Variable])
       ctx(id, info) match {
-        case Some(v : in.Var) => v
+        case Some(v : in.Var) =>
+          val src = meta(id, info)
+          v.withInfo(src)
         case Some(d@in.Deref(_: in.Var, _)) => d
         case Some(v) => violation(s"expected a variable or the dereference of a pointer but got $v")
         case None => localVarContextFreeD(id, info)

--- a/src/main/scala/viper/gobra/translator/encodings/defaults/DefaultPureMethodEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/defaults/DefaultPureMethodEncoding.scala
@@ -41,7 +41,8 @@ class DefaultPureMethodEncoding extends Encoding {
     val resultType = if (vResults.size == 1) vResults.head.typ else ctx.tuple.typ(vResults map (_.typ))
 
     val fixResultvar = (x: vpr.Exp) => {
-      x.transform { case v: vpr.LocalVar if v.name == meth.results.head.id => vpr.Result(resultType)() }
+      val (pos, info, errT) = (x.pos, x.info, x.errT)
+      x.transform { case v: vpr.LocalVar if v.name == meth.results.head.id => vpr.Result(resultType)(pos, info, errT) }
     }
 
     for {
@@ -86,7 +87,8 @@ class DefaultPureMethodEncoding extends Encoding {
     val resultType = if (vResults.size == 1) vResults.head.typ else ctx.tuple.typ(vResults map (_.typ))
 
     val fixResultvar = (x: vpr.Exp) => {
-      x.transform { case v: vpr.LocalVar if v.name == func.results.head.id => vpr.Result(resultType)() }
+      val (pos, info, errT) = (x.pos, x.info, x.errT)
+      x.transform { case v: vpr.LocalVar if v.name == func.results.head.id => vpr.Result(resultType)(pos, info, errT) }
     }
 
     for {

--- a/src/test/resources/regressions/features/purefuncs/result-var.gobra
+++ b/src/test/resources/regressions/features/purefuncs/result-var.gobra
@@ -18,3 +18,10 @@ decreases
 pure func (i I) P2() (res bool) {
     return false
 }
+
+//:: ExpectedOutput(postcondition_error:assertion_error)
+ensures b
+decreases
+pure func P3(b bool) (res bool) {
+    return false
+}

--- a/src/test/resources/regressions/features/purefuncs/result-var.gobra
+++ b/src/test/resources/regressions/features/purefuncs/result-var.gobra
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package debug
+
+//:: ExpectedOutput(postcondition_error:assertion_error)
+ensures res
+decreases
+pure func P1() (res bool) {
+    return false
+}
+
+type I struct{}
+
+//:: ExpectedOutput(postcondition_error:assertion_error)
+ensures res
+decreases
+pure func (i I) P2() (res bool) {
+    return false
+}


### PR DESCRIPTION
Currently, verifying the following function leads to a verification error with an unhelpful error message:
```
ensures res
decreases
pure func P1() (res bool) {
    return false
}
```

Message:
```
Error at: <:0:0> Postcondition might not hold.
[info] Assertion unknown might not hold.
```

This PR fixes that. I am sure most users of Gobra have seen this at some point, but it was never clear how it was triggered. @AndreaKe's experiments with Gobra helped me to finally identify the root cause: occurrences of the output variable in postconditions of pure functions are translated to vpr.Result, but the position information is not attached to this new node.