### PR TITLE
Allow outer function outputs in outline preconditions (Fix issue #1029)

### DIFF
--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -2276,6 +2276,8 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
 
   override def visitOutlineStatement(ctx: OutlineStatementContext): PSeq = super.visitOutlineStatement(ctx) match {
     case Vector(_, _, stmts: Vector[PStatement@unchecked], _) => PSeq(stmts)
+    // an outline block with an empty body (`outline ( )`) has no statementList child
+    case Vector(_, _, _) => PSeq(Vector.empty)
   }
 
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
@@ -152,9 +152,20 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
 
   implicit lazy val wellDefSpec: WellDefinedness[PSpecification] = createWellDef {
     case n@ PFunctionSpec(pres, preserves, posts, terminationMeasures, _, isPure, _, isOpaque, _) =>
+      // Collect the named output parameters of the spec's owner so that we only
+      // reject references to those (and not to outputs of an enclosing function,
+      // method, or closure - which is relevant for outline statements and nested
+      // closure literals).
+      val ownOutParams: Vector[PNamedParameter] = tree.parent(n).head match {
+        case p: PCodeRootWithResult => p.result.outs.collect {
+          case np: PNamedParameter => np
+          case PExplicitGhostParameter(np: PNamedParameter) => np
+        }
+        case _ => Vector.empty
+      }
       pres.flatMap(assignableToSpec) ++ preserves.flatMap(assignableToSpec) ++ posts.flatMap(assignableToSpec) ++
-      preserves.flatMap(e => allChildren(e).flatMap(illegalPreconditionNode)) ++
-      pres.flatMap(e => allChildren(e).flatMap(illegalPreconditionNode)) ++
+      preserves.flatMap(e => allChildren(e).flatMap(illegalPreconditionNode(_, ownOutParams))) ++
+      pres.flatMap(e => allChildren(e).flatMap(illegalPreconditionNode(_, ownOutParams))) ++
       terminationMeasures.flatMap(wellDefTerminationMeasure) ++
       // if has conditional clause, all clauses must be conditional
       // can only have one non-conditional clause
@@ -229,13 +240,16 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
     isExpr(e).out ++ assignableTo.errors(exprType(e), AssertionT, mayInit)(e) ++ isWeaklyPureExpr(e)
   }
 
-  private def illegalPreconditionNode(n: PNode): Messages = {
+  private def illegalPreconditionNode(n: PNode, ownOutParams: Vector[PNamedParameter]): Messages = {
     n match {
       case PLabeledOld(PLabelUse(PLabelNode.lhsLabel), _) => noMessages
       case n@ (_: POld | _: PLabeledOld) => message(n, s"old not permitted in precondition")
       case n@ (_: PBefore) => message(n, s"old not permitted in precondition")
-      case id: PIdnUse if entity(id).isInstanceOf[SymbolTable.OutParameter] =>
-        message(id, s"output parameter '${id.name}' cannot be referenced in a precondition")
+      case id: PIdnUse => entity(id) match {
+        case op: SymbolTable.OutParameter if ownOutParams.exists(_ eq op.decl) =>
+          message(id, s"output parameter '${id.name}' cannot be referenced in a precondition")
+        case _ => noMessages
+      }
       case _ => noMessages
     }
   }

--- a/src/test/resources/regressions/issues/001029-1.gobra
+++ b/src/test/resources/regressions/issues/001029-1.gobra
@@ -1,7 +1,7 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-package issue001029
+package issue001029_1
 
 // The check still rejects references to a closure's own output parameter in
 // the closure's own precondition. This lives in its own file because the

--- a/src/test/resources/regressions/issues/001029-1.gobra
+++ b/src/test/resources/regressions/issues/001029-1.gobra
@@ -1,0 +1,18 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue001029
+
+// The check still rejects references to a closure's own output parameter in
+// the closure's own precondition. This lives in its own file because the
+// type error aborts verification of the whole package, which would prevent
+// the positive examples in 001029.gobra from being verified.
+func bad() {
+	//:: ExpectedOutput(type_error)
+	c := requires s == 0
+	     ensures  s == 1
+	     func nested() (s int) {
+		return 1
+	}
+	return
+}

--- a/src/test/resources/regressions/issues/001029-1.gobra
+++ b/src/test/resources/regressions/issues/001029-1.gobra
@@ -10,7 +10,6 @@ package issue001029
 func bad() {
 	//:: ExpectedOutput(type_error)
 	c := requires s == 0
-	     ensures  s == 1
 	     func nested() (s int) {
 		return 1
 	}

--- a/src/test/resources/regressions/issues/001029.gobra
+++ b/src/test/resources/regressions/issues/001029.gobra
@@ -4,8 +4,7 @@
 package issue001029
 
 // Output parameters of the surrounding function may be referenced in the
-// precondition of an outline statement, because they have a meaningful value
-// at the entry of the outline block. (Issue #1029)
+// precondition of an outline statement and closures.
 
 ensures acc(r) && *r == 42
 func foo() (r *int) {
@@ -17,6 +16,7 @@ func foo() (r *int) {
 	outline (
 		*r = 42
 	)
+	return
 }
 
 // The outer function's output is also accepted in `preserves` clauses of an
@@ -30,6 +30,22 @@ func foo2() (r *int) {
 	outline (
 		// nothing
 	)
+	return
+}
+
+// A closure literal declared inside a function may reference the outer
+// function's named output parameter in its precondition.
+ensures acc(r) && *r == 42
+func foo3() (r *int) {
+	i@ := 42
+	r = &i
+
+	c := requires acc(r) && *r == 42
+	     func nested() {
+		// nothing
+	}
+	_ = c
+	return
 }
 
 // The check still rejects references to a closure's own output parameter in
@@ -42,19 +58,5 @@ func bad() {
 		return 1
 	}
 	_ = c
-}
-
-// An outline block in a function without named output parameters keeps
-// type-checking.
-func unnamedOut() *int {
-	i@ := 0
-	p := &i
-
-	requires acc(p)
-	ensures  acc(p) && *p == 42
-	outline (
-		*p = 42
-	)
-
-	return p
+	return
 }

--- a/src/test/resources/regressions/issues/001029.gobra
+++ b/src/test/resources/regressions/issues/001029.gobra
@@ -44,7 +44,6 @@ func foo3() (r *int) {
 	     func nested() {
 		// nothing
 	}
-	_ = c
 	return
 }
 
@@ -57,6 +56,5 @@ func bad() {
 	     func nested() (s int) {
 		return 1
 	}
-	_ = c
 	return
 }

--- a/src/test/resources/regressions/issues/001029.gobra
+++ b/src/test/resources/regressions/issues/001029.gobra
@@ -1,0 +1,60 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue001029
+
+// Output parameters of the surrounding function may be referenced in the
+// precondition of an outline statement, because they have a meaningful value
+// at the entry of the outline block. (Issue #1029)
+
+ensures acc(r) && *r == 42
+func foo() (r *int) {
+	i@ := 0
+	r = &i
+
+	requires acc(r)
+	ensures  acc(r) && *r == 42
+	outline (
+		*r = 42
+	)
+}
+
+// The outer function's output is also accepted in `preserves` clauses of an
+// outline statement.
+ensures acc(r) && *r == 42
+func foo2() (r *int) {
+	i@ := 42
+	r = &i
+
+	preserves acc(r) && *r == 42
+	outline (
+		// nothing
+	)
+}
+
+// The check still rejects references to a closure's own output parameter in
+// the closure's own precondition.
+func bad() {
+	//:: ExpectedOutput(type_error)
+	c := requires s == 0
+	     ensures  s == 1
+	     func nested() (s int) {
+		return 1
+	}
+	_ = c
+}
+
+// An outline block in a function without named output parameters keeps
+// type-checking.
+func unnamedOut() *int {
+	i@ := 0
+	p := &i
+
+	requires acc(p)
+	ensures  acc(p) && *p == 42
+	outline (
+		*p = 42
+	)
+
+	return p
+}

--- a/src/test/resources/regressions/issues/001029.gobra
+++ b/src/test/resources/regressions/issues/001029.gobra
@@ -4,8 +4,7 @@
 package issue001029
 
 // Output parameters of the surrounding function may be referenced in the
-// precondition of an outline statement and closures.
-
+// precondition of an outline statement.
 ensures acc(r) && *r == 42
 func foo() (r *int) {
 	i@ := 0

--- a/src/test/resources/regressions/issues/001029.gobra
+++ b/src/test/resources/regressions/issues/001029.gobra
@@ -28,33 +28,22 @@ func foo2() (r *int) {
 
 	preserves acc(r) && *r == 42
 	outline (
-		assert true
+		// nothing
 	)
 	return
 }
 
 // A closure literal declared inside a function may reference the outer
 // function's named output parameter in its precondition.
+ensures acc(r, 1/2) && *r == 42
 func foo3() (r *int) {
-	share r
+	share r // needed such that the closure can capture `r`
 	i@ := 42
 	r = &i
 
-	c := requires acc(r) && *r == 42
+	c := requires acc(&r) && acc(r, 1/2) && *r == 42
 	     func nested() {
 		// nothing
-	}
-	return
-}
-
-// The check still rejects references to a closure's own output parameter in
-// the closure's own precondition.
-func bad() {
-	//:: ExpectedOutput(type_error)
-	c := requires s == 0
-	     ensures  s == 1
-	     func nested() (s int) {
-		return 1
 	}
 	return
 }

--- a/src/test/resources/regressions/issues/001029.gobra
+++ b/src/test/resources/regressions/issues/001029.gobra
@@ -28,15 +28,15 @@ func foo2() (r *int) {
 
 	preserves acc(r) && *r == 42
 	outline (
-		// nothing
+		assert true
 	)
 	return
 }
 
 // A closure literal declared inside a function may reference the outer
 // function's named output parameter in its precondition.
-ensures acc(r) && *r == 42
 func foo3() (r *int) {
+	share r
 	i@ := 42
 	r = &i
 


### PR DESCRIPTION
PR #1018 introduced a regression where occurrences of a return parameter are no longer allowed in pres of outline blocks and closures declared inside the body. This fixes that and introduces new tests