### PR TITLE
Reports the Gobra commit in the CLI version output and bumps the copyright year to 2026

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,11 +120,8 @@ lazy val gobra = (project in file("."))
       "projectVersion" -> version.value,
       scalaVersion,
       sbtVersion,
-      BuildInfoKey.action("git") {
-        val revision = Try(Process("git rev-parse HEAD").!!.trim).getOrElse("<revision>")
-        val branch = Try(Process("git rev-parse --abbrev-ref HEAD").!!.trim).getOrElse("<branch>")
-        Map("revision" -> revision, "branch" -> branch)
-      }
+      BuildInfoKey.action("gitRevision")(Try(Process("git rev-parse HEAD").!!.trim).getOrElse("<revision>")),
+      BuildInfoKey.action("gitBranch")(Try(Process("git rev-parse --abbrev-ref HEAD").!!.trim).getOrElse("<branch>"))
     ),
     buildInfoPackage := "viper.gobra"
   )

--- a/build.sbt
+++ b/build.sbt
@@ -120,8 +120,8 @@ lazy val gobra = (project in file("."))
       "projectVersion" -> version.value,
       scalaVersion,
       sbtVersion,
-      BuildInfoKey.action("gitRevision")(Try(Process("git rev-parse HEAD").!!.trim).getOrElse("<revision>")),
-      BuildInfoKey.action("gitBranch")(Try(Process("git rev-parse --abbrev-ref HEAD").!!.trim).getOrElse("<branch>"))
+      BuildInfoKey.action("gitRevision")(Try(Process("git rev-parse HEAD", baseDirectory.value).!!.trim).getOrElse("<revision>")),
+      BuildInfoKey.action("gitBranch")(Try(Process("git rev-parse --abbrev-ref HEAD", baseDirectory.value).!!.trim).getOrElse("<branch>"))
     ),
     buildInfoPackage := "viper.gobra"
   )

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -25,7 +25,6 @@ import viper.gobra.reporting._
 import viper.gobra.translator.Translator
 import viper.gobra.util.Violation.{KnownZ3BugException, LogicException, UglyErrorMessage}
 import viper.gobra.util.{DefaultGobraExecutionContext, GobraExecutionContext}
-import viper.silicon.BuildInfo
 import viper.silver.{ast => vpr}
 
 import java.time.format.DateTimeFormatter
@@ -34,7 +33,7 @@ import scala.concurrent.{Await, Future, TimeoutException}
 
 object GoVerifier {
 
-  val copyright = "(c) Copyright ETH Zurich 2012 - 2024"
+  val copyright = "(c) Copyright ETH Zurich 2012 - 2026"
 
   val name = "Gobra"
 


### PR DESCRIPTION
## The problem

`gobra --version` previously reported **Silicon's** version and git revision: `Gobra.scala` imported `viper.silicon.BuildInfo`, although `build.sbt` already generates a `viper.gobra.BuildInfo` object containing Gobra's own revision — that generated object was never referenced anywhere. As a result, the CLI printed e.g. `1.1-SNAPSHOT (<silicon commit>@...)`, a commit that does not even exist in the Gobra repository, so there was no way to determine which Gobra commit a JAR was built from.

## The fix

- `build.sbt`: the map-valued `BuildInfoKey.action("git"){Map(...)}` is replaced by scalar `gitRevision`/`gitBranch` keys (same `Try(Process(...))` expressions), mirroring the field names of Silicon's `BuildInfo` API.
- `Gobra.scala`: the `viper.silicon.BuildInfo` import is removed, so the unqualified `BuildInfo` in `GoVerifier.version` resolves to the generated same-package `viper.gobra.BuildInfo`. Because the field names match, the `version` body is unchanged.
- The CLI copyright string is bumped to `(c) Copyright ETH Zurich 2012 - 2026` (source-file license headers untouched).

## Verification

`sbt "run --version"` prints:

```
Gobra (c) Copyright ETH Zurich 2012 - 2026
  version 0.1.0-SNAPSHOT (<gobra commit>@<branch>)
```

i.e., Gobra's own commit and branch (the `@<branch>` suffix is omitted on `master`, as before). `sbt compile` and `sbt assembly` both succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)