### PR TITLE
Change existential elimination operator from `|=` to `:|`

### DIFF
--- a/src/main/antlr4/GoLexer.g4
+++ b/src/main/antlr4/GoLexer.g4
@@ -86,7 +86,7 @@ DOT                    : '.';
 PLUS_PLUS              : '++' -> mode(NLSEMI);
 MINUS_MINUS            : '--' -> mode(NLSEMI);
 DECLARE_ASSIGN         : ':=';
-PIPE_ASSIGN            : '|=';
+COLON_PIPE_ASSIGN      : ':|=';
 ELLIPSIS               : '...';
 
 // Logical

--- a/src/main/antlr4/GoLexer.g4
+++ b/src/main/antlr4/GoLexer.g4
@@ -86,7 +86,7 @@ DOT                    : '.';
 PLUS_PLUS              : '++' -> mode(NLSEMI);
 MINUS_MINUS            : '--' -> mode(NLSEMI);
 DECLARE_ASSIGN         : ':=';
-COLON_PIPE_ASSIGN      : ':|=';
+COLON_PIPE             : ':|';
 ELLIPSIS               : '...';
 
 // Logical

--- a/src/main/antlr4/GobraParser.g4
+++ b/src/main/antlr4/GobraParser.g4
@@ -67,7 +67,7 @@ ghostStatement:
   | ASSERT expression (BY CONTRA? block)? #assertStatement
   | matchStmt #matchStmt_
   | OPEN_DUP_SINV #pkgInvStatement
-  | VAR IDENTIFIER type_ COLON_PIPE_ASSIGN expression #assignSuchThatStatement
+  | VAR IDENTIFIER type_ COLON_PIPE expression #assignSuchThatStatement
   ;
 
 // Auxiliary statements

--- a/src/main/antlr4/GobraParser.g4
+++ b/src/main/antlr4/GobraParser.g4
@@ -67,7 +67,7 @@ ghostStatement:
   | ASSERT expression (BY CONTRA? block)? #assertStatement
   | matchStmt #matchStmt_
   | OPEN_DUP_SINV #pkgInvStatement
-  | VAR IDENTIFIER type_ PIPE_ASSIGN expression #assignSuchThatStatement
+  | VAR IDENTIFIER type_ COLON_PIPE_ASSIGN expression #assignSuchThatStatement
   ;
 
 // Auxiliary statements

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -319,7 +319,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
       case PApplyWand(wand) => "apply" <+> showExpr(wand)
       case POpenDupPkgInv() => "openDupPkgInv"
       case PAssignSuchThat(left, typ, cond) =>
-        "var" <+> showId(left) <+> showType(typ) <+> "|=" <+> showExpr(cond)
+        "var" <+> showId(left) <+> showType(typ) <+> ":|=" <+> showExpr(cond)
       case PMatchStatement(exp, clauses, _) => "match" <+>
         showExpr(exp) <+> block(ssep(clauses map showMatchClauseStatement, line))
     }

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -319,7 +319,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
       case PApplyWand(wand) => "apply" <+> showExpr(wand)
       case POpenDupPkgInv() => "openDupPkgInv"
       case PAssignSuchThat(left, typ, cond) =>
-        "var" <+> showId(left) <+> showType(typ) <+> ":|=" <+> showExpr(cond)
+        "var" <+> showId(left) <+> showType(typ) <+> ":|" <+> showExpr(cond)
       case PMatchStatement(exp, clauses, _) => "match" <+>
         showExpr(exp) <+> block(ssep(clauses map showMatchClauseStatement, line))
     }

--- a/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
@@ -350,7 +350,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
     case Inhale(ass) => "inhale" <+> showAss(ass)
     case Exhale(ass) => "exhale" <+> showAss(ass)
     case AssignSuchThat(v, cond) =>
-      "var" <+> showVarDecl(v) <+> "|=" <+> showExpr(cond)
+      "var" <+> showVarDecl(v) <+> ":|=" <+> showExpr(cond)
     case Fold(acc)   => "fold" <+> showAss(acc)
     case Unfold(acc) => "unfold" <+> showAss(acc)
     case PackageWand(wand, block) => "package" <+> showAss(wand) <+> opt(block)(showStmt)
@@ -812,7 +812,7 @@ class ShortPrettyPrinter extends DefaultPrettyPrinter {
     case Inhale(ass) => "inhale" <+> showAss(ass)
     case Exhale(ass) => "exhale" <+> showAss(ass)
     case AssignSuchThat(v, cond) =>
-      "var" <+> showVarDecl(v) <+> "|=" <+> showExpr(cond)
+      "var" <+> showVarDecl(v) <+> ":|=" <+> showExpr(cond)
     case Fold(acc)   => "fold" <+> showAss(acc)
     case Unfold(acc) => "unfold" <+> showAss(acc)
     case PackageWand(wand, _) => "package" <+> showAss(wand)

--- a/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
@@ -350,7 +350,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
     case Inhale(ass) => "inhale" <+> showAss(ass)
     case Exhale(ass) => "exhale" <+> showAss(ass)
     case AssignSuchThat(v, cond) =>
-      "var" <+> showVarDecl(v) <+> ":|=" <+> showExpr(cond)
+      "var" <+> showVarDecl(v) <+> ":|" <+> showExpr(cond)
     case Fold(acc)   => "fold" <+> showAss(acc)
     case Unfold(acc) => "unfold" <+> showAss(acc)
     case PackageWand(wand, block) => "package" <+> showAss(wand) <+> opt(block)(showStmt)
@@ -812,7 +812,7 @@ class ShortPrettyPrinter extends DefaultPrettyPrinter {
     case Inhale(ass) => "inhale" <+> showAss(ass)
     case Exhale(ass) => "exhale" <+> showAss(ass)
     case AssignSuchThat(v, cond) =>
-      "var" <+> showVarDecl(v) <+> ":|=" <+> showExpr(cond)
+      "var" <+> showVarDecl(v) <+> ":|" <+> showExpr(cond)
     case Fold(acc)   => "fold" <+> showAss(acc)
     case Unfold(acc) => "unfold" <+> showAss(acc)
     case PackageWand(wand, _) => "package" <+> showAss(wand)

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -2231,7 +2231,7 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
 
   /**
     * Visits the production
-    * VAR IDENTIFIER type_ PIPE_ASSIGN expression
+    * VAR IDENTIFIER type_ COLON_PIPE_ASSIGN expression
     */
   override def visitAssignSuchThatStatement(ctx: AssignSuchThatStatementContext): PAssignSuchThat = {
     val left = idnDef.get(ctx.IDENTIFIER())

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -2231,7 +2231,7 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
 
   /**
     * Visits the production
-    * VAR IDENTIFIER type_ COLON_PIPE_ASSIGN expression
+    * VAR IDENTIFIER type_ COLON_PIPE expression
     */
   override def visitAssignSuchThatStatement(ctx: AssignSuchThatStatementContext): PAssignSuchThat = {
     val left = idnDef.get(ctx.IDENTIFIER())

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
@@ -61,7 +61,7 @@ trait NameResolution {
               case _ => UnknownEntity()
             }
           case decl: PAssignSuchThat =>
-            // Variables declared by `var x T :|= P` are always ghost, non-addressable,
+            // Variables declared by `var x T :| P` are always ghost, non-addressable,
             // and their type is given explicitly by the annotation.
             SingleLocalVariable(None, Some(decl.typ), decl, ghost = true, addressable = false, this)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
@@ -61,7 +61,7 @@ trait NameResolution {
               case _ => UnknownEntity()
             }
           case decl: PAssignSuchThat =>
-            // Variables declared by `var x T |= P` are always ghost, non-addressable,
+            // Variables declared by `var x T :|= P` are always ghost, non-addressable,
             // and their type is given explicitly by the annotation.
             SingleLocalVariable(None, Some(decl.typ), decl, ghost = true, addressable = false, this)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
@@ -43,7 +43,7 @@ trait GhostStmtTyping extends BaseTyping { this: TypeInfoImpl =>
         case _ => comparableTypes.errors((miscType(c.pattern), exprType(exp)))(c)
       }) ++ isPureExpr(exp)
     case PAssignSuchThat(_, _, cond) =>
-      // `var x T |= P` requires that `P` is a pure, boolean expression.
+      // `var x T :|= P` requires that `P` is a pure, boolean expression.
       isExpr(cond).out ++
         comparableTypes.errors(exprType(cond), BooleanT)(cond) ++
         isPureExpr(cond)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
@@ -43,7 +43,7 @@ trait GhostStmtTyping extends BaseTyping { this: TypeInfoImpl =>
         case _ => comparableTypes.errors((miscType(c.pattern), exprType(exp)))(c)
       }) ++ isPureExpr(exp)
     case PAssignSuchThat(_, _, cond) =>
-      // `var x T :|= P` requires that `P` is a pure, boolean expression.
+      // `var x T :| P` requires that `P` is a pure, boolean expression.
       isExpr(cond).out ++
         comparableTypes.errors(exprType(cond), BooleanT)(cond) ++
         isPureExpr(cond)

--- a/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
@@ -108,13 +108,13 @@ class AssertionEncoding extends Encoding {
     case n@ in.Exhale(ass) => for {v <- ctx.assertion(ass)} yield withSrc(vpr.Exhale(v), n)
 
     case n@ in.AssignSuchThat(v, cond) =>
-      // `var x T |= P` is encoded as
+      // `var x T :|= P` is encoded as
       //   assert exists x' : T :: P[x -> x']
       //   inhale P
       // The local variable `x` is already registered as a block-level Viper decl by the
       // desugarer (via `declare`), so it is in scope after the statement.
       // The existential carries `cond`'s source info so error messages show
-      // just `P` rather than the whole `var x T |= P` statement.
+      // just `P` rather than the whole `var x T :|= P` statement.
       val (condPos, condInfo, condErrT) = cond.vprMeta
       val boundVar = in.BoundVar(v.id + "_B", v.typ.withAddressability(Addressability.boundVariable))(v.info)
       val renaming: Map[in.LocalVar, in.Node] = Map(v -> boundVar)

--- a/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
@@ -108,13 +108,13 @@ class AssertionEncoding extends Encoding {
     case n@ in.Exhale(ass) => for {v <- ctx.assertion(ass)} yield withSrc(vpr.Exhale(v), n)
 
     case n@ in.AssignSuchThat(v, cond) =>
-      // `var x T :|= P` is encoded as
+      // `var x T :| P` is encoded as
       //   assert exists x' : T :: P[x -> x']
       //   inhale P
       // The local variable `x` is already registered as a block-level Viper decl by the
       // desugarer (via `declare`), so it is in scope after the statement.
       // The existential carries `cond`'s source info so error messages show
-      // just `P` rather than the whole `var x T :|= P` statement.
+      // just `P` rather than the whole `var x T :| P` statement.
       val (condPos, condInfo, condErrT) = cond.vprMeta
       val boundVar = in.BoundVar(v.id + "_B", v.typ.withAddressability(Addressability.boundVariable))(v.info)
       val renaming: Map[in.LocalVar, in.Node] = Map(v -> boundVar)

--- a/src/test/resources/regressions/features/assign-such-that/after-use.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/after-use.gobra
@@ -7,7 +7,7 @@ package assignsuchthatafteruse
 // and can be referenced in further ghost statements and assertions.
 
 func f() {
-	var x int |= true
+	var x int :|= true
 	// `x` is in scope after the statement. We can inhabit it in further specs.
 	assert x == x
 	ghost var y int = x

--- a/src/test/resources/regressions/features/assign-such-that/after-use.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/after-use.gobra
@@ -7,7 +7,7 @@ package assignsuchthatafteruse
 // and can be referenced in further ghost statements and assertions.
 
 func f() {
-	var x int :|= true
+	var x int :| true
 	// `x` is in scope after the statement. We can inhabit it in further specs.
 	assert x == x
 	ghost var y int = x

--- a/src/test/resources/regressions/features/assign-such-that/assumes-cond.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/assumes-cond.gobra
@@ -3,12 +3,12 @@
 
 package assignsuchthatassumescond
 
-// After `var x T |= P`, Gobra assumes `P` holds for `x` so subsequent
+// After `var x T :|= P`, Gobra assumes `P` holds for `x` so subsequent
 // assertions that follow from `P` go through.
 
 requires len(s) > 0
 func f(ghost s set[int]) {
-	var e int |= e elem s
+	var e int :|= e elem s
 	// We assumed `e elem s`, so consequences follow.
 	assert e elem s
 	assert s != set[int]{}

--- a/src/test/resources/regressions/features/assign-such-that/assumes-cond.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/assumes-cond.gobra
@@ -3,12 +3,12 @@
 
 package assignsuchthatassumescond
 
-// After `var x T :|= P`, Gobra assumes `P` holds for `x` so subsequent
+// After `var x T :| P`, Gobra assumes `P` holds for `x` so subsequent
 // assertions that follow from `P` go through.
 
 requires len(s) > 0
 func f(ghost s set[int]) {
-	var e int :|= e elem s
+	var e int :| e elem s
 	// We assumed `e elem s`, so consequences follow.
 	assert e elem s
 	assert s != set[int]{}

--- a/src/test/resources/regressions/features/assign-such-that/ghost-only.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/ghost-only.gobra
@@ -3,12 +3,12 @@
 
 package assignsuchthatghostonly
 
-// The variables declared by `var x T |= P` are always ghost, so assigning them
+// The variables declared by `var x T :|= P` are always ghost, so assigning them
 // into an existing non-ghost variable must be rejected by ghost-separation.
 
 func f() {
 	var y int = 0
-	var x int |= x > 0
+	var x int :|= x > 0
 	//:: ExpectedOutput(type_error)
 	y = x
 }

--- a/src/test/resources/regressions/features/assign-such-that/ghost-only.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/ghost-only.gobra
@@ -3,12 +3,12 @@
 
 package assignsuchthatghostonly
 
-// The variables declared by `var x T :|= P` are always ghost, so assigning them
+// The variables declared by `var x T :| P` are always ghost, so assigning them
 // into an existing non-ghost variable must be rejected by ghost-separation.
 
 func f() {
 	var y int = 0
-	var x int :|= x > 0
+	var x int :| x > 0
 	//:: ExpectedOutput(type_error)
 	y = x
 }

--- a/src/test/resources/regressions/features/assign-such-that/impure-rhs.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/impure-rhs.gobra
@@ -14,5 +14,5 @@ func impure(p *int) bool {
 func f() {
 	p := new(int)
 	//:: ExpectedOutput(type_error)
-	var x int |= x > 0 && impure(p)
+	var x int :|= x > 0 && impure(p)
 }

--- a/src/test/resources/regressions/features/assign-such-that/impure-rhs.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/impure-rhs.gobra
@@ -14,5 +14,5 @@ func impure(p *int) bool {
 func f() {
 	p := new(int)
 	//:: ExpectedOutput(type_error)
-	var x int :|= x > 0 && impure(p)
+	var x int :| x > 0 && impure(p)
 }

--- a/src/test/resources/regressions/features/assign-such-that/impure-rhs2.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/impure-rhs2.gobra
@@ -8,5 +8,5 @@ package assignsuchthatimpurerhs2
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x *int |= acc(x)
+	var x *int :|= acc(x)
 }

--- a/src/test/resources/regressions/features/assign-such-that/impure-rhs2.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/impure-rhs2.gobra
@@ -8,5 +8,5 @@ package assignsuchthatimpurerhs2
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x *int :|= acc(x)
+	var x *int :| acc(x)
 }

--- a/src/test/resources/regressions/features/assign-such-that/multi-rejected.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/multi-rejected.gobra
@@ -3,10 +3,10 @@
 
 package assignsuchthatmultirejected
 
-// Only a single variable can be declared per `:|=` statement.
-// `var x, y int :|= ...` must be rejected.
+// Only a single variable can be declared per `:|` statement.
+// `var x, y int :| ...` must be rejected.
 
 func f() {
 	//:: ExpectedOutput(parser_error)
-	var x, y int :|= true
+	var x, y int :| true
 }

--- a/src/test/resources/regressions/features/assign-such-that/multi-rejected.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/multi-rejected.gobra
@@ -3,10 +3,10 @@
 
 package assignsuchthatmultirejected
 
-// Only a single variable can be declared per `|=` statement.
-// `var x, y int |= ...` must be rejected.
+// Only a single variable can be declared per `:|=` statement.
+// `var x, y int :|= ...` must be rejected.
 
 func f() {
 	//:: ExpectedOutput(parser_error)
-	var x, y int |= true
+	var x, y int :|= true
 }

--- a/src/test/resources/regressions/features/assign-such-that/non-bool.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/non-bool.gobra
@@ -5,5 +5,5 @@ package assignsuchthatnonbool
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x int :|= x + 1
+	var x int :| x + 1
 }

--- a/src/test/resources/regressions/features/assign-such-that/non-bool.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/non-bool.gobra
@@ -5,5 +5,5 @@ package assignsuchthatnonbool
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x int |= x + 1
+	var x int :|= x + 1
 }

--- a/src/test/resources/regressions/features/assign-such-that/not-pure.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/not-pure.gobra
@@ -6,5 +6,5 @@ package assignsuchthatnotpure
 func f() {
 	p := new(int)
 	//:: ExpectedOutput(type_error)
-	var x int :|= acc(p) && *p == x
+	var x int :| acc(p) && *p == x
 }

--- a/src/test/resources/regressions/features/assign-such-that/not-pure.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/not-pure.gobra
@@ -6,5 +6,5 @@ package assignsuchthatnotpure
 func f() {
 	p := new(int)
 	//:: ExpectedOutput(type_error)
-	var x int |= acc(p) && *p == x
+	var x int :|= acc(p) && *p == x
 }

--- a/src/test/resources/regressions/features/assign-such-that/predicate-in-rhs.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/predicate-in-rhs.gobra
@@ -10,5 +10,5 @@ pred P(x int)
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x int :|= P(x)
+	var x int :| P(x)
 }

--- a/src/test/resources/regressions/features/assign-such-that/predicate-in-rhs.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/predicate-in-rhs.gobra
@@ -10,5 +10,5 @@ pred P(x int)
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x int |= P(x)
+	var x int :|= P(x)
 }

--- a/src/test/resources/regressions/features/assign-such-that/redeclare.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/redeclare.gobra
@@ -9,5 +9,5 @@ package assignsuchthatredeclare
 func f() {
 	x := 5
 	//:: ExpectedOutput(type_error)
-	var x int |= x > 0
+	var x int :|= x > 0
 }

--- a/src/test/resources/regressions/features/assign-such-that/redeclare.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/redeclare.gobra
@@ -9,5 +9,5 @@ package assignsuchthatredeclare
 func f() {
 	x := 5
 	//:: ExpectedOutput(type_error)
-	var x int :|= x > 0
+	var x int :| x > 0
 }

--- a/src/test/resources/regressions/features/assign-such-that/rhs-string.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/rhs-string.gobra
@@ -7,5 +7,5 @@ package assignsuchthatrhsstring
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x int :|= "hello"
+	var x int :| "hello"
 }

--- a/src/test/resources/regressions/features/assign-such-that/rhs-string.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/rhs-string.gobra
@@ -7,5 +7,5 @@ package assignsuchthatrhsstring
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x int |= "hello"
+	var x int :|= "hello"
 }

--- a/src/test/resources/regressions/features/assign-such-that/set-elem.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/set-elem.gobra
@@ -7,6 +7,6 @@ package assignsuchthatsetelem
 
 requires len(s) > 0
 func f(ghost s set[int]) {
-	var e int |= e elem s
+	var e int :|= e elem s
 	assert e elem s
 }

--- a/src/test/resources/regressions/features/assign-such-that/set-elem.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/set-elem.gobra
@@ -7,6 +7,6 @@ package assignsuchthatsetelem
 
 requires len(s) > 0
 func f(ghost s set[int]) {
-	var e int :|= e elem s
+	var e int :| e elem s
 	assert e elem s
 }

--- a/src/test/resources/regressions/features/assign-such-that/undeclared-in-rhs.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/undeclared-in-rhs.gobra
@@ -8,5 +8,5 @@ package assignsuchthatundeclaredrhs
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x int :|= x > y
+	var x int :| x > y
 }

--- a/src/test/resources/regressions/features/assign-such-that/undeclared-in-rhs.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/undeclared-in-rhs.gobra
@@ -8,5 +8,5 @@ package assignsuchthatundeclaredrhs
 
 func f() {
 	//:: ExpectedOutput(type_error)
-	var x int |= x > y
+	var x int :|= x > y
 }

--- a/src/test/resources/regressions/features/assign-such-that/wildcard-perm.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/wildcard-perm.gobra
@@ -9,5 +9,5 @@ package assignsuchthatwildcardperm
 func f() {
 	p := new(int)
 	//:: ExpectedOutput(type_error)
-	var x int :|= acc(p, _) && *p == x
+	var x int :| acc(p, _) && *p == x
 }

--- a/src/test/resources/regressions/features/assign-such-that/wildcard-perm.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/wildcard-perm.gobra
@@ -9,5 +9,5 @@ package assignsuchthatwildcardperm
 func f() {
 	p := new(int)
 	//:: ExpectedOutput(type_error)
-	var x int |= acc(p, _) && *p == x
+	var x int :|= acc(p, _) && *p == x
 }

--- a/src/test/resources/regressions/features/assign-such-that/witness-fail.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/witness-fail.gobra
@@ -5,5 +5,5 @@ package assignsuchthatwitnessfail
 
 func f() {
 	//:: ExpectedOutput(assign_such_that_error:assign_such_that_no_witness_error)
-	var x int :|= x > 0 && x < 0
+	var x int :| x > 0 && x < 0
 }

--- a/src/test/resources/regressions/features/assign-such-that/witness-fail.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/witness-fail.gobra
@@ -5,5 +5,5 @@ package assignsuchthatwitnessfail
 
 func f() {
 	//:: ExpectedOutput(assign_such_that_error:assign_such_that_no_witness_error)
-	var x int |= x > 0 && x < 0
+	var x int :|= x > 0 && x < 0
 }

--- a/src/test/resources/regressions/features/assign-such-that/witness-nonzero.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/witness-nonzero.gobra
@@ -10,7 +10,7 @@ package assignsuchthatwitnessnonzero
 
 requires len(s) > 0 && !(0 elem s)
 func f(ghost s set[int]) {
-	var x int :|= x elem s
+	var x int :| x elem s
 	//:: ExpectedOutput(assert_error:assertion_error)
 	assert false
 }

--- a/src/test/resources/regressions/features/assign-such-that/witness-nonzero.gobra
+++ b/src/test/resources/regressions/features/assign-such-that/witness-nonzero.gobra
@@ -10,7 +10,7 @@ package assignsuchthatwitnessnonzero
 
 requires len(s) > 0 && !(0 elem s)
 func f(ghost s set[int]) {
-	var x int |= x elem s
+	var x int :|= x elem s
 	//:: ExpectedOutput(assert_error:assertion_error)
 	assert false
 }

--- a/src/test/resources/regressions/features/integers/bitwise-or-assign.gobra
+++ b/src/test/resources/regressions/features/integers/bitwise-or-assign.gobra
@@ -1,0 +1,13 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package integers
+
+// Checks that Go's bitwise OR-assign operator `|=` is accepted by Gobra.
+// The existential-elimination ghost statement uses `:|=`, so the bare `|=`
+// must continue to be parsed as the compound assignment from Go.
+
+func bitwiseOrAssign() {
+	x := 1
+	x |= 2
+}

--- a/src/test/resources/regressions/features/integers/bitwise-or-assign.gobra
+++ b/src/test/resources/regressions/features/integers/bitwise-or-assign.gobra
@@ -4,7 +4,7 @@
 package integers
 
 // Checks that Go's bitwise OR-assign operator `|=` is accepted by Gobra.
-// The existential-elimination ghost statement uses `:|=`, so the bare `|=`
+// The existential-elimination ghost statement uses `:|`, so the bare `|=`
 // must continue to be parsed as the compound assignment from Go.
 
 func bitwiseOrAssign() {


### PR DESCRIPTION
The recently introduced operator for existential elimination (`|=`) clashes with the `|=` operator for "bit-or + assign" (e.g., `x |= 2`). Programs that currently use the bitwise operator now run into parser errors. While this can always be disambiguated (or rather, we can change the parser to be able to always disambiguate this), I'd rather change the operator to avoid the clash in the first place. Thus, I propose `:|`, the same operator that is used in Dafny for a similar purpose.