### PR TITLE
Introduces canonical, memoized type factories for context-carrying types

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -213,7 +213,7 @@ object Desugar extends LazyLogging {
     }
 
     def domainFunctionProxy(symb: st.DomainFunction): in.DomainFuncProxy = {
-      val domainName = nm.domain(Type.DomainT(symb.domain, symb.context))
+      val domainName = nm.domain(symb.context.symbType(symb.domain).asInstanceOf[Type.DomainT])
       val functionName = idName(symb.decl.id, symb.context.getTypeInfo)
       in.DomainFuncProxy(functionName, domainName)(meta(symb.decl.id, symb.context.getTypeInfo))
     }
@@ -567,8 +567,8 @@ object Desugar extends LazyLogging {
     //       However, currently, this would require to have versions of [[typeD]].
     /** desugars a defined type for each addressability modifier to register them with [[definedTypes]] */
     def desugarAllTypeDefVariants(decl: PTypeDef): Unit = {
-      typeD(DeclaredT(decl, info), Addressability.Shared)(meta(decl, info))
-      typeD(DeclaredT(decl, info), Addressability.Exclusive)(meta(decl, info))
+      typeD(info.declaredSymbType(decl), Addressability.Shared)(meta(decl, info))
+      typeD(info.declaredSymbType(decl), Addressability.Exclusive)(meta(decl, info))
     }
 
     def desugarBackendAnnotations(annotations: Vector[PBackendAnnotation]): Vector[BackendAnnotation] = {
@@ -2124,7 +2124,7 @@ object Desugar extends LazyLogging {
           )(src))(src)
 
         case disc: st.AdtDiscriminator =>
-          val declT = Type.DeclaredT(disc.typeDecl, disc.context)
+          val declT = disc.context.declaredSymbType(disc.typeDecl)
           in.AdtDiscriminator(
             base,
             adtClauseProxy(nm.adt(declT), disc.decl, disc.context.getTypeInfo)

--- a/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
+++ b/src/main/scala/viper/gobra/frontend/info/ExternalTypeInfo.scala
@@ -6,11 +6,11 @@
 
 package viper.gobra.frontend.info
 
-import viper.gobra.ast.frontend.{PCodeRoot, PEmbeddedDecl, PExpression, PFieldDecl, PFunctionDecl, PFunctionOrMethodDecl, PGeneralForStmt, PIdnNode, PIdnUse, PKeyedElement, PLabelUse, PMPredicateDecl, PMPredicateSig, PMember, PMethodDecl, PMethodSig, PMisc, PNode, PParameter, PPkgDef, PScope, PType}
+import viper.gobra.ast.frontend.{PAdtClause, PCodeRoot, PEmbeddedDecl, PExpression, PFieldDecl, PFunctionDecl, PFunctionOrMethodDecl, PGeneralForStmt, PIdnNode, PIdnUse, PInterfaceType, PKeyedElement, PLabelUse, PMPredicateDecl, PMPredicateSig, PMember, PMethodDecl, PMethodSig, PMisc, PNode, PParameter, PPkgDef, PScope, PType, PTypeDecl}
 import viper.gobra.frontend.PackageInfo
 import viper.gobra.frontend.PackageResolver.AbstractImport
 import viper.gobra.frontend.info.base.BuiltInMemberTag.BuiltInMemberTag
-import viper.gobra.frontend.info.base.Type.{AbstractType, InterfaceT, StructT, Type}
+import viper.gobra.frontend.info.base.Type.{AbstractType, AdtClauseT, DeclaredT, InterfaceT, StructT, Type}
 import viper.gobra.frontend.info.base.SymbolTable
 import viper.gobra.frontend.info.base.SymbolTable.{Embbed, Field, MPredicateImpl, MPredicateSpec, MethodImpl, MethodSpec, Regular, TypeMember}
 import viper.gobra.frontend.info.implementation.resolution.{AdvancedMemberSet, MemberPath}
@@ -63,6 +63,21 @@ trait ExternalTypeInfo {
   def typ(misc: PMisc): Type
 
   def symbType(typ: PType): Type
+
+  /** Returns the canonical declared type for a type declaration owned by this context.
+    * Kiama's attribute caches are keyed on reference identity, thus, only this canonical instance
+    * (as opposed to a freshly constructed, structurally equal one) benefits from caching.
+    **/
+  def declaredSymbType(decl: PTypeDecl): DeclaredT
+
+  /** Returns the canonical symbolic type for an interface declaration owned by this context.
+    * In contrast to [[symbType]], the result is not gated on well-definedness of the declaration
+    * and can therefore be used from within well-definedness checks without creating attribute cycles.
+    **/
+  def interfaceSymbType(decl: PInterfaceType): InterfaceT
+
+  /** Returns the canonical symbolic type for an ADT clause declaration owned by this context. */
+  def adtClauseSymbType(decl: PAdtClause): AdtClauseT
 
   def typ(typ: PIdnNode): Type
 

--- a/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
+++ b/src/main/scala/viper/gobra/frontend/info/base/SymbolTable.scala
@@ -201,7 +201,8 @@ object SymbolTable extends Environments[Entity] {
     override val args: Vector[PParameter] = spec.args
     override def result: PResult = spec.result
     override val isAtomic: Boolean = spec.spec.isAtomic
-    val itfType: Type.InterfaceT = Type.InterfaceT(itfDef, context)
+    // lazy, since the entity is created before typing and the context's attributes may not be evaluated yet
+    lazy val itfType: Type.InterfaceT = context.interfaceSymbType(itfDef)
   }
 
   case class Import(decl: PImport, context: ExternalTypeInfo) extends ActualRegular with TypeEntity {
@@ -248,7 +249,8 @@ object SymbolTable extends Environments[Entity] {
   case class MPredicateSpec(decl: PMPredicateSig, itfDef: PInterfaceType, context: ExternalTypeInfo) extends MPredicate {
     override def rep: PNode = decl
     override val args: Vector[PParameter] = decl.args
-    val itfType: Type.InterfaceT = Type.InterfaceT(itfDef, context)
+    // lazy, since the entity is created before typing and the context's attributes may not be evaluated yet
+    lazy val itfType: Type.InterfaceT = context.interfaceSymbType(itfDef)
   }
 
   sealed trait GhostStructMember extends StructMember with GhostTypeMember

--- a/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/TypeInfoImpl.scala
@@ -83,6 +83,11 @@ class TypeInfoImpl(final val tree: Info.GoTree, override final val dependentType
 
   override def symbType(typ: PType): Type.Type = typeSymbType(typ)
 
+  override def declaredSymbType(decl: PTypeDecl): Type.DeclaredT = declaredSymbTypeAttr(decl)
+
+  private lazy val declaredSymbTypeAttr: PTypeDecl => Type.DeclaredT =
+    attr(decl => Type.DeclaredT(decl, this))
+
   override def typ(id: PIdnNode): Type.Type = idType(id)
 
   override def scope(n: PIdnNode): PScope = enclosingIdScope(n)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/MemberResolution.scala
@@ -46,7 +46,12 @@ trait MemberResolution { this: TypeInfoImpl =>
 
   private val fieldSuffix: Type => AdvancedMemberSet[StructMember] = {
 
-    def go(pastDeref: Boolean): Type => AdvancedMemberSet[StructMember] = attr[Type, AdvancedMemberSet[StructMember]] {
+    // one attribute per `pastDeref` polarity such that the recursive calls share the attributes' caches
+    def go(pastDeref: Boolean): Type => AdvancedMemberSet[StructMember] = if (pastDeref) goPastDeref else goNoDeref
+    lazy val goNoDeref: Type => AdvancedMemberSet[StructMember] = mk(pastDeref = false)
+    lazy val goPastDeref: Type => AdvancedMemberSet[StructMember] = mk(pastDeref = true)
+
+    def mk(pastDeref: Boolean): Type => AdvancedMemberSet[StructMember] = attr[Type, AdvancedMemberSet[StructMember]] {
 
       case DeclaredT(decl, context) => go(pastDeref)(context.symbType(decl.right)).surface
       case PointerT(t) if !pastDeref => go(pastDeref = true)(t).ref
@@ -63,7 +68,7 @@ trait MemberResolution { this: TypeInfoImpl =>
 
   val structMemberSet: Type => AdvancedMemberSet[StructMember] =
     attr[Type, AdvancedMemberSet[StructMember]] {
-      case Single(t) => fieldSuffix(t) union pastPromotions(fieldSuffix)(t)
+      case Single(t) => fieldSuffix(t) union pastPromotedFields(t)
       case _ => AdvancedMemberSet.empty
     }
 
@@ -82,7 +87,12 @@ trait MemberResolution { this: TypeInfoImpl =>
     **/
   private val adtSuffix: Type => AdvancedMemberSet[AdtMember] = {
 
-    def go(pastDeref: Boolean): Type => AdvancedMemberSet[AdtMember] = attr[Type, AdvancedMemberSet[AdtMember]] {
+    // one attribute per `pastDeref` polarity such that the recursive calls share the attributes' caches
+    def go(pastDeref: Boolean): Type => AdvancedMemberSet[AdtMember] = if (pastDeref) goPastDeref else goNoDeref
+    lazy val goNoDeref: Type => AdvancedMemberSet[AdtMember] = mk(pastDeref = false)
+    lazy val goPastDeref: Type => AdvancedMemberSet[AdtMember] = mk(pastDeref = true)
+
+    def mk(pastDeref: Boolean): Type => AdvancedMemberSet[AdtMember] = attr[Type, AdvancedMemberSet[AdtMember]] {
 
       case DeclaredT(decl, context) => go(pastDeref)(context.symbType(decl.right)).surface
       case PointerT(t) if !pastDeref => go(pastDeref = true)(t).ref
@@ -101,43 +111,39 @@ trait MemberResolution { this: TypeInfoImpl =>
 
   lazy val adtMemberSet: Type => AdvancedMemberSet[AdtMember] =
     attr[Type, AdvancedMemberSet[AdtMember]] {
-      case Single(t) => adtSuffix(t) union pastPromotions(adtSuffix)(t)
+      case Single(t) => adtSuffix(t) union pastPromotedAdtMembers(t)
       case _ => AdvancedMemberSet.empty
     }
 
-  lazy val adtConstructorSet: Type => AdvancedMemberSet[AdtClause] = {
-
-    def constructorSuffix(t: Type): AdvancedMemberSet[AdtClause] = {
-      t match {
-        case t: AdtT =>
-          AdvancedMemberSet.init(
-            t.adtDecl.clauses.map { clause => AdtClause(clause, t.decl, t.context) }
-          )
-        case _ => AdvancedMemberSet.empty
-      }
+  private def adtConstructorSuffix(t: Type): AdvancedMemberSet[AdtClause] = {
+    t match {
+      case t: AdtT =>
+        AdvancedMemberSet.init(
+          t.adtDecl.clauses.map { clause => AdtClause(clause, t.decl, t.context) }
+        )
+      case _ => AdvancedMemberSet.empty
     }
+  }
 
+  lazy val adtConstructorSet: Type => AdvancedMemberSet[AdtClause] =
     attr[Type, AdvancedMemberSet[AdtClause]] {
-      case Single(t) => constructorSuffix(t) union pastPromotions(constructorSuffix)(t)
+      case Single(t) => adtConstructorSuffix(t) union pastPromotedAdtConstructors(t)
+      case _ => AdvancedMemberSet.empty
+    }
+
+  private def domainFunctionSuffix(t: Type): AdvancedMemberSet[DomainFunction] = {
+    t match {
+      case t: DomainT =>
+        AdvancedMemberSet.init(t.decl.funcs.map { f => DomainFunction(f, t.decl, t.context) })
       case _ => AdvancedMemberSet.empty
     }
   }
 
-  lazy val domainFunctionSet: Type => AdvancedMemberSet[DomainFunction] = {
-
-    def domainSuffix(t: Type): AdvancedMemberSet[DomainFunction] = {
-      t match {
-        case t: DomainT =>
-          AdvancedMemberSet.init(t.decl.funcs.map { f => DomainFunction(f, t.decl, t.context) })
-        case _ => AdvancedMemberSet.empty
-      }
-    }
-
+  lazy val domainFunctionSet: Type => AdvancedMemberSet[DomainFunction] =
     attr[Type, AdvancedMemberSet[DomainFunction]] {
-      case Single(t) => domainSuffix(t) union pastPromotions(domainSuffix)(t)
+      case Single(t) => domainFunctionSuffix(t) union pastPromotedDomainFunctions(t)
       case _ => AdvancedMemberSet.empty
     }
-  }
 
   // Methods
 
@@ -219,9 +225,14 @@ trait MemberResolution { this: TypeInfoImpl =>
 
   // Promotion
 
-  private def pastPromotions[M <: TypeMember](cont: Type => AdvancedMemberSet[M]): Type => AdvancedMemberSet[M] = {
+  private def makePastPromotions[M <: TypeMember](cont: Type => AdvancedMemberSet[M]): Type => AdvancedMemberSet[M] = {
 
-    def go(pastDeref: Boolean): Type => AdvancedMemberSet[M] = attr[Type, AdvancedMemberSet[M]] {
+    // one attribute per `pastDeref` polarity such that the recursive calls share the attributes' caches
+    def go(pastDeref: Boolean): Type => AdvancedMemberSet[M] = if (pastDeref) goPastDeref else goNoDeref
+    lazy val goNoDeref: Type => AdvancedMemberSet[M] = mk(pastDeref = false)
+    lazy val goPastDeref: Type => AdvancedMemberSet[M] = mk(pastDeref = true)
+
+    def mk(pastDeref: Boolean): Type => AdvancedMemberSet[M] = attr[Type, AdvancedMemberSet[M]] {
 
       case DeclaredT(decl, context) => go(pastDeref)(context.symbType(decl.right)).surface
       case PointerT(t) if !pastDeref => go(pastDeref = true)(t).ref
@@ -240,6 +251,13 @@ trait MemberResolution { this: TypeInfoImpl =>
     go(pastDeref = false)
   }
 
+  // one memoized promotion closure per continuation such that repeated evaluations share the caches
+  private lazy val pastPromotedFields: Type => AdvancedMemberSet[StructMember] = makePastPromotions(fieldSuffix)
+  private lazy val pastPromotedAdtMembers: Type => AdvancedMemberSet[AdtMember] = makePastPromotions(adtSuffix)
+  private lazy val pastPromotedAdtConstructors: Type => AdvancedMemberSet[AdtClause] = makePastPromotions(adtConstructorSuffix)
+  private lazy val pastPromotedDomainFunctions: Type => AdvancedMemberSet[DomainFunction] = makePastPromotions(domainFunctionSuffix)
+  private lazy val pastPromotedMethods: Type => AdvancedMemberSet[TypeMember] = makePastPromotions(pastPromotionsMethodSuffix)
+
   // Methodsets
 
   private val pastPromotionsMethodSuffix: Type => AdvancedMemberSet[TypeMember] =
@@ -253,7 +271,7 @@ trait MemberResolution { this: TypeInfoImpl =>
   val nonAddressableMethodSet: Type => AdvancedMemberSet[TypeMember] =
     attr[Type, AdvancedMemberSet[TypeMember]] {
       case Single(t) =>
-        pastPromotions(pastPromotionsMethodSuffix)(t) union (t match {
+        pastPromotedMethods(t) union (t match {
           case pt@ PointerT(st) => receiverSet(pt) union receiverSet(st).ref
           case _ => receiverSet(t)
         })
@@ -263,7 +281,7 @@ trait MemberResolution { this: TypeInfoImpl =>
   val addressableMethodSet: Type => AdvancedMemberSet[TypeMember] =
     attr[Type, AdvancedMemberSet[TypeMember]] {
       case Single(t) =>
-        pastPromotions(pastPromotionsMethodSuffix)(t) union (t match {
+        pastPromotedMethods(t) union (t match {
           case pt@ PointerT(st) => receiverSet(pt) union receiverSet(st).ref
           // we do not add `receiverSet(GhostPointerT(t)).deref` since this would result in implicitly assuming that the receiver points to the ghost heap, which is not guaranteed:
           case _ => receiverSet(t) union receiverSet(ActualPointerT(t)).deref

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/NameResolution.scala
@@ -425,7 +425,7 @@ trait NameResolution {
           (res, scope) match {
             case (None, int : PInterfaceType) =>
               try {
-                memberSet(InterfaceT(int, this)).lookup(n.name) // lookup in the embeddedFields
+                memberSet(interfaceSymbType(int)).lookup(n.name) // lookup in the embeddedFields
               }
               catch { // happens if we are in a cycle because of unknown interface members
                 case _ : IllegalStateException => None

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ExprTyping.scala
@@ -150,9 +150,7 @@ trait ExprTyping extends BaseTyping { this: TypeInfoImpl =>
         case Some(p: ap.Predicate) => FunctionT(p.symb.args map p.symb.context.typ, AssertionT)
         case Some(p: ap.DomainFunction) => FunctionT(p.symb.args map p.symb.context.typ, p.symb.context.typ(p.symb.result))
 
-        case Some(p: ap.AdtClause) =>
-          val fields = p.symb.fields.map(f => f.id.name -> p.symb.context.symbType(f.typ))
-          AdtClauseT(p.symb.getName, fields, p.symb.decl, p.symb.typeDecl, p.symb.context)
+        case Some(p: ap.AdtClause) => p.symb.context.adtClauseSymbType(p.symb.decl)
 
         case Some(p: ap.AdtField) =>
           p.symb match {

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
@@ -159,14 +159,12 @@ trait IdTyping extends BaseTyping { this: TypeInfoImpl =>
 
   lazy val idSymType: Typing[PIdnNode] = createTyping { id =>
     entity(id) match {
-      case NamedType(decl, _, context) => DeclaredT(decl, context)
+      case NamedType(decl, _, context) => context.declaredSymbType(decl)
       case TypeAlias(decl, _, context) => context.symbType(decl.right)
       case Import(decl, _) => ImportT(decl)
 
       // ADT clause is special since it is a type with a name that is not a named type
-      case a: AdtClause =>
-        val fields = a.fields.map(f => f.id.name -> a.context.symbType(f.typ))
-        AdtClauseT(a.getName, fields, a.decl, a.typeDecl, a.context)
+      case a: AdtClause => a.context.adtClauseSymbType(a.decl)
 
       case BuiltInType(tag, _, _) => tag.typ
       case _ => violation(s"expected type, but got $id")

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/TypeTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/TypeTyping.scala
@@ -66,7 +66,7 @@ trait TypeTyping extends BaseTyping { this: TypeInfoImpl =>
     case t: PInterfaceType =>
       val isRecursiveInterface = error(t, "invalid recursive interface", cyclicInterfaceDef(t))
       if (isRecursiveInterface.isEmpty) {
-        val methodSet = addressableMethodSet(InterfaceT(t, this))
+        val methodSet = addressableMethodSet(interfaceSymbType(t))
         val methodsContainMayInit = methodSet.exists {
           case (_, (m, _)) => m match {
             case m: SymbolTable.MethodSpec =>
@@ -113,10 +113,11 @@ trait TypeTyping extends BaseTyping { this: TypeInfoImpl =>
       firstGhostEmbedding.fold(noMessages)(error(_, "embeddings cannot be ghost in a non-ghost struct", !isGhost))
     }
 
+    val structT = structSymbType(t, isGhost = isGhost)
     t.embedded.flatMap(e => isNotPointerTypePE.errors(e.typ)(e)) ++
       noGhostEmbeddings ++
       t.fields.flatMap(f => isType(f.typ).out ++ isNotPointerTypeP.errors(f.typ)(f)) ++
-      structMemberSet(structSymbType(t, isGhost = isGhost)).errors(t) ++ addressableMethodSet(structSymbType(t, isGhost = isGhost)).errors(t) ++
+      structMemberSet(structT).errors(t) ++ addressableMethodSet(structT).errors(t) ++
       error(t, "invalid recursive struct", cyclicStructDef(t))
   }
 
@@ -192,10 +193,7 @@ trait TypeTyping extends BaseTyping { this: TypeInfoImpl =>
 
     case PFunctionType(args, r) => FunctionT(args map miscType, miscType(r))
 
-    case t: PInterfaceType =>
-      val res = InterfaceT(t, this)
-      addDemandedEmbeddedInterfaceImplements(res)
-      res
+    case t: PInterfaceType => interfaceSymbType(t)
 
     case n: PNamedOperand => idSymType(n.id)
 
@@ -208,18 +206,33 @@ trait TypeTyping extends BaseTyping { this: TypeInfoImpl =>
 
     case n: PDot =>
       resolve(n) match {
-        case Some(p: ap.NamedType) => DeclaredT(p.symb.decl, p.symb.context)
+        case Some(p: ap.NamedType) => p.symb.context.declaredSymbType(p.symb.decl)
 
         // ADT clause is special since it is a type with a name that is not a named type
-        case Some(p: ap.AdtClause) =>
-          val fields = p.symb.fields.map(f => f.id.name -> p.symb.context.symbType(f.typ))
-          AdtClauseT(p.symb.getName, fields, p.symb.decl, p.symb.typeDecl, p.symb.context)
+        case Some(p: ap.AdtClause) => p.symb.context.adtClauseSymbType(p.symb.decl)
 
         case p => violation(s"expected type, but got $n with resolved pattern $p")
       }
   }
 
-  private[typing] def structSymbType(t: PStructType, isGhost: Boolean): StructT = {
+  override def interfaceSymbType(t: PInterfaceType): InterfaceT = interfaceSymbTypeAttr(t)
+
+  /** Canonical [[InterfaceT]] per interface declaration. Not gated on well-definedness (in contrast
+    * to [[typeSymbType]]), so that well-definedness checks can obtain the canonical instance without
+    * creating attribute cycles. Memoization also guarantees that the embedded interfaces are
+    * registered exactly once.
+    **/
+  private lazy val interfaceSymbTypeAttr: PInterfaceType => InterfaceT =
+    attr { t =>
+      val res = InterfaceT(t, this)
+      addDemandedEmbeddedInterfaceImplements(res)
+      res
+    }
+
+  private[typing] def structSymbType(t: PStructType, isGhost: Boolean): StructT = structSymbTypeAttr(isGhost)(t)
+
+  /** Canonical [[StructT]] per struct declaration and ghostness. Not gated on well-definedness. */
+  private lazy val structSymbTypeAttr: Boolean => PStructType => StructT = paramAttr { isGhost => (t: PStructType) => {
     def infoFromFieldDecl(f: PFieldDecl, isFieldGhost: Boolean): StructFieldT = StructFieldT(typeSymbType(f.typ), isFieldGhost)
 
     def makeFields(x: PFieldDecls, areFieldsGhost: Boolean): ListMap[String, StructClauseT] = {
@@ -238,7 +251,7 @@ trait TypeTyping extends BaseTyping { this: TypeInfoImpl =>
       case (prev, PExplicitGhostStructClause(x: PEmbeddedDecl)) => prev ++ makeEmbedded(x, isEmbeddedGhost = true)
     }
     StructT(clauses, isGhost = isGhost, t, this)
-  }
+  }}
 
   /**
     * Checks whether a struct is cyclically defined in terms of itself (if its name is provided)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostIdTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostIdTyping.scala
@@ -45,9 +45,7 @@ trait GhostIdTyping { this: TypeInfoImpl =>
     case predicate: Predicate => FunctionT(predicate.args map predicate.context.typ, AssertionT)
     case func: DomainFunction => FunctionT(func.args map func.context.typ, func.context.typ(func.result.outs.head))
 
-    case c: AdtClause =>
-      val fields = c.fields.map(f => f.id.name -> c.context.symbType(f.typ))
-      AdtClauseT(c.getName, fields, c.decl, c.typeDecl, c.context)
+    case c: AdtClause => c.context.adtClauseSymbType(c.decl)
 
     case MatchVariable(decl, p, context) => p match {
       case PMatchAdt(clause, fields) =>

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
@@ -145,7 +145,7 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
     case _: SymbolTable.GhostStructMember => ???
     case dest: SymbolTable.AdtDestructor => dest.context.symbType(dest.decl.typ)
     case _: SymbolTable.AdtDiscriminator => BooleanT
-    case const: SymbolTable.AdtClause => DeclaredT(const.typeDecl, const.context)
+    case const: SymbolTable.AdtClause => const.context.declaredSymbType(const.typeDecl)
     case BuiltInMPredicate(tag, _, _) => typ(tag)
     case f: SymbolTable.DomainFunction => FunctionT(f.args map f.context.typ, f.context.typ(f.result))
   }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostTypeTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostTypeTyping.scala
@@ -57,17 +57,23 @@ trait GhostTypeTyping extends BaseTyping { this : TypeInfoImpl =>
     case PPredType(args) => PredT(args map typeSymbType)
   }
 
-  /** Requires that the parent of a is PTypeDef. */
-  private def adtSymbType(a: PAdtType): Type = {
-    a match {
-      case tree.parent(decl: PTypeDef) =>
-        val clauses = a.clauses.map { clause =>
-          val fields = clause.args.flatMap(_.fields.map(f => f.id.name -> typeSymbType(f.typ)))
-          AdtClauseT(clause.id.name, fields, clause, decl, this)
-        }
-        AdtT(clauses, decl, this)
-
-      case _ => Violation.violation(s"$a is not within a type declaration")
+  /** Canonical [[AdtT]] per ADT declaration. Requires that the parent of a is PTypeDef. */
+  private lazy val adtSymbType: PAdtType => Type =
+    attr {
+      case a@tree.parent(decl: PTypeDef) => AdtT(a.clauses.map(adtClauseSymbType), decl, this)
+      case a => Violation.violation(s"$a is not within a type declaration")
     }
-  }
+
+  override def adtClauseSymbType(clause: PAdtClause): AdtClauseT = adtClauseSymbTypeAttr(clause)
+
+  /** Canonical [[AdtClauseT]] per ADT clause declaration. Requires that the clause is part of an
+    * ADT declaration nested within a type definition.
+    **/
+  private lazy val adtClauseSymbTypeAttr: PAdtClause => AdtClauseT =
+    attr {
+      case clause@tree.parent(tree.parent.pair(_: PAdtType, decl: PTypeDef)) =>
+        val fields = clause.args.flatMap(_.fields.map(f => f.id.name -> typeSymbType(f.typ)))
+        AdtClauseT(clause.id.name, fields, clause, decl, this)
+      case clause => Violation.violation(s"$clause is not within a type declaration")
+    }
 }


### PR DESCRIPTION
Follow-up to the audit @jcp19 asked for in the review of #1054; implements the cache-canonicalization findings (companions: #1071, #1073).

## Background

Kiama's attribute caches are keyed on **reference identity** (weak identity maps), so a freshly constructed `Type` value never hits the cache of a memoized attribute — even when it is structurally equal to the canonical instance and carries the correct context. Several places in the type checker reconstructed `DeclaredT`/`InterfaceT`/`StructT`/`AdtT`/`AdtClauseT` by hand because there was no cycle-safe way to obtain the canonical instance during well-definedness checking: `symbType` is gated on well-definedness (`createTyping`), so calling it from within a `wellDef*` check of the same node creates an attribute cycle. Every such hand-rolled construction paid for the full member-set/underlying-type machinery again on a throwaway cache key — the same class of problem as the #1053 slowdown.

## Changes

**Canonical factories, not gated on well-definedness:**
- `declaredSymbType(PTypeDecl)`, `interfaceSymbType(PInterfaceType)`, `adtClauseSymbType(PAdtClause)` — new on `ExternalTypeInfo`, so other contexts obtain the owning context's canonical instances; memoized per declaration node.
- `structSymbType` (per struct declaration and ghostness) and `adtSymbType` are now memoized internally. `wellDefActualType`/`wellDefStructType`/`wellDefGhostType` previously computed full method sets on throwaway `InterfaceT`/`StructT`/`AdtT` instances once per declaration — the well-definedness check of every interface, struct, and ADT paid the member-set computation at least twice.
- `interfaceSymbType`'s memoization also guarantees the `addDemandedEmbeddedInterfaceImplements` registration fires exactly once per interface.

**Call sites switched to canonical instances** (each previously allocated a fresh type, defeating the identity-keyed caches):
- `NameResolution.symbTableLookup` level 2 — ran per identifier occurrence inside interface bodies and recomputed the interface's member set every time;
- `idSymType` / `actualTypeSymbType` (`PDot`) — one fresh `DeclaredT` per occurrence of a named type, including the qualified `pkg.T` path where cross-package cache reuse matters most;
- the four hand-rolled `AdtClauseT` reconstructions (`TypeTyping`, `IdTyping`, `ExprTyping`, `GhostIdTyping`) — also removes the need to keep four copies of the construction logic in sync;
- `GhostMiscTyping.ghostMemberType`, `Desugar.desugarAllTypeDefVariants`, `Desugar.adtSelectionD` (discriminator branch, now consistent with the destructor branch), `Desugar.domainFunctionProxy`;
- `MethodSpec`/`MPredicateSpec.itfType` is now a `lazy` alias of the canonical interface type instead of minting a second identity per interface (lazy, because the entities are created before typing).

**Memoization repair in `MemberResolution`:** `fieldSuffix`, `adtSuffix`, and the `pastPromotions` closures re-created their inner Kiama attributes on every call (and on every recursive `pastDeref` step), so those memo tables could never produce a hit and were pure allocation overhead. The attributes are now created once per continuation and `pastDeref` polarity (`pastPromotedFields`/`AdtMembers`/`AdtConstructors`/`DomainFunctions`/`Methods`) and shared across all call sites.

## Verification

- Full `sbt test`: failure set identical to the unmodified base on the same machine (Carbon-without-Boogie and local scratch files only); all tracked Silicon-based tests pass.
- Smoke-checked ADT- and interface-heavy examples end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)