### PR TITLE
Lift `asserting` expressions from Viper

### DIFF
--- a/src/main/antlr4/GobraLexer.g4
+++ b/src/main/antlr4/GobraLexer.g4
@@ -44,6 +44,7 @@ ACCESS      : 'acc' -> mode(NLSEMI);
 FOLD        : 'fold';
 UNFOLD      : 'unfold';
 UNFOLDING   : 'unfolding';
+ASSERTING   : 'asserting';
 LET         : 'let';
 IN          : 'in';
 GHOST       : 'ghost';

--- a/src/main/antlr4/GobraParser.g4
+++ b/src/main/antlr4/GobraParser.g4
@@ -343,6 +343,7 @@ expression:
   |<assoc=right> expression IMPLIES expression #implication
   |<assoc=right> expression QMARK expression COLON expression #ternaryExpr
   | UNFOLDING predicateAccess IN expression #unfolding
+  | ASSERTING assertion IN expression #asserting
   | LET shortVarDecl IN expression #let
   | (FORALL | EXISTS) boundVariables COLON COLON triggers expression #quantification
   ;

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -584,6 +584,10 @@ case class PUnfolding(pred: PPredicateAccess, op: PExpression) extends PActualEx
   override def nonGhostChildren: Vector[PNode] = Vector(op)
 }
 
+case class PAsserting(ass: PExpression, op: PExpression) extends PActualExpression with PProofAnnotation {
+  override def nonGhostChildren: Vector[PNode] = Vector(op)
+}
+
 case class PLet(ass: PShortVarDecl, op: PExpression) extends PGhostExpression with PProofAnnotation with PScope {
   override def nonGhostChildren: Vector[PNode] = Vector(op)
 }

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -518,6 +518,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
       case PMod(left, right) => showSubExpr(expr, left) <+> "%" <+> showSubExpr(expr, right)
       case PDiv(left, right) => showSubExpr(expr, left) <+> "/" <+> showSubExpr(expr, right)
       case PUnfolding(acc, op) => "unfolding" <+> showExpr(acc) <+> "in" <+> showExpr(op)
+      case PAsserting(ass, op) => "asserting" <+> showExpr(ass) <+> "in" <+> showExpr(op)
       case PLength(expr) => "len" <> parens(showExpr(expr))
       case PCapacity(expr) => "cap" <> parens(showExpr(expr))
       case PMake(typ, args) => "make" <> parens(showList[PExpressionOrType](typ +: args){

--- a/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/internal/PrettyPrinter.scala
@@ -481,6 +481,8 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
   def showExpr(e: Expr): Doc = updatePositionStore(e) <> (e match {
     case Unfolding(acc, exp) => "unfolding" <+> showAss(acc) <+> "in" <+> showExpr(exp)
 
+    case Asserting(ass, exp) => "asserting" <+> showAss(ass) <+> "in" <+> showExpr(exp)
+
     case PureLet(left, right, exp) =>
       "let" <+> showVar(left) <+> "==" <+> parens(showExpr(right)) <+> "in" <+> showExpr(exp)
 

--- a/src/main/scala/viper/gobra/ast/internal/Program.scala
+++ b/src/main/scala/viper/gobra/ast/internal/Program.scala
@@ -586,6 +586,11 @@ case class Unfolding(acc: Access, in: Expr)(val info: Source.Parser.Info) extend
   require(typ.addressability == Addressability.unfolding(in.typ.addressability))
 }
 
+case class Asserting(assertion: Assertion, in: Expr)(val info: Source.Parser.Info) extends Expr {
+  override def typ: Type = in.typ
+  require(typ.addressability == Addressability.asserting(in.typ.addressability))
+}
+
 case class PureLet(left: LocalVar, right: Expr, in: Expr)(val info: Source.Parser.Info) extends Expr {
   override def typ: Type = in.typ
 }

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -2734,6 +2734,11 @@ object Desugar extends LazyLogging {
             val dOp = pureExprD(ctx, info)(op)
             unit(in.Unfolding(dAcc, dOp)(src))
 
+          case PAsserting(ass, op) =>
+            val dAss = specificationD(ctx, info)(ass)
+            val dOp = pureExprD(ctx, info)(op)
+            unit(in.Asserting(dAss, dOp)(src))
+
           case n : PIndexedExp => indexedExprD(n)(ctx, info)
 
           case PSliceExp(base, low, high, cap) => for {

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -1734,6 +1734,17 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
     PUnfolding(pred, op).at(ctx)
   }
 
+  /**
+    *
+    * @param ctx the parse tree
+    * @return the positioned PAsserting
+    */
+  override def visitAsserting(ctx: AssertingContext): PAsserting = {
+    val ass = visitNode[PExpression](ctx.assertion())
+    val op = visitNode[PExpression](ctx.expression())
+    PAsserting(ass, op).at(ctx)
+  }
+
   override def visitLet(ctx: LetContext): PLet = {
     val ass = visitNode[PShortVarDecl](ctx.shortVarDecl())
     val op = visitNode[PExpression](ctx.expression())

--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/Addressability.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/Addressability.scala
@@ -99,6 +99,7 @@ trait Addressability extends BaseProperty { this: TypeInfoImpl =>
       case _: PPermission => AddrMod.rValue
       case _: PPredConstructor => AddrMod.rValue
       case n: PUnfolding => AddrMod.unfolding(addressability(n.op))
+      case n: PAsserting => AddrMod.asserting(addressability(n.op))
       case n: PLet => AddrMod.let(addressability(n.op))
       case _: POld | _: PLabeledOld | _: PBefore => AddrMod.old
       case _: PConditional | _: PImplication | _: PForall | _: PExists => AddrMod.rValue

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
@@ -195,6 +195,7 @@ trait Enclosing { this: TypeInfoImpl =>
           case PUnequals(l, `n`) => val t = exprOrTypeType(l); if (t == Type.NilType) None else Some(t)
             // no and, or, less, at most, greater, at least, add, sub, mul, mod, div
           case p: PUnfolding => aux(p)
+          case p: PAsserting => aux(p)
             // no array type
             // no range
             // no function spec, no invariants, no predicate body

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -584,6 +584,8 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
         s"unfolding predicate expression instance ${n.pred} not supported",
         resolve(n.pred.pred).exists(_.isInstanceOf[ap.PredExprInstance]))
 
+    case n: PAsserting => assignableToSpec(n.ass) ++ isExpr(n.op).out ++ isPureExpr(n.op)
+
     case PLength(op) => isExpr(op).out ++ {
       underlyingType(exprType(op)) match {
         case _: ArrayT | _: SliceT | _: GhostSliceT | StringT | _: VariadicT | _: MapT | _: MathMapT => noMessages
@@ -827,6 +829,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
       if (typ == UNTYPED_INT_CONST) getNonInterfaceTypeFromCtxt(exprNum).getOrElse(typ) else typ
 
     case n: PUnfolding => exprType(n.op)
+    case n: PAsserting => exprType(n.op)
 
     case n: PExpressionAndType => exprAndTypeType(n)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
@@ -355,7 +355,7 @@ trait StmtTyping extends BaseTyping { this: TypeInfoImpl =>
       case invoke: PInvoke => failedProp(s"The call must be $expectedCall", !isExpectedCall(invoke))
       case f: PUnfolding => validExpression(f.op)
       case f: PAsserting => validExpression(f.op)
-      case _ => failedProp(s"only unfolding/asserting expressions and the call $expectedCall is allowed")
+      case _ => failedProp(s"only unfolding/asserting expressions and the call $expectedCall are allowed")
     }
 
     validExpression(retExpr)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/StmtTyping.scala
@@ -354,7 +354,8 @@ trait StmtTyping extends BaseTyping { this: TypeInfoImpl =>
     def validExpression(expr: PExpression): PropertyResult = expr match {
       case invoke: PInvoke => failedProp(s"The call must be $expectedCall", !isExpectedCall(invoke))
       case f: PUnfolding => validExpression(f.op)
-      case _ => failedProp(s"only unfolding expressions and the call $expectedCall is allowed")
+      case f: PAsserting => validExpression(f.op)
+      case _ => failedProp(s"only unfolding/asserting expressions and the call $expectedCall is allowed")
     }
 
     validExpression(retExpr)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -465,6 +465,7 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
       })
 
       case _: PUnfolding => true
+      case _: PAsserting => true // the well-definedness check makes sure that the body sub-expression is pure.
       case _: PLet => true // the well-definedness check makes sure that both sub-expressions are pure.
       case _: POld | _: PLabeledOld | _: PBefore => true
       case f: PForall => go(f.body)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
@@ -177,6 +177,7 @@ class GhostLessPrinter(classifier: GhostClassifier) extends DefaultPrettyPrinter
 
     case e: PProofAnnotation => e match {
       case PUnfolding(_, op) => showExpr(op)
+      case PAsserting(_, op) => showExpr(op)
     }
     case e if classifier.isExprGhost(e) => ghostToken
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostWellDef.scala
@@ -117,6 +117,7 @@ trait GhostWellDef { this: TypeInfoImpl =>
        | _: PBitNegation
        | _: PBinaryExp[_,_]
        | _: PUnfolding
+       | _: PAsserting
        | _: PLength
        | _: PCapacity
        | _: PLiteral

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GoifyingPrinter.scala
@@ -30,7 +30,7 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
   val decorators = new Decorators(info.tree)
   lazy val isInGoifiedScope: PNode => Boolean =
     decorators.down(false){
-      case _: PFPredicateDecl | _: PMPredicateDecl | _: PFunctionSpec | _: PGhostStatement | _: PUnfolding  => true
+      case _: PFPredicateDecl | _: PMPredicateDecl | _: PFunctionSpec | _: PGhostStatement | _: PUnfolding | _: PAsserting  => true
       case m: PMember => classifier.isMemberGhost(m)
       case s: PStatement => classifier.isStmtGhost(s)
     }
@@ -50,6 +50,7 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
   private val addressable_variables: String = "addressable:"
   private val with_keyword: String = "with:"
   private val unfolding_keyword: String = "unfolding:"
+  private val asserting_keyword: String = "asserting:"
 
   private val specComment: Doc = "//@"
   private def blockSpecComment(doc: Doc): Doc = "/*@" <> line <> doc <> line <> "@*/"
@@ -256,6 +257,8 @@ class GoifyingPrinter(info: TypeInfoImpl) extends DefaultPrettyPrinter {
     case e: PProofAnnotation => e match {
       case e: PUnfolding =>
         parens(inlinedSpecComment(unfolding_keyword <+> super.showExpr(e.pred)) <+> showExpr(e.op))
+      case e: PAsserting =>
+        parens(inlinedSpecComment(asserting_keyword <+> super.showExpr(e.ass)) <+> showExpr(e.op))
     }
 
     case e => super.showExpr(e)

--- a/src/main/scala/viper/gobra/theory/Addressability.scala
+++ b/src/main/scala/viper/gobra/theory/Addressability.scala
@@ -119,6 +119,7 @@ object Addressability {
   val mathDataStructureLookup: Addressability = mathDataStructureElement
 
   def unfolding(bodyAddressability: Addressability): Addressability = bodyAddressability
+  def asserting(bodyAddressability: Addressability): Addressability = bodyAddressability
   def let(bodyAddressability: Addressability): Addressability = bodyAddressability
   val old: Addressability = rValue
   val make: Addressability = Exclusive

--- a/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
@@ -70,6 +70,11 @@ class AssertionEncoding extends Encoding {
     case as: in.Asserting =>
       for {
         a <- ctx.assertion(as.assertion)
+        // `pure` folds any auxiliary (pure) code emitted while encoding the body
+        // into the body expression itself, keeping it inside the `vpr.Asserting`
+        // node so that `e2` is sequenced *after* `e1`. In practice, this is
+        // a defensive strategy (mirroring `unfolding`'s encoding) that is
+        // not strictly necessary at the moment.
         e <- pure(ctx.expression(as.in))(ctx)
       } yield withSrc(vpr.Asserting(a, e), as)
 

--- a/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
@@ -67,6 +67,12 @@ class AssertionEncoding extends Encoding {
         r <- ctx.expression(let.right)
       } yield withSrc(vpr.Let(l, r, exp), let)
 
+    case as: in.Asserting =>
+      for {
+        a <- ctx.assertion(as.assertion)
+        e <- pure(ctx.expression(as.in))(ctx)
+      } yield withSrc(vpr.Asserting(a, e), as)
+
     case n@ in.Low(e) => for {arg <- ctx.expression(e) } yield withSrc(SIFLowExp(arg), n)
     case n: in.LowContext => unit(withSrc(SIFLowEventExp(), n))
     case n@ in.Rel(e, i) => for {

--- a/src/test/resources/regressions/features/asserting/asserting-fail.gobra
+++ b/src/test/resources/regressions/features/asserting/asserting-fail.gobra
@@ -1,0 +1,11 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// The assertion `e1` of an `asserting` expression must hold; here it does not.
+func assertionFails() {
+	ghost x := 5
+	//:: ExpectedOutput(assert_error:assertion_error)
+	assert asserting x == 6 in x > 0
+}

--- a/src/test/resources/regressions/features/asserting/asserting-purity.gobra
+++ b/src/test/resources/regressions/features/asserting/asserting-purity.gobra
@@ -1,0 +1,21 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+func impure(x *int) int {
+	*x += 1
+	return *x
+}
+
+// Calling an impure function in the body `e2` is not allowed.
+pure func bodyNotPure(x *int) int {
+	//:: ExpectedOutput(type_error)
+	return asserting *x == *x in impure(x)
+}
+
+// Calling an impure function in the assertion `e1` is not allowed.
+pure func assertionNotPure(x *int) bool {
+	//:: ExpectedOutput(type_error)
+	return asserting impure(x) == 0 in true
+}

--- a/src/test/resources/regressions/features/asserting/asserting-simple.gobra
+++ b/src/test/resources/regressions/features/asserting/asserting-simple.gobra
@@ -1,0 +1,28 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// `asserting e1 in e2` evaluates to `e2` and additionally asserts that the
+// assertion `e1` holds in the current state.
+
+ghost
+decreases
+ensures res == x
+pure func identity(x int) (res int) {
+	return asserting x == x in x
+}
+
+func simple() {
+	ghost x := 5
+	// the asserting expression evaluates to its body `x > 0`
+	assert asserting x == 5 in x > 0
+}
+
+ghost
+decreases
+requires 0 <= x && x < 10
+ensures res == x
+pure func nested(x int) (res int) {
+	return asserting 0 <= x in (asserting x < 10 in x)
+}

--- a/src/test/resources/regressions/features/asserting/asserting-with-acc.gobra
+++ b/src/test/resources/regressions/features/asserting/asserting-with-acc.gobra
@@ -1,0 +1,24 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// The assertion `e1` may mention permissions; `asserting` is non-consuming, so
+// the permissions are still available after evaluating the expression.
+
+pred mem(x *int) {
+	acc(x)
+}
+
+requires mem(x)
+decreases
+pure func readUnfolding(x *int) int {
+	return unfolding mem(x) in *x
+}
+
+requires mem(x)
+ensures mem(x)
+func useAcc(x *int) {
+	// asserting that we hold `mem(x)`, then read through it via a pure function
+	ghost v := asserting mem(x) in readUnfolding(x)
+}

--- a/src/test/resources/regressions/features/asserting/asserting-with-acc.gobra
+++ b/src/test/resources/regressions/features/asserting/asserting-with-acc.gobra
@@ -24,7 +24,9 @@ func useAcc(x *int) {
 }
 
 func assertingPermissions(x *int) bool {
-    // asserting that we hold `mem(x)` even though we don't hold it
-    //:: ExpectedOutput(assert_error:assertion_error)
+    // asserting that we hold `mem(x)` even though we don't hold it.
+    // Silicon reports this as an assignment error, which is unexpected and
+    // requires changes in Viper to fix.
+    //:: ExpectedOutput(assignment_error:permission_error)
     return asserting mem(x) in true
 }

--- a/src/test/resources/regressions/features/asserting/asserting-with-acc.gobra
+++ b/src/test/resources/regressions/features/asserting/asserting-with-acc.gobra
@@ -22,3 +22,9 @@ func useAcc(x *int) {
 	// asserting that we hold `mem(x)`, then read through it via a pure function
 	ghost v := asserting mem(x) in readUnfolding(x)
 }
+
+func assertingPermissions(x *int) bool {
+    // asserting that we hold `mem(x)` even though we don't hold it
+    //:: ExpectedOutput(assert_error:assertion_error)
+    return asserting mem(x) in true
+}


### PR DESCRIPTION
This PR introduces `asserting a in e` expressions, where `a` is an assertion and `e` is a pure expression.