### PR TITLE
Fix #1057

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -993,6 +993,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
                   }
                   */
                   None
+                case UnknownType => None
                 case c => Violation.violation(s"This case should be unreachable, but got $c")
               }
 
@@ -1013,6 +1014,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
                   }
                   */
                   None
+                case UnknownType => None
                 case c => Violation.violation(s"This case should be unreachable, but got $c")
               }
 

--- a/src/test/resources/regressions/issues/001057-1.gobra
+++ b/src/test/resources/regressions/issues/001057-1.gobra
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue001057
+
+//:: ExpectedOutput(type_error)
+pred ProgramShape(p *Program, frac perm) {
+    acc(p, frac) &&
+    //:: ExpectedOutput(type_error)
+    (forall i int :: { &p.Methods[i] } 0 <= i && i < len(p.Methods) ==> acc(&p.Methods[i], frac))
+}
+
+pure
+// older versions of Gobra would crash when parsing the following precondition
+// as it tried to infer the type of `1/2` from context. However, due to the
+// absence of `Program`, `ProgramShape` ends up being ill-typed and, thus,
+// inferring the type of `1/2` used to result in a violation.
+requires acc(ProgramShape(p, 1/2))
+//:: ExpectedOutput(type_error)
+func memberIn(p *Program) bool

--- a/src/test/resources/regressions/issues/001057-2.gobra
+++ b/src/test/resources/regressions/issues/001057-2.gobra
@@ -1,0 +1,23 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue001057
+
+type Program struct {
+    Methods []*Method
+}
+
+type Method struct {
+    Name string
+}
+
+//:: ExpectedOutput(predicate_not_well_defined:negative_permission_error)
+pred ProgramShape(p *Program, frac perm) {
+    acc(p, frac) &&
+    (forall i int :: { &p.Methods[i] } 0 <= i && i < len(p.Methods) ==> acc(&p.Methods[i], frac))
+}
+
+ghost
+pure
+requires acc(ProgramShape(p, 1/2))
+func memberIn(p *Program) bool


### PR DESCRIPTION
Addresses Gobra's violation when trying to infer the type for a numerical expression in an ill-typed context

Fixes #1057