### PR TITLE
Fix position of result assignments

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -665,7 +665,7 @@ object Desugar extends LazyLogging {
       // r1 := r1'; .... rn := rn'
       val resultAssignments =
         returnsWithSubs.flatMap{
-          case (p, Some(v)) => Some(singleAss(in.Assignee.Var(p), v)(fsrc))
+          case (p, Some(v)) => Some(singleAss(in.Assignee.Var(p), v)(p.info))
           case _ => None
         } // :+ in.Return()(fsrc)
 
@@ -864,7 +864,7 @@ object Desugar extends LazyLogging {
       // r1 := r1'; .... rn := rn'
       val resultAssignments =
         returnsWithSubs.flatMap{
-          case (p, Some(v)) => Some(singleAss(in.Assignee.Var(p), v)(fsrc))
+          case (p, Some(v)) => Some(singleAss(in.Assignee.Var(p), v)(p.info))
           case _ => None
         } // :+ in.Return()(fsrc)
 


### PR DESCRIPTION
Previously, result assignments in method encodings received the meta of the method itself. I changed this such that the meta is derived from the result variable instead. This is more precise and required for the dependency analysis to work correctly.