### PR TITLE
Delegates interface method-set computation to the interface's owning type-checking context

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
+++ b/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
@@ -95,6 +95,9 @@ trait ExternalTypeInfo {
   /* memberset within a specific context */
   def localMemberSet(t: Type): AdvancedMemberSet[TypeMember]
 
+  /** method set of interface `t`, whose declaration must belong to this context */
+  def localInterfaceMethodSet(t: InterfaceT): AdvancedMemberSet[TypeMember]
+
   /** returns all subtype relation found in the current package */
   def localRequiredImplements: Set[(Type, InterfaceT)]
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -141,7 +141,10 @@ class TypeInfoImpl(final val tree: Info.GoTree, override final val dependentType
   }
 
   override def struct(n: PNode): Option[Type.StructT] =
-    enclosingStruct(n).map(structDecl => symbType(structDecl).asInstanceOf[Type.StructT])
+    enclosingStruct(n).map(structDecl => symbType(structDecl) match {
+      case structT: Type.StructT => structT
+      case t => violation(s"expected struct type, but got $t")
+    })
 
   override def boolConstantEvaluation(expr: PExpression): Option[Boolean] = boolConstantEval(expr)
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -201,7 +201,24 @@ trait MemberResolution { this: TypeInfoImpl =>
 
   // Interfaces
 
-  lazy val interfaceMethodSet: InterfaceT => AdvancedMemberSet[TypeMember] =
+  /** Returns the method set of interface `t`.
+    * The computation is delegated to the context owning the interface's declaration such that the
+    * names of embedded interfaces are resolved in the tree they belong to and such that all
+    * importers share the owning context's cached results.
+    **/
+  def interfaceMethodSet(t: InterfaceT): AdvancedMemberSet[TypeMember] =
+    t.context.localInterfaceMethodSet(t)
+
+  /** Returns the method set of interface `t`, whose declaration must belong to this context.
+    * The purpose of this method is that typecheckers of other packages access it to compute
+    * [[interfaceMethodSet]].
+    **/
+  override def localInterfaceMethodSet(t: InterfaceT): AdvancedMemberSet[TypeMember] = {
+    Violation.violation(t.context == this, s"interface ${t.decl} does not belong to this context")
+    interfaceMethodSetAttr(t)
+  }
+
+  private lazy val interfaceMethodSetAttr: InterfaceT => AdvancedMemberSet[TypeMember] =
     attr[InterfaceT, AdvancedMemberSet[TypeMember]] {
       case InterfaceT(PInterfaceType(es, methSpecs, predSpecs), ctxt) =>
         val topLevel = AdvancedMemberSet.init[TypeMember](methSpecs.map(m => ctxt.createMethodSpec(m))) union

--- a/src/test/resources/regressions/issues/001053-1.gobra
+++ b/src/test/resources/regressions/issues/001053-1.gobra
@@ -1,0 +1,21 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue001053
+
+// ##(-I ./)
+import interfaces "001053"
+
+type MyItf interfaces.Derived
+
+// Computing the method set of `S` promotes the members of `MyItf` and, thus,
+// of `interfaces.Derived`. Resolving the interface embedded in `Derived` must
+// happen within the imported package's tree, not in this package's tree.
+type S struct {
+	MyItf
+}
+
+requires s.MyItf != nil && s.MyItf.Mem()
+func use(s S) {
+	s.M()
+}


### PR DESCRIPTION
Follow-up to #1054, addressing a residual issue in the same code path (found while auditing for the problems @jcp19 asked about in the review of #1054). **Stacked on #1054** (base branch `issue-1053`); should be retargeted to / merged into master once #1054 lands.

## The problem

`interfaceMethodSet` resolves the names of embedded interfaces with the **local** `entity` attribute even when the interface declaration belongs to another type-checking context:

```scala
entity(e.typ.id) match { ... }
```

`entity` walks `tree.parent` / chain attributes of the *local* tree. When `interfaceMethodSet` is evaluated in a context different from the one owning the interface declaration, `e.typ.id` is a node of a *foreign* tree, and the lookup crashes with Kiama's `NodeNotInTreeException`.

This situation is reachable today: a local struct embeds a locally-defined type whose underlying type is an imported interface that itself embeds another interface. The local promotion chain (`pastPromotions` → `pastPromotionsMethodSuffix`) then evaluates `interfaceMethodSet` on the foreign `InterfaceT` in the local context:

```
org.bitbucket.inkytonik.kiama.relation.NodeNotInTreeException: node not in tree: Base
  at NameResolution.$anonfun$entity$1(NameResolution.scala:352)
  at MemberResolution.$anonfun$interfaceMethodSet$4(MemberResolution.scala:211)
  at MemberResolution.$anonfun$pastPromotionsMethodSuffix$1(MemberResolution.scala:247)
  ...
  at TypeTyping.wellDefStructType(TypeTyping.scala:115)
```

The added regression test `regressions/issues/001053-1.gobra` reproduces exactly this (it reuses the imported package of the `001053` regression) and crashes without this fix.

## The fix

`interfaceMethodSet` is now a dispatching method that delegates to the context owning the interface declaration, mirroring the existing `memberSet` → `getMethodReceiverContext` → `localMemberSet` pattern:

```scala
def interfaceMethodSet(t: InterfaceT): AdvancedMemberSet[TypeMember] =
  t.context.localInterfaceMethodSet(t)
```

`localInterfaceMethodSet` (new on `ExternalTypeInfo`) checks that the interface belongs to the context and evaluates the previous memoized attribute. Consequently:

1. Embedded interface names are always resolved in the tree they belong to — the crash above disappears.
2. All importers share the owning context's Kiama cache instead of each recomputing the method set, extending the caching benefit of #1054 one level deeper (the recursive case).

Additionally, the unchecked cast in `TypeInfoImpl.struct` is replaced with a pattern match + `Violation.violation` carrying a clear message (same shape as 393a02fc), since this method is part of the cross-package `ExternalTypeInfo` interface and would otherwise fail with an uninformative `ClassCastException` on misuse.

## Verification

- The new regression test crashes before the fix and verifies successfully with it.
- Full `sbt test` produces a failure set identical to the base branch (local pre-existing failures unrelated to this change; verified by diffing the failing-test lists of both runs), with the new test passing on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)