### PR TITLE
Variadic type identity

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/property/TypeIdentity.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/property/TypeIdentity.scala
@@ -65,6 +65,11 @@ trait TypeIdentity extends BaseProperty { this: TypeInfoImpl =>
           case (l, r) => identicalTypes(l, r)
         } && identicalTypes(lr, rr)
 
+      // regarding variadic types, the Go spec states in the "Type identity" subsection that "two function
+      // types are identical if ... parameter and result types are identical, and either both functions are
+      // variadic or neither is."
+      case (VariadicT(l), VariadicT(r)) => identicalTypes(l, r)
+
       case (PredT(larg), PredT(rarg)) =>
         larg.size == rarg.size && larg.zip(rarg).forall {
           case (l, r) => identicalTypes(l, r)

--- a/src/test/resources/regressions/issues/001063-1.gobra
+++ b/src/test/resources/regressions/issues/001063-1.gobra
@@ -1,0 +1,22 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue1063_1
+
+// Tests that ClientImpl.Ping has the same signature as Client.Ping.
+
+type CallOption interface{}
+
+type Client interface {
+	Ping(req *int, opts ...CallOption) (*int, error)
+}
+
+type ClientImpl struct{}
+
+func (c *ClientImpl) Ping(req *int, opts ...CallOption) (*int, error) {
+	return req, nil
+}
+
+func New() Client {
+	return &ClientImpl{}
+}

--- a/src/test/resources/regressions/issues/001063-2.gobra
+++ b/src/test/resources/regressions/issues/001063-2.gobra
@@ -1,0 +1,33 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue1063_2
+
+// Tests that Implementation.F has the same signature as VariadicInt.F,
+// but not the same signature as SliceInt.F or VariadicBool.F, despite
+// the Go spec stating that `...int` is equivalent to `[]int` (within a
+// function but not for deciding type identity).
+
+type VariadicInt interface {
+	F(xs ...int)
+}
+
+type SliceInt interface {
+	F(xs []int)
+}
+
+type VariadicBool interface {
+	F(xs ...bool)
+}
+
+type Implementation struct{}
+
+func (x *Implementation) F(xs ...int)
+
+*Implementation implements VariadicInt
+
+//:: ExpectedOutput(type_error)
+*Implementation implements SliceInt
+
+//:: ExpectedOutput(type_error)
+*Implementation implements VariadicBool


### PR DESCRIPTION
So far, variadic types were not handled by our type identity logic, such that two variadic types ended up being non-identical.
This PR addresses this issue.

Fixes #1063