### PR TITLE
Makes AdtT and AdtClauseT contextual types

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/base/Type.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/Type.scala
@@ -60,12 +60,12 @@ object Type {
 
   case class DomainT(decl: PDomainType, context: ExternalTypeInfo) extends PrettyType("domain{...}") with ContextualType
 
-  case class AdtT(clauses: Vector[AdtClauseT], decl: PTypeDef, context: ExternalTypeInfo) extends PrettyType(decl.left.name) {
+  case class AdtT(clauses: Vector[AdtClauseT], decl: PTypeDef, context: ExternalTypeInfo) extends PrettyType(decl.left.name) with ContextualType {
     val adtDecl: PAdtType = decl.right.asInstanceOf[PAdtType]
     val declaredType: DeclaredT = DeclaredT(decl, context)
   }
 
-  case class AdtClauseT(name: String, fields: Vector[(String, Type)], decl: PAdtClause, typeDecl: PTypeDef, context: ExternalTypeInfo) extends PrettyType(name) {
+  case class AdtClauseT(name: String, fields: Vector[(String, Type)], decl: PAdtClause, typeDecl: PTypeDef, context: ExternalTypeInfo) extends PrettyType(name) with ContextualType {
     val adtDecl: PAdtType = typeDecl.right.asInstanceOf[PAdtType]
     val typeMap: Map[String, Type] = fields.toMap
     val declaredType: DeclaredT = DeclaredT(typeDecl, context)

--- a/src/test/resources/regressions/features/adts/importedAdt.gobra
+++ b/src/test/resources/regressions/features/adts/importedAdt.gobra
@@ -1,0 +1,41 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package importedAdt
+
+// ##(-I ./)
+import defs "importedAdtPkg"
+
+// Exercises the member surface of an ADT declared in another package:
+// constructors, destructors, discriminators, pattern matches, and clause types.
+
+func test1() {
+  ghost y := defs.Leaf{Value: 3}
+  assert y == defs.Leaf{3}
+  assert y.Value == 3
+  assert y.isLeaf
+}
+
+func test2(ghost x defs.Tree) {
+  ghost var y int
+  match x {
+    case defs.Node{defs.Leaf{5}, _}: y = 4
+    case _: y = 3
+  }
+
+  assert y >= 3
+}
+
+func test3() {
+  x := defs.Node{defs.Leaf{3}, defs.Node{defs.Leaf{4}, defs.Leaf{5}}}
+  ghost var q int
+  match x {
+    case defs.Node{_, defs.Node{defs.Leaf{?z}, _}}: q = z
+  }
+  assert q == 4
+}
+
+func test4(ghost l defs.Leaf) {
+  ghost v := l.Value
+  assert v == l.Value
+}

--- a/src/test/resources/regressions/features/adts/importedAdtPkg/defs.gobra
+++ b/src/test/resources/regressions/features/adts/importedAdtPkg/defs.gobra
@@ -1,0 +1,9 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package defs
+
+ghost type Tree adt {
+  Leaf{ Value int }
+  Node{ Left, Right Tree }
+}


### PR DESCRIPTION
Follow-up to the audit @jcp19 asked for in the review of #1054 (types resolved against the wrong context).

## The problem

`AdtT` and `AdtClauseT` both carry the `ExternalTypeInfo` of the package owning their declaration, but — unlike `DeclaredT`, `DomainT`, `StructT`, and `InterfaceT` — they do not extend `ContextualType`. This has two consequences:

1. `MemberResolution.getMethodReceiverContext` only dispatches member lookups to the owning context for `ContextualType`s, so lookups on imported ADTs silently run in the *importing* package's `TypeInfoImpl`. Each importer recomputes the ADT member sets instead of sharing the owning context's Kiama cache, and the lookup runs in a context the type does not belong to (the same class of problem as #1053/#1054, even though no crash is currently reachable for ADTs since their member computation only touches nodes of the ADT's own declaration).
2. `Assignability.isImportedContextualType` / `isLocallyDefinedContextualType` treat imported ADTs as locally defined.

## The fix

`AdtT` and `AdtClauseT` now extend `ContextualType`, making ADTs consistent with the other context-carrying types. The behavior switches that newly see them are exactly the two above; `ExprTyping`'s use of `isLocallyDefinedContextualType` is guarded by `isInterfaceType` and therefore unaffected.

## Regression test

`regressions/features/adts/importedAdt.gobra` exercises the member surface of an ADT declared in another package: constructor literals, destructors, discriminators, pattern matches (including nested patterns and binders), and clause types used as parameter types. The test passes both before and after this change, locking in the behavior across the dispatch change.

(While writing the test we noticed that `assert l.isLeaf` for a parameter `l` of clause type `Leaf` is not provable — this is an orthogonal encoding incompleteness that equally affects package-local ADTs, so the test uses the destructor instead.)

## Verification

Full `sbt test`: the only failures are local-environment ones (Carbon tests without a Boogie setup and untracked local experiment files); all tracked Silicon-based tests pass, including all existing ADT tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)