### PR TITLE
Reject occurrences of output parameters in preconditions

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
@@ -227,6 +227,8 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
       case PLabeledOld(PLabelUse(PLabelNode.lhsLabel), _) => noMessages
       case n@ (_: POld | _: PLabeledOld) => message(n, s"old not permitted in precondition")
       case n@ (_: PBefore) => message(n, s"old not permitted in precondition")
+      case id: PIdnUse if entity(id).isInstanceOf[SymbolTable.OutParameter] =>
+        message(id, s"output parameter '${id.name}' cannot be referenced in a precondition")
       case _ => noMessages
     }
   }

--- a/src/test/resources/regressions/issues/001017.gobra
+++ b/src/test/resources/regressions/issues/001017.gobra
@@ -1,0 +1,40 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue001017
+
+// Referencing a named return value in a precondition must be a type error,
+// because output parameters have no meaningful value at function entry.
+
+//:: ExpectedOutput(type_error)
+requires len(r) == 1
+ensures acc(r)
+func returnInPre() (r []int) {
+	return []int{}
+}
+
+// preserves is equivalent to requires + ensures, so it must also be rejected.
+//:: ExpectedOutput(type_error)
+preserves len(r) == 1
+func preservesOut() (r []int) {
+	return []int{}
+}
+
+type T struct{}
+
+//:: ExpectedOutput(type_error)
+requires len(r) == 1
+func (t T) returnInPreMethod() (r []int) {
+	return []int{}
+}
+
+// Valid: the output parameter may be referenced in the postcondition.
+ensures len(r) == 0
+func okPost() (r []int) {
+	return []int{}
+}
+
+// Valid: a precondition may reference an input parameter of the same name.
+requires len(r) == 1
+func okInParam(r []int) {
+}

--- a/src/test/resources/regressions/issues/001017.gobra
+++ b/src/test/resources/regressions/issues/001017.gobra
@@ -35,3 +35,19 @@ func okPost() (r []int) {
 	return []int{}
 }
 
+// the check also applies to pure functions
+//:: ExpectedOutput(type_error)
+requires res
+decreases
+pure func pureReturnInPre() (res bool) {
+	return false
+}
+
+// and to pure methods
+//:: ExpectedOutput(type_error)
+requires res
+decreases
+pure func (t T) pureReturnInPreMethod() (res bool) {
+	return false
+}
+

--- a/src/test/resources/regressions/issues/001017.gobra
+++ b/src/test/resources/regressions/issues/001017.gobra
@@ -22,6 +22,7 @@ func preservesOut() (r []int) {
 
 type T struct{}
 
+// the check is performed on methods, as well as on functions
 //:: ExpectedOutput(type_error)
 requires len(r) == 1
 func (t T) returnInPreMethod() (r []int) {
@@ -34,7 +35,3 @@ func okPost() (r []int) {
 	return []int{}
 }
 
-// Valid: a precondition may reference an input parameter of the same name.
-requires len(r) == 1
-func okInParam(r []int) {
-}


### PR DESCRIPTION
Disable output parameters from being used in preconditions, regardless of whether they are declared with `requires` or `preserves`