### PR TITLE
Desugar map keys to the key type of the map

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -2481,6 +2481,26 @@ object Desugar extends LazyLogging {
       }
     }
 
+    /**
+      * Returns the type of the elements that `typ` is indexed with, i.e., the key type of a (mathematical) map.
+      * Returns None for all other types (in particular for types that are indexed with integers).
+      */
+    def indexType(typ: in.Type): Option[in.Type] = underlyingType(typ) match {
+      case t: in.MapT => Some(t.keys)
+      case t: in.MathMapT => Some(t.keys)
+      case _ => None
+    }
+
+    /** Returns the type of the elements contained in `typ`, if `typ` is a collection type. */
+    def elementType(typ: in.Type): Option[in.Type] = underlyingType(typ) match {
+      case t: in.SequenceT => Some(t.t)
+      case t: in.SetT => Some(t.t)
+      case t: in.MultisetT => Some(t.t)
+      case t: in.MapT => Some(t.keys)
+      case t: in.MathMapT => Some(t.keys)
+      case _ => None
+    }
+
     def singleAss(left: in.Assignee, right: in.Expr)(info: Source.Parser.Info): in.SingleAss = {
       in.SingleAss(left, implicitConversion(right.typ, left.op.typ, right))(info)
     }
@@ -2561,7 +2581,10 @@ object Desugar extends LazyLogging {
         dbase <- exprD(ctx, info)(base)
         dindex <- exprD(ctx, info)(index)
         baseUnderlyingType = underlyingType(dbase.typ)
-      } yield in.IndexedExp(dbase, dindex, baseUnderlyingType)(src)
+        // the index of a map may require an implicit conversion, e.g., when the key type of the map is an
+        // interface type and `index` has a concrete type
+        dkey = indexType(baseUnderlyingType).fold(dindex)(implicitConversion(dindex.typ, _, dindex))
+      } yield in.IndexedExp(dbase, dkey, baseUnderlyingType)(src)
     }
 
     def indexedExprD(expr : PIndexedExp)(ctx : FunctionContext, info : TypeInfo) : Writer[in.IndexedExp] =
@@ -3282,7 +3305,7 @@ object Desugar extends LazyLogging {
       sequence(
         lit.elems map {
           case PKeyedElement(Some(key), value) => for {
-            entryKey <- key match {
+            dKey <- key match {
               case v: PCompositeVal => compositeValD(ctx, info)(v, keys)
               case k: PIdentifierKey => info.regular(k.id) match {
                 case _: st.Variable => unit(varD(ctx, info)(k.id))
@@ -3290,6 +3313,9 @@ object Desugar extends LazyLogging {
                 case _ => violation(s"unexpected key $key")
               }
             }
+            // keys that are not composite values do not go through `compositeValD` and, thus, may still require
+            // an implicit conversion, e.g., when the key type is an interface type
+            entryKey = implicitConversion(dKey.typ, keys, dKey)
             entryVal <- compositeValD(ctx, info)(value, values)
           } yield (entryKey, entryVal)
 
@@ -4543,10 +4569,13 @@ object Desugar extends LazyLogging {
         case PElem(left, right) => for {
           dleft <- go(left)
           dright <- go(right)
+          // the left-hand side may require an implicit conversion, e.g., when the elements of the collection have
+          // an interface type and `left` has a concrete type
+          delem = elementType(dright.typ).fold(dleft)(implicitConversion(dleft.typ, _, dleft))
         } yield underlyingType(dright.typ) match {
-          case _: in.SequenceT | _: in.SetT => in.Contains(dleft, dright)(src)
-          case _: in.MultisetT => in.LessCmp(in.IntLit(0)(src), in.Contains(dleft, dright)(src))(src)
-          case _: in.MapT => in.Contains(dleft, dright)(src)
+          case _: in.SequenceT | _: in.SetT => in.Contains(delem, dright)(src)
+          case _: in.MultisetT => in.LessCmp(in.IntLit(0)(src), in.Contains(delem, dright)(src))(src)
+          case _: in.MapT => in.Contains(delem, dright)(src)
           case t => violation(s"expected a sequence or (multi)set type, but got $t")
         }
 

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -2482,23 +2482,37 @@ object Desugar extends LazyLogging {
     }
 
     /**
-      * Returns the type of the elements that `typ` is indexed with, i.e., the key type of a (mathematical) map.
-      * Returns None for all other types (in particular for types that are indexed with integers).
+      * Returns the type that an index of `typ` has, if `typ` can be indexed. The index type of a (mathematical) map
+      * is its key type; all other indexable types are indexed with integers.
       */
     def indexType(typ: in.Type): Option[in.Type] = underlyingType(typ) match {
       case t: in.MapT => Some(t.keys)
       case t: in.MathMapT => Some(t.keys)
+      case _: in.ArrayT | _: in.SliceT | _: in.SequenceT | _: in.StringT => Some(in.IntT(Addressability.rValue))
+      case in.PointerT(base, _) if underlyingType(base).isInstanceOf[in.ArrayT] => Some(in.IntT(Addressability.rValue))
       case _ => None
     }
 
     /** Returns the type of the elements contained in `typ`, if `typ` is a collection type. */
     def elementType(typ: in.Type): Option[in.Type] = underlyingType(typ) match {
+      case t: in.ArrayT => Some(t.elems)
+      case t: in.SliceT => Some(t.elems)
       case t: in.SequenceT => Some(t.t)
       case t: in.SetT => Some(t.t)
       case t: in.MultisetT => Some(t.t)
-      case t: in.MapT => Some(t.keys)
-      case t: in.MathMapT => Some(t.keys)
+      case t: in.MapT => Some(t.values)
+      case t: in.MathMapT => Some(t.values)
       case _ => None
+    }
+
+    /**
+      * Returns the type that the left-hand side of a membership expression `x elem c` must have, where `c` has type
+      * `typ`. Membership in a (mathematical) map ranges over its keys, whereas membership in any other collection
+      * ranges over its elements.
+      */
+    def membershipType(typ: in.Type): Option[in.Type] = underlyingType(typ) match {
+      case _: in.MapT | _: in.MathMapT => indexType(typ)
+      case t => elementType(t)
     }
 
     def singleAss(left: in.Assignee, right: in.Expr)(info: Source.Parser.Info): in.SingleAss = {
@@ -4571,7 +4585,7 @@ object Desugar extends LazyLogging {
           dright <- go(right)
           // the left-hand side may require an implicit conversion, e.g., when the elements of the collection have
           // an interface type and `left` has a concrete type
-          delem = elementType(dright.typ).fold(dleft)(implicitConversion(dleft.typ, _, dleft))
+          delem = membershipType(dright.typ).fold(dleft)(implicitConversion(dleft.typ, _, dleft))
         } yield underlyingType(dright.typ) match {
           case _: in.SequenceT | _: in.SetT => in.Contains(delem, dright)(src)
           case _: in.MultisetT => in.LessCmp(in.IntLit(0)(src), in.Contains(delem, dright)(src))(src)

--- a/src/test/resources/regressions/features/maps/maps-interface-key1.gobra
+++ b/src/test/resources/regressions/features/maps/maps-interface-key1.gobra
@@ -1,0 +1,110 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package mapsinterfacekey
+
+// Tests maps whose key type is an interface type. Keys with a concrete type must be implicitly
+// converted to the key type of the map, see https://github.com/viperproject/gobra/issues/1081.
+
+type Node interface {
+	pure
+	decreases
+	Pos() int
+}
+
+type BlockStmt struct {
+	list int
+}
+
+decreases
+pure func (b *BlockStmt) Pos() int {
+	return 0
+}
+
+type Metadata struct {
+	block int
+}
+
+// lookups with a key of a concrete type
+
+requires acc(m, _)
+func lookup1(m map[Node]*Metadata, b *BlockStmt) (md *Metadata, ok bool) {
+	md, ok = m[b]
+	return md, ok
+}
+
+requires acc(m, _)
+func lookup2(m map[Node]*Metadata, b *BlockStmt) *Metadata {
+	return m[b]
+}
+
+ghost
+requires acc(m, _)
+decreases
+pure func lookup3(m map[Node]*Metadata, b *BlockStmt) bool {
+	return b elem m
+}
+
+// a key of a concrete type denotes the same key as the corresponding interface value
+
+requires acc(m, _)
+func lookup4(m map[Node]*Metadata, b *BlockStmt) {
+	var n Node = b
+	assert (b elem m) == (n elem m)
+	assert m[b] == m[n]
+}
+
+// updates with a key of a concrete type
+
+requires acc(m)
+ensures acc(m)
+ensures b elem m && m[b] == md
+func update1(m map[Node]*Metadata, b *BlockStmt, md *Metadata) {
+	m[b] = md
+}
+
+requires acc(m)
+ensures acc(m)
+func update2(m map[Node]*Metadata, b *BlockStmt, md *Metadata) {
+	var n Node = b
+	m[b] = md
+	assert m[n] == md
+}
+
+// map literals with keys of a concrete type
+
+func lit1() {
+	b := &BlockStmt{}
+	md := &Metadata{}
+	m := map[Node]*Metadata{b: md}
+	assert b elem m
+	assert m[b] == md
+}
+
+func lit2() {
+	b := &BlockStmt{}
+	md := &Metadata{}
+	var n Node = b
+	m := map[Node]*Metadata{n: md}
+	assert b elem m
+	assert m[b] == md
+}
+
+// the same holds for mathematical maps
+
+ghost
+requires b elem domain(m)
+decreases
+pure func mathLookup(m dict[Node]*Metadata, b *BlockStmt) *Metadata {
+	return m[b]
+}
+
+ghost
+decreases
+func mathLookup2(m dict[Node]*Metadata, b *BlockStmt) {
+	var n Node = b
+	assert (b elem domain(m)) == (n elem domain(m))
+	if b elem domain(m) {
+		assert m[b] == m[n]
+	}
+}

--- a/src/test/resources/regressions/issues/001081.gobra
+++ b/src/test/resources/regressions/issues/001081.gobra
@@ -27,19 +27,19 @@ type Metadata struct {
 
 // lookups with a key of a concrete type
 
-requires acc(m, _)
+requires acc(m)
 func lookup1(m map[Node]*Metadata, b *BlockStmt) (md *Metadata, ok bool) {
 	md, ok = m[b]
 	return md, ok
 }
 
-requires acc(m, _)
+requires acc(m)
 func lookup2(m map[Node]*Metadata, b *BlockStmt) *Metadata {
 	return m[b]
 }
 
 ghost
-requires acc(m, _)
+requires acc(m)
 decreases
 pure func lookup3(m map[Node]*Metadata, b *BlockStmt) bool {
 	return b elem m
@@ -47,7 +47,7 @@ pure func lookup3(m map[Node]*Metadata, b *BlockStmt) bool {
 
 // a key of a concrete type denotes the same key as the corresponding interface value
 
-requires acc(m, _)
+requires acc(m)
 func lookup4(m map[Node]*Metadata, b *BlockStmt) {
 	var n Node = b
 	assert (b elem m) == (n elem m)


### PR DESCRIPTION
Fixes #1081.

## Problem

Gobra never inserted the implicit conversion to an interface type for a map key. When the key type of a map is an interface type and the key expression has a concrete type, the desugared program keeps the key at its concrete type, and the encoding then compares it against values of the encoded interface type. The resulting Viper program is ill-typed, and Silicon crashes with an internal `AssertionError` instead of verifying the program or reporting a verification error. Because the exception aborts the run, all remaining members are reported as "did not terminate".

Minimal reproduction (from #1081): a `map[Node]*Metadata` read with a `*BlockStmt` key gives

```
java.lang.AssertionError: assertion failed: Expected first operand b_V0@3@03 to be of sort Tuple2[Ref, Types], but found ShStruct1[Ref].
	at viper.silicon.state.terms.utils$.assertSort(Terms.scala:2594)
	at viper.silicon.state.terms.SetIn$.apply(Terms.scala:1843)
	at viper.silicon.rules.evaluator$.$anonfun$evalBinOp$1(Evaluator.scala:1207)
	...
```

`Tuple2[Ref, Types]` is the encoding of an interface value and `ShStruct1[Ref]` the encoding of `*BlockStmt`. The `SetIn` term comes from `MapEncoding`, which encodes `m[k]` as `[k] in domain([m].underlyingMapField) ? ... : [dflt]`: the domain of the underlying Viper map has interface-typed elements, while the encoded key has the type of the concrete key.

The crash only shows up once the caller has permission to the map, because otherwise the field read fails before the offending term is built — which matches the bisection reported in the issue.

## Changes

`Desugar` already has `implicitConversion`, which is applied to assignments, call arguments, return values and composite literal elements. This PR additionally applies it to:

* the index of a map index expression (`indexedExprD`), covering reads, comma-ok reads and map updates, for both `map` and `dict`;
* the left-hand side of a membership expression (`PElem`), covering `k elem m` as well as sequences, sets and multisets whose elements have an interface type;
* keys of map literals that are not composite values (`handleMapEntries`) — composite-value keys already went through `compositeValD`.

Two small helpers, `indexType` and `elementType`, return the relevant type of a collection. Where the target type is not an interface type, `implicitConversion` is the identity, so nothing changes for existing programs.

## Testing

* The reproduction from the issue no longer crashes; it now reports a regular verification error for the postcondition that does not hold. The crash reproduces on the parent commit with the exact stack trace above.
* New regression test `src/test/resources/regressions/issues/001081.gobra` covers lookups, comma-ok lookups, membership, updates and literals with keys of a concrete type, for both `map` and `dict`, and checks that a concrete key denotes the same key as the corresponding interface value.
* `testOnly viper.gobra.GobraTests` is green on CI for both commits of this PR.
