### PR TITLE
Resolve embedded interfaces through their owning type context's cached

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -209,8 +209,8 @@ trait MemberResolution { this: TypeInfoImpl =>
         AdvancedMemberSet.union {
           topLevel +: es.map(e => interfaceMethodSet(
             entity(e.typ.id) match {
-              // TODO: might break for imported interfaces
-              case NamedType(PTypeDef(t: PInterfaceType, _), _, _) => InterfaceT(t, ctxt)
+              case NamedType(PTypeDef(t: PInterfaceType, _), _, context) =>
+                context.symbType(t).asInstanceOf[InterfaceT]
               case _ => ???
             }
           ).promoteItf(e.typ.name))

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -209,9 +209,11 @@ trait MemberResolution { this: TypeInfoImpl =>
         AdvancedMemberSet.union {
           topLevel +: es.map(e => interfaceMethodSet(
             entity(e.typ.id) match {
-              case NamedType(PTypeDef(t: PInterfaceType, _), _, context) =>
-                context.symbType(t).asInstanceOf[InterfaceT]
-              case _ => ???
+              case NamedType(PTypeDef(t: PInterfaceType, _), _, ownerCtxt) =>
+                ownerCtxt.symbType(t) match {
+                  case itf: InterfaceT => itf
+                  case other => Violation.violation(s"expected interface type, but got $other")
+                }
             }
           ).promoteItf(e.typ.name))
         }

--- a/src/test/resources/regressions/issues/001053.gobra
+++ b/src/test/resources/regressions/issues/001053.gobra
@@ -1,0 +1,12 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue001053
+
+// ##(-I ./)
+import interfaces "001053"
+
+requires x != nil && x.Mem()
+func use(x interfaces.Derived) {
+	x.M()
+}

--- a/src/test/resources/regressions/issues/001053/interfaces.gobra
+++ b/src/test/resources/regressions/issues/001053/interfaces.gobra
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package interfaces
+
+type Base interface {
+	pred Mem()
+
+	requires Mem()
+	M()
+}
+
+type Derived interface {
+	Base
+}


### PR DESCRIPTION
This PR fixes the interface method-set performance issue reported in #1053.

When Gobra computes the method set of an interface, it recursively computes the method sets of all embedded interfaces. Previously, the embedded interface type was reconstructed using the context of the interface currently being processed:

`InterfaceT(t, ctxt)`

However, resolving the embedded interface already produces a `NamedType` containing the `ExternalTypeInfo` that owns its declaration. Ignoring that context is problematic when the embedded interface is defined in another file or package.

## Why this caused the slowdown

Kiama attributes are memoized based on their input. For `interfaceMethodSet`, that input is an `InterfaceT`, which contains both:

- the `PInterfaceType` declaration;
- its `ExternalTypeInfo` context.

For interfaces inside the current syntax tree, repeated type resolution generally returns the same cached symbolic type. This allows subsequent `interfaceMethodSet` evaluations to hit Kiama's cache.

For an interface resolved through another type-checking context, the old code instead constructed a new `InterfaceT` using the caller's context. This type did not correspond to the canonical symbolic type maintained by the context that owns the declaration. Consequently, computations involving interfaces outside the current tree could use inconsistent attribute keys and repeatedly evaluate interface member resolution instead of reusing the owning type checker's cached result.

This repeated work becomes particularly expensive for interfaces containing predicates and for programs with many implementations, producing the large type-checking slowdown described in #1053.

## The fix

The embedded interface is now obtained through the context carried by the resolved `NamedType`:

`context.symbType(t).asInstanceOf[InterfaceT]`

`context.symbType(t)` is an existing Kiama attribute. It therefore returns the symbolic interface type cached by the type checker that owns the declaration.

This has two important effects:

1. The embedded interface is associated with the correct package/type-checking context.
2. Repeated method-set computations receive the same cached symbolic type and can hit Kiama's attribute cache.

The change does not depend on whether the interface is declared in the current file, another file of the package, or an imported package. Interface resolution consistently delegates to the context that owns the declaration.

## Regression test

The PR adds a regression in `regressions/issues/001053` covering an interface imported from another package. The imported interface embeds a base interface containing both a method and a predicate. The test checks that those inherited members can be resolved from file mode through the derived interface.

Generated by CodeX

Fixes #1053