### PR TITLE
Handle Throwable errors in main exception handler

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -391,6 +391,13 @@ object GobraRunner extends GobraFrontend with StrictLogging {
         logger.error("An unknown Exception was thrown.")
         logger.error(e.getLocalizedMessage, e)
         exitCode = 1
+      // this case must be kept: `Error`s (e.g. `NoClassDefFoundError` or `ExceptionInInitializerError`) are not
+      // `Exception`s. Without it, such a throwable propagates out of the `try` while `sys.exit(exitCode)` in the
+      // `finally` block terminates the JVM with the still unmodified exit code 0 and without reporting anything.
+      case e: Throwable =>
+        logger.error(s"${verifier.name} terminated abnormally.")
+        logger.error(e.getLocalizedMessage, e)
+        exitCode = 1
     } finally {
       executor.terminate()
       sys.exit(exitCode)


### PR DESCRIPTION
## Summary
Adds a catch-all handler for `Throwable` errors (not just `Exception`s) in the main Gobra runner to ensure proper error reporting and exit code handling.

## Key Changes
- Added a new catch clause for `Throwable` in the exception handler of `GobraRunner.scala`
- This ensures that errors like `NoClassDefFoundError` and `ExceptionInInitializerError` are properly caught and logged instead of propagating uncaught
- Sets exit code to 1 and logs the error before the `finally` block executes `sys.exit(exitCode)`, preventing silent failures with exit code 0

## Implementation Details
The issue was that `Error` subclasses (which are `Throwable` but not `Exception`) would bypass the existing exception handler. Without catching them, such errors would propagate out of the try-catch block, and the `finally` block would then call `sys.exit(exitCode)` with the unmodified exit code of 0, masking the actual failure and providing no error output to the user.

The new catch clause for `Throwable` is placed after the `Exception` handler to maintain proper exception hierarchy handling, ensuring that specific `Exception` cases are handled first before falling back to the general `Throwable` case.

https://claude.ai/code/session_01TzJU4ijStAV7QecanFeVj2