### PR TITLE
Add position information to nodes related to closures that don't have it

### DIFF
--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -1234,7 +1234,7 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
   override def visitFunctionLit(ctx: FunctionLitContext): PFunctionLit = {
     visitChildren(ctx) match {
       case Vector(spec: PFunctionSpec, (id: Option[PIdnDef@unchecked], args: Vector[PParameter@unchecked], result: PResult, body: Option[(PBodyParameterInfo, PBlock)@unchecked])) =>
-        PFunctionLit(id, PClosureDecl(args, result, spec, body).at(spec))
+        PFunctionLit(id, PClosureDecl(args, result, spec, body).at(spec)).at(ctx)
     }
   }
 
@@ -1242,17 +1242,27 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
     val id = if(ctx.IDENTIFIER() == null) None else Some(goIdnDef.get(ctx.IDENTIFIER()))
     val sig = visitNode[Signature](ctx.signature())
     // Translate the function body if the function is not abstract or trusted, specOnly isn't set or the function is pure
-    val body = if (has(ctx.blockWithBodyParameterInfo()) && !ctx.trusted && (!specOnly || ctx.pure)) Some(visitNode[(PBodyParameterInfo, PBlock)](ctx.blockWithBodyParameterInfo())) else None
+    val body =
+      if (has(ctx.blockWithBodyParameterInfo()) && !ctx.trusted && (!specOnly || ctx.pure))
+        Some(visitNode[(PBodyParameterInfo, PBlock)](ctx.blockWithBodyParameterInfo()))
+      else
+        None
     (id, sig._1, sig._2, body)
   }
 
   override def visitClosureSpecInstance(ctx: ClosureSpecInstanceContext): PClosureSpecInstance = visitChildren(ctx) match {
-    case name: TerminalNode => PClosureSpecInstance(PNamedOperand(idnUse.get(name)).at(name), Vector.empty)
-    case imported: PDot => PClosureSpecInstance(imported, Vector.empty)
-    case Vector(name: TerminalNode, "{", "}") => PClosureSpecInstance(PNamedOperand(idnUse.get(name)).at(name), Vector.empty)
-    case Vector(imported: PDot, "{", "}") => PClosureSpecInstance(imported, Vector.empty)
-    case Vector(name: TerminalNode, "{", params: Vector[PKeyedElement@unchecked], "}") => PClosureSpecInstance(PNamedOperand(idnUse.get(name)).at(name), params)
-    case Vector(imported: PDot, "{", params: Vector[PKeyedElement@unchecked], "}") => PClosureSpecInstance(imported, params)
+    case name: TerminalNode =>
+      PClosureSpecInstance(PNamedOperand(idnUse.get(name)).at(name), Vector.empty).at(ctx)
+    case imported: PDot =>
+      PClosureSpecInstance(imported, Vector.empty).at(ctx)
+    case Vector(name: TerminalNode, "{", "}") =>
+      PClosureSpecInstance(PNamedOperand(idnUse.get(name)).at(name), Vector.empty).at(ctx)
+    case Vector(imported: PDot, "{", "}") =>
+      PClosureSpecInstance(imported, Vector.empty).at(ctx)
+    case Vector(name: TerminalNode, "{", params: Vector[PKeyedElement@unchecked], "}") =>
+      PClosureSpecInstance(PNamedOperand(idnUse.get(name)).at(name), params).at(ctx)
+    case Vector(imported: PDot, "{", params: Vector[PKeyedElement@unchecked], "}") =>
+      PClosureSpecInstance(imported, params).at(ctx)
   }
 
   override def visitClosureSpecParams(ctx: ClosureSpecParamsContext): Vector[PKeyedElement] = visitChildren(ctx) match {
@@ -1261,21 +1271,21 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
   }
 
   override def visitClosureSpecParam(ctx: ClosureSpecParamContext): PKeyedElement = visitChildren(ctx) match {
-    case e: PExpression => PKeyedElement(None, PExpCompositeVal(e).at(e))
+    case e: PExpression => PKeyedElement(None, PExpCompositeVal(e).at(e)).at(ctx)
     case Vector(name: TerminalNode, ":", e: PExpression) =>
-      PKeyedElement(Some(PIdentifierKey(idnUse.get(name)).at(name)), PExpCompositeVal(e).at(e))
+      PKeyedElement(Some(PIdentifierKey(idnUse.get(name)).at(name)), PExpCompositeVal(e).at(e)).at(ctx)
   }
 
   override def visitClosureImplSpecExpr(ctx: ClosureImplSpecExprContext): PClosureImplements = {
     visitChildren(ctx) match {
       case Vector(closure: PExpression, "implements", spec: PClosureSpecInstance) =>
-        PClosureImplements(closure, spec)
+        PClosureImplements(closure, spec).at(ctx)
     }
   }
 
   override def visitClosureImplProofStmt(ctx: ClosureImplProofStmtContext): PClosureImplProof = visitChildren(ctx) match {
     case Vector("proof", closure: PExpression, "implements", spec:PClosureSpecInstance, body: PBlock) =>
-      PClosureImplProof(PClosureImplements(closure, spec), body)
+      PClosureImplProof(PClosureImplements(closure, spec).at(ctx), body).at(ctx)
   }
 
   //region Primary Expressions

--- a/src/main/scala/viper/gobra/translator/encodings/closures/ClosureEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/closures/ClosureEncoding.scala
@@ -141,12 +141,13 @@ class ClosureEncoding(config: Config) extends LeafTypeEncoding {
     val (exhalePos, _, _) = proof.vprMeta
     val inhalePres = cl.seqns(proof.pres map (a => for {
           ass <- ctx.assertion(a)
-        } yield vpr.Inhale(ass)()))
+          (info, post, errT) = a.vprMeta
+        } yield vpr.Inhale(ass)(info, post, errT)))
     val exhalePosts = for {
-      assertions <- proof.posts.foldLeft(cl.unit(vpr.TrueLit() ().asInstanceOf[vpr.Exp])) ((acc, a) => for {
+      assertions <- proof.posts.foldLeft(cl.unit(vpr.TrueLit()().asInstanceOf[vpr.Exp])) ((acc, a) => for {
         rest <- acc
         ass <- ctx.assertion (a)
-      } yield vpr.And(rest, ass) ())
+      } yield vpr.And(rest, ass)())
     } yield vpr.Exhale(assertions)(exhalePos)
 
     def failedExhale: ErrorTransformer = {
@@ -190,12 +191,12 @@ class ClosureEncoding(config: Config) extends LeafTypeEncoding {
           invNumIterationsIsLow <- ctx.expression(lowExprOrTrue(in.Low(numIterations)(src)))
           terminationMeasure <- ctx.assertion(in.NonItfTupleTerminationMeasure(Vector(numIterations), None)(src))
         } yield vpr.While(numIterationsGT0, Seq(invNumIterationsIsLow, terminationMeasure), whileBody)(pos, info, errT)
-        assumeFalse = vpr.Assume(vpr.FalseLit()())()
+        assumeFalse = vpr.Assume(vpr.FalseLit()(pos, info, errT))(pos, info, errT)
         ifThen = vu.seqn(Vector(assignNumIterations, assumeNumIterLow, whileStmt, assumeFalse))(pos, info, errT)
         ifElse = vu.nop(pos, info, errT)
       } yield vpr.If(ndBoolTrue, ifThen, ifElse)(pos, info, errT)
       implementsAssertion <- ctx.expression(in.ClosureImplements(proof.closure, proof.spec)(src))
-      assumeImplements = vpr.Assume(implementsAssertion)()
+      assumeImplements = vpr.Assume(implementsAssertion)(pos, info, errT)
       _ <- cl.errorT(failedExhale)
     } yield vu.seqn(Vector(assumeNdLow, ifStmt, assumeImplements))(pos, info, errT)
   }

--- a/src/main/scala/viper/gobra/translator/encodings/closures/ClosureSpecsEncoder.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/closures/ClosureSpecsEncoder.scala
@@ -190,10 +190,11 @@ protected class ClosureSpecsEncoder {
     * function closureImplements$[spec]$[idx of params](closure: Closure, [params name and type]): Bool
     * */
   private def implementsFunction(spec: in.ClosureSpec)(ctx: Context, info: Source.Parser.Info): vpr.DomainFunc = {
+    val (nodePos, nodeInfo, nodeErrT) = spec.vprMeta
     val closurePar = in.Parameter.In(Names.closureArg, genericFuncType)(info)
     val params = spec.params.map(p => in.Parameter.In(Names.closureImplementsParam(p._1), p._2.typ.withAddressability(Addressability.inParameter))(p._2.info))
     val args = (Vector(closurePar) ++ params) map ctx.variable
-    vpr.DomainFunc(implementsFunctionName(spec), args, vpr.Bool)(domainName = Names.closureDomain)
+    vpr.DomainFunc(implementsFunctionName(spec), args, vpr.Bool)(pos = nodePos, info = nodeInfo, errT = nodeErrT, domainName = Names.closureDomain)
   }
 
   /**

--- a/src/main/scala/viper/gobra/translator/encodings/typeless/DeferEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/typeless/DeferEncoding.scala
@@ -55,7 +55,7 @@ class DeferEncoding extends Encoding {
       val appliedCore = Core.core(n.stmt).run(vars)
 
       val vprVars = vars map ctx.variable // temporary variables
-      val activationVar = vpr.LocalVarDecl(s"${name}_activation", vpr.Bool)(pos,info,errT) // activation variable
+      val activationVar = vpr.LocalVarDecl(s"${name}_activation", vpr.Bool)(pos, info, errT) // activation variable
 
       val w = ml.block(ctx.statement(appliedCore))
 
@@ -66,7 +66,7 @@ class DeferEncoding extends Encoding {
         })
         _ <- collect(Defer(activationVar, vprVars, w))
         // active = true
-      } yield vpr.LocalVarAssign(activationVar.localVar, vpr.BoolLit(b = true)(pos,info,errT))(): vpr.Stmt
+      } yield vpr.LocalVarAssign(activationVar.localVar, vpr.BoolLit(b = true)(pos, info, errT))(pos, info, errT): vpr.Stmt
   }
 
   override def extendStatement(ctx: Context): in.Stmt ==> Extension[CodeWriter[vpr.Stmt]] = {


### PR DESCRIPTION
While these nodes are never used for generating an error message, they must have position information so that we can soundly apply the dependency analysis developed by @AndreaKe 