### PR TITLE
Optimize openInvariants set usage in loops and methods

### DIFF
--- a/src/main/scala/viper/gobra/ast/frontend/utility/Nodes.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/utility/Nodes.scala
@@ -1,0 +1,29 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2026 ETH Zurich.
+
+package viper.gobra.ast.frontend.utility
+
+import viper.gobra.ast.frontend.PNode
+
+object Nodes {
+
+  /** Returns a list of all direct sub-nodes of this node. */
+  def subnodes(n: PNode): Seq[PNode] = {
+
+    def extractChildren(a: Any): Seq[PNode] = a match {
+      case t: PNode => Seq(t)
+      // Handles Vector, Seq, Option, Map (as iterator of key and value pairs)
+      case t: Iterable[_] => t.flatMap(extractChildren).toSeq
+      // Handles all tuples and case classes that are not subtypes of node
+      case t: Product => t.productIterator.flatMap(extractChildren).toSeq
+      // If it is not a node nor contains a node, then it is irrelevant.
+      case _ => Seq.empty
+    }
+
+    n.productIterator.flatMap(extractChildren).toSeq
+  }
+
+}

--- a/src/main/scala/viper/gobra/ast/frontend/utility/Nodes.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/utility/Nodes.scala
@@ -13,6 +13,7 @@ object Nodes {
   /** Returns a list of all direct sub-nodes of this node. */
   def subnodes(n: PNode): Seq[PNode] = {
 
+    // extracts all reachable `PNode`s including the current node
     def extractChildren(a: Any): Seq[PNode] = a match {
       case t: PNode => Seq(t)
       // Handles Vector, Seq, Option, Map (as iterator of key and value pairs)

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -8,6 +8,7 @@ package viper.gobra.frontend
 
 import com.typesafe.scalalogging.LazyLogging
 import viper.gobra.ast.frontend.{AstPattern => ap, _}
+import viper.gobra.ast.frontend.utility.Nodes
 import viper.gobra.ast.{internal => in}
 import viper.gobra.frontend.PackageResolver.RegularImport
 import viper.gobra.frontend.Source.TransformableSource
@@ -541,15 +542,10 @@ object Desugar extends LazyLogging {
       * the set at all, and loops whose bodies do not contain a critical region cannot modify it
       * (and thus, do not need a loop invariant preserving its value).
       */
-    def containsCriticalRegion(n: PNode): Boolean = {
-      def go(x: Any): Boolean = x match {
-        case _: PCritical => true
-        case _: PClosureDecl => false
-        case p: Product => p.productIterator.exists(go)
-        case xs: Iterable[_] => xs.exists(go)
-        case _ => false
-      }
-      go(n)
+    def containsCriticalRegion(n: PNode): Boolean = n match {
+      case _: PCritical => true
+      case _: PClosureDecl => false
+      case _ => Nodes.subnodes(n).exists(containsCriticalRegion)
     }
 
     def constDeclD(block: PConstDecl): Vector[in.GlobalConstDecl] = block.specs.flatMap(constSpecD)

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -533,6 +533,25 @@ object Desugar extends LazyLogging {
           in.PredT(Vector.empty, Addressability.exclusiveVariable),
           Addressability.exclusiveVariable))(Source.Parser.Internal)
 
+    /**
+      * Returns whether the subtree rooted at `n` contains a critical region. Function literals
+      * are not inspected, given that their bodies are desugared separately and get their own
+      * `openInvariants` set. The `openInvariants` set is only modified by the encoding of
+      * critical regions, so members whose bodies do not contain a critical region do not need
+      * the set at all, and loops whose bodies do not contain a critical region cannot modify it
+      * (and thus, do not need a loop invariant preserving its value).
+      */
+    def containsCriticalRegion(n: PNode): Boolean = {
+      def go(x: Any): Boolean = x match {
+        case _: PCritical => true
+        case _: PClosureDecl => false
+        case p: Product => p.productIterator.exists(go)
+        case xs: Iterable[_] => xs.exists(go)
+        case _ => false
+      }
+      go(n)
+    }
+
     def constDeclD(block: PConstDecl): Vector[in.GlobalConstDecl] = block.specs.flatMap(constSpecD)
 
     def constSpecD(decl: PConstSpec): Vector[in.GlobalConstDecl] = decl.left.flatMap(l => info.regular(l) match {
@@ -699,7 +718,8 @@ object Desugar extends LazyLogging {
       val capturedWithAliases = (captured.map { v => in.Ref(localVarD(outerCtx, info)(v))(meta(v, info)) } zip capturedPar)
 
       val bodyOpt = decl.body.map{ case (_, s) =>
-        val vars = argSubs.flatten ++ capturedSubs ++ returnSubs.flatten ++ Vector(openInvsVar)
+        val vars = argSubs.flatten ++ capturedSubs ++ returnSubs.flatten ++
+          (if (containsCriticalRegion(s)) Vector(openInvsVar) else Vector.empty)
         val varsInit = vars map (v => in.Initialization(v)(v.info))
         val body = varsInit ++ argInits ++ capturedInits ++ Vector(blockD(ctx, info)(s))
         in.MethodBody(vars, in.MethodBodySeqn(body)(fsrc), resultAssignments)(fsrc)
@@ -897,7 +917,8 @@ object Desugar extends LazyLogging {
 
 
       val bodyOpt = decl.body.map{ case (_, s) =>
-        val vars = recvSub.toVector ++ argSubs.flatten ++ returnSubs.flatten ++ Vector(openInvsVar)
+        val vars = recvSub.toVector ++ argSubs.flatten ++ returnSubs.flatten ++
+          (if (containsCriticalRegion(s)) Vector(openInvsVar) else Vector.empty)
         val varsInit = vars map (v => in.Initialization(v)(v.info))
         val body = varsInit ++ recvInits ++ argInits ++ Vector(blockD(ctx, info)(s))
         in.MethodBody(vars, in.MethodBodySeqn(body)(fsrc), resultAssignments)(fsrc)
@@ -1111,15 +1132,24 @@ object Desugar extends LazyLogging {
         * which would prevent opening invariants in later iterations or after the loop. It does
         * not impose any restrictions on the user, given that the syntax of critical regions
         * guarantees that no invariant may be open for longer than one loop iteration.
+        *
+        * The openInvariants set is only assigned by the encoding of critical regions. Thus, for
+        * loops whose body does not contain a critical region (the common case), the set is not
+        * modified by the loop and its value is trivially preserved, so no snapshot and no loop
+        * invariant are generated (`n` is the loop node, whose subtree includes the loop's body).
         */
-      def openInvsUnchangedByLoop(n: PNode)(src: Source.Parser.Info): Writer[(in.Stmt, in.Assertion)] =
-        for {
-          oldOpenInvs <- freshDeclaredExclusiveVar(
-            in.SetT(in.PredT(Vector.empty, Addressability.Exclusive), Addressability.Exclusive), n, info
-          )(src)
-          init = in.SingleAss(in.Assignee.Var(oldOpenInvs), openInvsVar)(src)
-          unchanged = in.ExprAssertion(in.EqCmp(oldOpenInvs, openInvsVar)(src))(src)
-        } yield (init, unchanged)
+      def openInvsUnchangedByLoop(n: PNode)(src: Source.Parser.Info): Writer[(in.Stmt, Vector[in.Assertion])] =
+        if (containsCriticalRegion(n)) {
+          for {
+            oldOpenInvs <- freshDeclaredExclusiveVar(
+              in.SetT(in.PredT(Vector.empty, Addressability.Exclusive), Addressability.Exclusive), n, info
+            )(src)
+            init = in.SingleAss(in.Assignee.Var(oldOpenInvs), openInvsVar)(src)
+            unchanged = in.ExprAssertion(in.EqCmp(oldOpenInvs, openInvsVar)(src))(src)
+          } yield (init, Vector(unchanged))
+        } else {
+          unit((in.Seqn(Vector.empty)(src), Vector.empty))
+        }
 
       def desugarArrSliceShortRange(n: PShortForRange, range: PRange, shorts: Vector[PUnkLikeId], spec: PLoopSpec, body: PBlock)(src: Source.Parser.Info): Writer[in.Stmt] = unit(block(for {
         exp <- goE(range.exp)
@@ -1151,8 +1181,7 @@ object Desugar extends LazyLogging {
         (dTerPre, dTer) <- prelude(option(spec.terminationMeasure map terminationMeasureD(ctx, info, false)))
         (dInvPre, dInv) <- prelude(sequence(spec.invariants map assertionD(ctx, info)))
         (initOldOpenInvs, openInvsDoesNotChange) <- openInvsUnchangedByLoop(n)(src)
-        addedInvariantsBefore = Vector(
-          openInvsDoesNotChange,
+        addedInvariantsBefore = openInvsDoesNotChange ++ Vector(
           in.ExprAssertion(in.And(
             in.AtMostCmp(in.IntLit(0)(src), i0)(src),
             in.AtMostCmp(i0, in.Length(c)(src))(src))(src))(src),
@@ -1293,8 +1322,7 @@ object Desugar extends LazyLogging {
         (dTerPre, dTer) <- prelude(option(spec.terminationMeasure map terminationMeasureD(ctx, info, false)))
         (dInvPre, dInv) <- prelude(sequence(spec.invariants map assertionD(ctx, info)))
         (initOldOpenInvs, openInvsDoesNotChange) <- openInvsUnchangedByLoop(n)(src)
-        addedInvariantsBefore = Vector(
-          openInvsDoesNotChange,
+        addedInvariantsBefore = openInvsDoesNotChange ++ Vector(
           in.ExprAssertion(in.And(
             in.AtMostCmp(in.IntLit(0)(src), i0)(src),
             in.AtMostCmp(i0, in.Length(c)(src))(src))(src))(src)
@@ -1449,7 +1477,7 @@ object Desugar extends LazyLogging {
         (dTerPre, dTer) <- prelude(option(spec.terminationMeasure map terminationMeasureD(ctx, info, false)))
         (dInvPre, dInv) <- prelude(sequence(spec.invariants map assertionD(ctx, info)))
         (initOldOpenInvs, openInvsDoesNotChange) <- openInvsUnchangedByLoop(n)(src)
-        addedInvariants = openInvsDoesNotChange +: (if (range.enumerated != PWildcard()) // emit invariants about visited set only if we actually use a with clause and specify an identifier for it
+        addedInvariants = openInvsDoesNotChange ++ (if (range.enumerated != PWildcard()) // emit invariants about visited set only if we actually use a with clause and specify an identifier for it
           Vector(
             in.ExprAssertion(in.AtMostCmp(in.Length(visited.op)(src), in.Length(c)(src))(src))(src),
             in.ExprAssertion(in.Subset(visited.op, domain)(src))(src))
@@ -1533,8 +1561,7 @@ object Desugar extends LazyLogging {
         (dTerPre, dTer) <- prelude(option(spec.terminationMeasure map terminationMeasureD(ctx, info, false)))
         (dInvPre, dInv) <- prelude(sequence(spec.invariants map assertionD(ctx, info)))
         (initOldOpenInvs, openInvsDoesNotChange) <- openInvsUnchangedByLoop(n)(src)
-        addedInvariants = Vector(
-          openInvsDoesNotChange,
+        addedInvariants = openInvsDoesNotChange ++ Vector(
           in.ExprAssertion(in.AtMostCmp(in.Length(visited.op)(src), in.Length(c)(src))(src))(src),
           in.ExprAssertion(in.Subset(visited.op, domain)(src))(src))
 
@@ -1643,7 +1670,7 @@ object Desugar extends LazyLogging {
 
                 wh = in.Seqn(
                   Vector(initOldOpenInvs, dPre) ++ dCondPre ++ dInvPre ++ dTerPre ++ Vector(
-                    in.While(dCond, openInvsDoesNotChange +: dInv, dTer, in.Block(Vector(continueLoopLabelProxy),
+                    in.While(dCond, openInvsDoesNotChange ++ dInv, dTer, in.Block(Vector(continueLoopLabelProxy),
                       Vector(dBody, continueLoopLabel, dPost) ++ dCondPre ++ dInvPre ++ dTerPre
                     )(src))(src), breakLoopLabel
                   )
@@ -3735,6 +3762,13 @@ object Desugar extends LazyLogging {
         }.values.flatten.toVector
       }
 
+      // The generated function inlines the bodies of the file's init functions. Thus, it only
+      // needs the openInvariants set if one of these bodies contains a critical region.
+      val needsOpenInvs = p.declarations.exists {
+        case x: PFunctionDecl if x.id.name == Constants.INIT_FUNC_NAME => containsCriticalRegion(x)
+        case _ => false
+      }
+
       /**
         * [ p ] ->
         * requires progPres // import preconditions
@@ -3764,7 +3798,7 @@ object Desugar extends LazyLogging {
         backendAnnotations = Vector.empty,
         body = Some(
           in.MethodBody(
-            decls = Vector(openInvsVar),
+            decls = if (needsOpenInvs) Vector(openInvsVar) else Vector.empty,
             postprocessing = Vector(),
             seqn = in.MethodBodySeqn{
               // Init all global variables declared in the file (not all declarations in the package!).

--- a/src/main/scala/viper/gobra/frontend/Parser.scala
+++ b/src/main/scala/viper/gobra/frontend/Parser.scala
@@ -492,7 +492,7 @@ object Parser extends LazyLogging {
           case n@PTupleTerminationMeasure(_, cond) => PWildcardMeasure(cond).at(n)
           case t => t
         }
-        PFunctionSpec(spec.clauses, replacedMeasures, spec.backendAnnotations, spec.isPure, spec.isTrusted, spec.isOpaque, spec.mayBeUsedInInit)
+        spec.copy(terminationMeasures = replacedMeasures)
       }
 
       val replaceTerminationMeasuresForFunctionsAndMethods: Strategy =

--- a/src/test/resources/regressions/features/atomicsAndInvariants/atomics-loops-no-critical.gobra
+++ b/src/test/resources/regressions/features/atomicsAndInvariants/atomics-loops-no-critical.gobra
@@ -1,0 +1,38 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+pred Own(x *int) { acc(x) }
+
+decreases
+func getRandomBool() bool
+
+// Members without critical regions do not carry the set of open invariants around
+// (neither the variable itself nor loop invariants about it). Their encoding
+// (including loops) must still verify without it.
+ensures res >= 10
+func plainLoop() (res int) {
+	res = 0
+	invariant 0 <= i && i <= 10
+	invariant res >= i
+	for i := 0; i < 10; i++ {
+		res += 1
+	}
+	return res
+}
+
+// A loop that does not contain a critical region cannot modify the set of open
+// invariants, so no loop invariant about the set is generated for it. Opening an
+// invariant after such a loop must still be possible.
+requires Invariant(Own{x})
+func loopThenCritical(x *int) {
+	invariant true
+	for getRandomBool() {
+	}
+	critical Own{x} (
+		unfold Own{x}()
+		assert acc(x)
+		fold Own{x}()
+	)
+}

--- a/src/test/resources/same_package/pkg_init/mayinit_import/bar/bar.gobra
+++ b/src/test/resources/same_package/pkg_init/mayinit_import/bar/bar.gobra
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package bar
+
+// ##(-I ../)
+
+var A@ int = Double(21)
+
+ensures res == 2 * x
+decreases
+mayInit
+func Double(x int) (res int) {
+	return 2 * x
+}

--- a/src/test/resources/same_package/pkg_init/mayinit_import/pkg/importer.gobra
+++ b/src/test/resources/same_package/pkg_init/mayinit_import/pkg/importer.gobra
@@ -1,0 +1,17 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// ##(-I ../)
+
+import "bar"
+
+// Importing a package with a 'mayInit' member must not produce errors: the 'mayInit'
+// annotation must survive the spec-only parsing of imported packages (and, in
+// particular, must not be turned into an 'atomic' annotation).
+ensures res == 4
+decreases
+func four() (res int) {
+	return bar.Double(2)
+}


### PR DESCRIPTION
I noticed some significatn slow-downs due to the introduction of this feature in `gobra-libs`. Right now, we declare a variable of `set[pred()]` type in every method and add helper invariants automatically to loops, even in methods that do not open invariants and thus, never change the set of open invariants. This PR introduces an optimization that skips the declaration of these variables and automatic generation of invariants if no invariants are open. It also fixes an issue with the positional arguments for imported mayInit functions