### PR TITLE
Fixes an incompleteness of append and copy

### DIFF
--- a/src/main/scala/viper/gobra/translator/encodings/typeless/BuiltInEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/typeless/BuiltInEncoding.scala
@@ -441,6 +441,7 @@ class BuiltInEncoding extends Encoding {
           * ensures len(res) == len(dst) + len(src)
           * ensures forall i int :: { &res[i] } 0 <= i && i < len(res) ==> acc(&res[i])
           * ensures forall i int :: { &src[i] } 0 <= i && i < len(src) ==> acc(&src[i], p)
+          * ensures forall i int :: { &src[i] } 0 <= i && i < len(src) ==> src[i] === old(src[i])
           * ensures forall i int :: { &res[i] } 0 <= i && i < len(dst) ==> res[i] === old(dst[i])
           * ensures forall i int :: { &res[i] } len(dst) <= i && i < len(res) ==> res[i] === src[i - len(dst)]
           */
@@ -476,6 +477,18 @@ class BuiltInEncoding extends Encoding {
         )(src)
         val postRes = accessSlice(resultParam, in.FullPerm(src))
         val postVariadic = accessSlice(variadicParam, pParam)
+        val postCmpVariadicUnchanged = quantify(
+          trigger = { i => Vector(in.Trigger(Vector(in.Ref(in.IndexedExp(variadicParam, i, sliceType)(src))(src)))(src)) },
+          range = { inRange(_, in.IntLit(0)(src), in.Length(variadicParam)(src)) },
+          body = {
+            i => in.ExprAssertion(
+              in.GhostEqCmp(
+                in.IndexedExp(variadicParam, i, sliceType)(src),
+                in.Old(in.IndexedExp(variadicParam, i, sliceType)(src))(src)
+              )(src)
+            )(src)
+          }
+        )
         val postCmpSlice = quantify(
           trigger = { i => Vector(in.Trigger(Vector(in.Ref(in.IndexedExp(resultParam, i, sliceType)(src))(src)))(src)) },
           range = { inRange(_, in.IntLit(0)(src), in.Length(sliceParam)(src)) },
@@ -488,7 +501,7 @@ class BuiltInEncoding extends Encoding {
             )(src)
           }
         )
-        val postCmpVariadic = quantify(
+        val postCmpVariadicCopied = quantify(
           trigger = { i => Vector(in.Trigger(Vector(in.Ref(in.IndexedExp(resultParam, i, sliceType)(src))(src)))(src)) },
           range = { inRange(_,  in.Length(sliceParam)(src), in.Length(resultParam)(src)) },
           body = { i =>
@@ -500,7 +513,7 @@ class BuiltInEncoding extends Encoding {
             )(src)
           }
         )
-        val posts: Vector[in.Assertion] = Vector(postLen, postRes, postVariadic, postCmpSlice, postCmpVariadic)
+        val posts: Vector[in.Assertion] = Vector(postLen, postRes, postVariadic, postCmpVariadicUnchanged, postCmpSlice, postCmpVariadicCopied)
 
         in.Function(x.name, args, results, pres, posts, Vector(in.NonItfMethodWildcardMeasure(None)(src)), Vector.empty, None)(src)
 
@@ -513,6 +526,7 @@ class BuiltInEncoding extends Encoding {
           * ensures len(src) < len(dst) ==> res == len(src)
           * ensures forall i int :: { &dst[i] } 0 <= i && i < len(dst) ==> acc(&dst[i], write)
           * ensures forall i int :: { &src[i] } 0 <= i && i < len(src) ==> acc(&src[i], p)
+          * ensures forall i int :: { &src[i] } 0 <= i && i < len(src) ==> src[i] === old(src[i])
           * ensures forall i int :: { &dst[i] } (0 <= i && i < len(src) && i < len(dst)) ==> dst[i] === old(src[i])
           * ensures forall i int :: { &dst[i] } (len(src) <= i && i < len(dst)) ==> dst[i] === old(dst[i])
           * func copy(dst, src []int, ghost p perm) (res int)
@@ -574,6 +588,18 @@ class BuiltInEncoding extends Encoding {
         // the assertions in the pre-conditions can be reused here
         val postDst = preDst
         val postSrc = preSrc
+        val postSrcSame = quantify(
+          trigger = { i => Vector(in.Trigger(Vector(in.Ref(in.IndexedExp(srcParam, i, srcUnderlyingType)(src))(src)))(src)) },
+          range = { i => inRange(i, in.IntLit(0)(src), in.Length(srcParam)(src)) },
+          body = { i =>
+            in.ExprAssertion(
+              in.GhostEqCmp(
+                in.IndexedExp(srcParam, i, srcUnderlyingType)(src),
+                in.Old(in.IndexedExp(srcParam, i, srcUnderlyingType)(src))(src)
+              )(src)
+            )(src)
+          }
+        )
         val postUpdate = quantify(
           trigger = { i => Vector(in.Trigger(Vector(in.Ref(in.IndexedExp(dstParam, i, dstUnderlyingType)(src))(src)))(src)) },
           range = { i =>
@@ -591,7 +617,7 @@ class BuiltInEncoding extends Encoding {
             )(src)
           }
         )
-        val postSame = quantify(
+        val postDstSame = quantify(
           trigger = { i => Vector(in.Trigger(Vector(in.Ref(in.IndexedExp(dstParam, i, dstUnderlyingType)(src))(src)))(src)) },
           range = { i => inRange(i, in.Length(srcParam)(src), in.Length(dstParam)(src)) },
           body = { i =>
@@ -604,7 +630,7 @@ class BuiltInEncoding extends Encoding {
           }
         )
 
-        val posts = Vector(postRes1, postRes2, postDst, postSrc, postUpdate, postSame)
+        val posts = Vector(postRes1, postRes2, postDst, postSrc, postSrcSame, postUpdate, postDstSame)
 
         in.Function(x.name, args, results, pres, posts, Vector(in.NonItfMethodWildcardMeasure(None)(src)), Vector.empty, None)(src)
 

--- a/src/test/resources/regressions/issues/001061.gobra
+++ b/src/test/resources/regressions/issues/001061.gobra
@@ -1,0 +1,27 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue1061
+
+// this test case checks that `append` and `copy` possess specification that states
+// that the source element / slice is not modified, even if full permissions are passed (
+// as in that case framing does not apply).
+
+requires acc(s)
+ensures  len(result) == len(s) + 1
+ensures  acc(result)
+ensures  result[len(result) - 1] == v
+func appendOne(s []string, v string) (result []string) {
+	result = append(writePerm, s, v) // using fractional permission would side-step the issue
+	return
+}
+
+preserves acc(s)
+ensures   len(result) == len(s)
+ensures   acc(result)
+ensures   forall i int :: {&result[i]} 0 <= i && i < len(result) ==> result[i] == s[i]
+func myCopy(s []string) (result []string) {
+    result = make([]string, len(s))
+	copy(result, s, writePerm) // using fractional permission would side-step the issue
+	return
+}

--- a/src/test/resources/regressions/issues/001061.gobra
+++ b/src/test/resources/regressions/issues/001061.gobra
@@ -3,9 +3,9 @@
 
 package issue1061
 
-// this test case checks that `append` and `copy` possess specification that states
-// that the source element / slice is not modified, even if full permissions are passed (
-// as in that case framing does not apply).
+// This test checks that `append` and `copy` specifications expose that the source
+// slice/elements are not modified, even when full permissions are passed (since
+// framing does not apply in that case).
 
 requires acc(s)
 ensures  len(result) == len(s) + 1


### PR DESCRIPTION
While the specification so far is complete-enough as one can simply pass a fraction of permissions and, thus, exploit framing, I nonetheless think it's useful to have stronger spec as this is a common pitfall.

Fixes #1061