### PR TITLE
Fix crashes on comma-ok lookups and on comparing map lookups to nil (#893)

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -2103,13 +2103,30 @@ object Desugar extends LazyLogging {
             )
           )(src)
 
-        case l@ in.IndexedExp(base, _, _) if base.typ.isInstanceOf[in.MapT] && lefts.size == 2 =>
+        case l@ in.IndexedExp(_, _, _: in.MapT) if lefts.size == 2 =>
           val resTarget = freshExclusiveVar(lefts(0).op.typ.withAddressability(Addressability.exclusiveVariable), astCtx, info)(src)
           val successTarget = freshExclusiveVar(in.BoolT(Addressability.exclusiveVariable), astCtx, info)(src)
           in.Block(
             Vector(resTarget, successTarget),
             Vector(
               in.SafeMapLookup(resTarget, successTarget, l)(l.info),
+              singleAss(lefts(0), resTarget)(src),
+              singleAss(lefts(1), successTarget)(src)
+            )
+          )(src)
+
+        case l@ in.IndexedExp(base, idx, t: in.MathMapT) if lefts.size == 2 =>
+          // in contrast to a lookup in a map, a lookup in a mathematical map is only well-defined if the key is
+          // contained in the map. Thus, the zero value of the value type is assigned for keys that are not contained.
+          val resTarget = freshExclusiveVar(lefts(0).op.typ.withAddressability(Addressability.exclusiveVariable), astCtx, info)(src)
+          val successTarget = freshExclusiveVar(in.BoolT(Addressability.exclusiveVariable), astCtx, info)(src)
+          val contains = in.Contains(idx, in.MapKeys(base, t)(src))(src)
+          val lookup = in.Conditional(contains, l, in.DfltVal(l.typ)(src), l.typ)(src)
+          in.Block(
+            Vector(resTarget, successTarget),
+            Vector( // the results are computed before they are assigned because a target may occur in `l`
+              singleAss(in.Assignee.Var(resTarget), lookup)(src),
+              singleAss(in.Assignee.Var(successTarget), contains)(src),
               singleAss(lefts(0), resTarget)(src),
               singleAss(lefts(1), successTarget)(src)
             )

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -4511,15 +4511,21 @@ object Desugar extends LazyLogging {
             dIdx.res
           case rights => violation(s"expected the comma-ok form of a map lookup, but got $rights")
         }
-        // `ok` holds iff the key is contained in the map, which is exactly the condition under which the lookup
-        // returns the value stored in the map instead of the zero value of the map's value type
-        val contains = lookup.baseUnderlyingType match {
-          case _: in.MapT => in.Contains(lookup.index, lookup.base)(src)
-          case t: in.MathMapT => in.Contains(lookup.index, in.MapKeys(lookup.base, t)(src))(src)
+        // `ok` holds iff the key is contained in the map. If it is not, then the zero value of the map's value type
+        // is bound instead of the value stored in the map.
+        val (value, contains) = lookup.baseUnderlyingType match {
+          case _: in.MapT =>
+            // a lookup in a map already yields the zero value if the key is not contained in the map
+            (lookup, in.Contains(lookup.index, lookup.base)(src))
+          case t: in.MathMapT =>
+            // in contrast, a lookup in a mathematical map is only well-defined if the key is contained in the map
+            val contains = in.Contains(lookup.index, in.MapKeys(lookup.base, t)(src))(src)
+            val dflt = in.DfltVal(lookup.typ)(src)
+            (in.Conditional(contains, lookup, dflt, lookup.typ)(src), contains)
           case t => violation(s"expected a map type, but got $t")
         }
         Vector(
-          (binder(ass.left(0), lookup), lookup),
+          (binder(ass.left(0), value), value),
           (binder(ass.left(1), contains), contains)
         )
       }

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -4483,6 +4483,48 @@ object Desugar extends LazyLogging {
     }
 
     // Ghost Expression
+
+    /**
+      * Desugars the assignment of a let expression `let ass in ...` to the pairs of variables and the expressions
+      * that they are bound to, in the order in which they are introduced by `ass`.
+      * Besides the case where every variable on the left is bound to the expression at the same position on the
+      * right, the "comma-ok" form of map lookups is supported: `let v, ok := m[k] in ...` binds `v` to `m[k]` and
+      * `ok` to `k in m`. The type checker rejects all other assignments of a let expression.
+      */
+    def letBindingsD(ctx: FunctionContext, info: TypeInfo)(ass: PShortVarDecl)(src: Meta): Vector[(in.LocalVar, in.Expr)] = {
+      def binder(id: PUnkLikeId, right: in.Expr): in.LocalVar = in.LocalVar(
+        nm.variable(id.name, info.scope(id), info),
+        right.typ.withAddressability(Addressability.exclusiveVariable)
+      )(src)
+
+      if (ass.left.length == ass.right.length) {
+        (ass.left zip ass.right).map { case (id, exp) =>
+          val right = pureExprD(ctx, info)(exp)
+          (binder(id, right), right)
+        }
+      } else {
+        // the type checker guarantees that all remaining cases are of the form `v, ok := m[k]`
+        val lookup = ass.right match {
+          case Vector(idx: PIndexedExp) =>
+            val dIdx = indexedExprD(idx)(ctx, info)
+            Violation.violation(dIdx.stmts.isEmpty && dIdx.decls.isEmpty, s"expected pure expression, but got $idx")
+            dIdx.res
+          case rights => violation(s"expected the comma-ok form of a map lookup, but got $rights")
+        }
+        // `ok` holds iff the key is contained in the map, which is exactly the condition under which the lookup
+        // returns the value stored in the map instead of the zero value of the map's value type
+        val contains = lookup.baseUnderlyingType match {
+          case _: in.MapT => in.Contains(lookup.index, lookup.base)(src)
+          case t: in.MathMapT => in.Contains(lookup.index, in.MapKeys(lookup.base, t)(src))(src)
+          case t => violation(s"expected a map type, but got $t")
+        }
+        Vector(
+          (binder(ass.left(0), lookup), lookup),
+          (binder(ass.left(1), contains), contains)
+        )
+      }
+    }
+
     def ghostExprD(ctx: FunctionContext, info: TypeInfo)(expr: PGhostExpression): Writer[in.Expr] = {
 
       def go(e: PExpression): Writer[in.Expr] = exprD(ctx, info)(e)
@@ -4503,14 +4545,9 @@ object Desugar extends LazyLogging {
 
         case PLet(ass, op) =>
           val dOp = pureExprD(ctx, info)(op)
-          unit((ass.left zip ass.right).foldRight(dOp)((lr, letop) => {
-            val right = pureExprD(ctx, info)(lr._2)
-            val left = in.LocalVar(
-              nm.variable(lr._1.name, info.scope(lr._1), info),
-              right.typ.withAddressability(Addressability.exclusiveVariable)
-            )(src)
+          unit(letBindingsD(ctx, info)(ass)(src).foldRight(dOp) { case ((left, right), letop) =>
             in.PureLet(left, right, letop)(src)
-          }))
+          })
 
         case PForall(vars, triggers, body) =>
           for { (newVars, newTriggers, newBody) <- quantifierD(ctx, info)(vars, triggers, body)(ctx => exprD(ctx, info)) }
@@ -4796,14 +4833,9 @@ object Desugar extends LazyLogging {
         case PLet(ass, op) =>
           for {
             dOp <- assertionD(ctx, info)(op)
-            lets = (ass.left zip ass.right).foldRight(dOp)((lr, letop) => {
-              val right = pureExprD(ctx, info)(lr._2)
-              val left = in.LocalVar(
-                nm.variable(lr._1.name, info.scope(lr._1), info),
-                right.typ.withAddressability(Addressability.exclusiveVariable)
-              )(src)
+            lets = letBindingsD(ctx, info)(ass)(src).foldRight(dOp) { case ((left, right), letop) =>
               in.Let(left, right, letop)(src)
-            })
+            }
           } yield lets
 
         case m: PMatchExp =>

--- a/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/resolution/Enclosing.scala
@@ -150,6 +150,15 @@ trait Enclosing { this: TypeInfoImpl =>
     }}
 
 
+  /**
+    * Returns the type that an occurrence of `nil` gets from being compared to the operand `n`, if any.
+    * The type of `n` is projected to its single-valued type because expressions such as map lookups,
+    * type assertions, and receives are typed as [[Type.InternalSingleMulti]], i.e., their type depends on the
+    * context in which they occur. Only the single-valued type is relevant in a comparison.
+    */
+  private def typeOfComparedOperand(n: PExpressionOrType): Option[Type] =
+    Type.Single.unapply(exprOrTypeType(n)).filter(_ != Type.NilType)
+
   def nilType(nil: PNilLit): Option[Type] = {
 
     @tailrec
@@ -192,10 +201,10 @@ trait Enclosing { this: TypeInfoImpl =>
             // no reference
             // no deref
             // no negation
-          case PEquals(`n`, r) => val t = exprOrTypeType(r); if (t == Type.NilType) None else Some(t)
-          case PEquals(l, `n`) => val t = exprOrTypeType(l); if (t == Type.NilType) None else Some(t)
-          case PUnequals(`n`, r) => val t = exprOrTypeType(r); if (t == Type.NilType) None else Some(t)
-          case PUnequals(l, `n`) => val t = exprOrTypeType(l); if (t == Type.NilType) None else Some(t)
+          case PEquals(`n`, r) => typeOfComparedOperand(r)
+          case PEquals(l, `n`) => typeOfComparedOperand(l)
+          case PUnequals(`n`, r) => typeOfComparedOperand(r)
+          case PUnequals(l, `n`) => typeOfComparedOperand(l)
             // no and, or, less, at most, greater, at least, add, sub, mul, mod, div
           case p: PUnfolding => aux(p)
           case p: PAsserting => aux(p)
@@ -206,7 +215,7 @@ trait Enclosing { this: TypeInfoImpl =>
           case p: POld => aux(p)
           case p: PLabeledOld => aux(p)
           case p: PBefore => aux(p)
-          case p: PConditional => val t = typ(p); if (t == Type.NilType) None else Some(t)
+          case p: PConditional => typeOfComparedOperand(p)
             // no implication, access
             // no forall or exists body
           case PElem(`n`, s) => Some(typ(s).asInstanceOf[Type.GhostCollectionType].elem)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostExprTyping.scala
@@ -15,6 +15,7 @@ import viper.gobra.frontend.{Config, Hyper}
 import viper.gobra.frontend.info.base.Type
 import viper.gobra.frontend.info.base.Type._
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
+import viper.gobra.frontend.info.implementation.property.{AssignMode, StrictAssignMode}
 import viper.gobra.frontend.info.implementation.typing.BaseTyping
 import viper.gobra.util.Violation.violation
 
@@ -85,7 +86,8 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
     case n: PClosureImplements => isPureExpr(n.closure) ++ wellDefIfClosureMatchesSpec(n.closure, n.spec)
 
     case n: PLet => isExpr(n.op).out ++ isWeaklyPureExpr(n.op) ++
-      n.ass.right.foldLeft(noMessages)((a, b) => a ++ isPureExpr(b))
+      n.ass.right.foldLeft(noMessages)((a, b) => a ++ isPureExpr(b)) ++
+      supportedLetAssignment(n.ass)
 
     case n: PAccess =>
       val mayInit = isEnclosingMayInit(n)
@@ -248,6 +250,26 @@ trait GhostExprTyping extends BaseTyping { this: TypeInfoImpl =>
       case PWildcardPerm() => noMessages
       case PNoPerm() => noMessages
     }
+  }
+
+  /**
+    * Checks that the assignment of a let expression is supported. Besides binding every variable on the left to the
+    * expression at the same position on the right, only the "comma-ok" form of map lookups, e.g. `let v, ok := m[k]`,
+    * is supported. In particular, binding the results of a call to a function with multiple results is not supported.
+    */
+  private def supportedLetAssignment(ass: PShortVarDecl): Messages = {
+    lazy val isCommaOkMapLookup = ass.left.length == 2 && (ass.right match {
+      case Vector(idx: PIndexedExp) => underlyingType(exprType(idx.base)) match {
+        case _: MapT | _: MathMapT => true
+        case _ => false
+      }
+      case _ => false
+    })
+    error(
+      ass,
+      s"expected either as many expressions as variables or a map lookup of the form 'v, ok := m[k]', but got $ass",
+      StrictAssignMode(ass.left.length, ass.right.length) != AssignMode.Single && !isCommaOkMapLookup
+    )
   }
 
   private[typing] def wellDefMapUpdClause(keys: Type, values : Type, clause : PGhostCollectionUpdateClause, mayInit: Boolean) : Messages = {

--- a/src/test/resources/regressions/features/let/let_fail2.gobra
+++ b/src/test/resources/regressions/features/let/let_fail2.gobra
@@ -1,0 +1,19 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+ghost
+pure func f1(x interface{}) bool {
+	// the "comma-ok" form is only supported for map lookups
+	//:: ExpectedOutput(type_error)
+	return let v, ok := x.(int) in ok
+}
+
+ghost
+requires acc(m, _)
+pure func f2(m map[int]int) int {
+	// the "comma-ok" form of a map lookup binds exactly two variables
+	//:: ExpectedOutput(type_error)
+	return let x, y, z := m[0] in x
+}

--- a/src/test/resources/regressions/features/let/let_fail2.gobra
+++ b/src/test/resources/regressions/features/let/let_fail2.gobra
@@ -5,7 +5,7 @@ package pkg
 
 ghost
 pure func f1(x interface{}) bool {
-	// the "comma-ok" form is only supported for map lookups
+	// the "comma-ok" form is only supported for map lookups for now
 	//:: ExpectedOutput(type_error)
 	return let v, ok := x.(int) in ok
 }

--- a/src/test/resources/regressions/features/maps/maps-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/maps-simple1.gobra
@@ -154,3 +154,17 @@ func test18(m map[string]*int) {}
 requires m != nil ==> acc(m)
 requires forall i int :: { i elem range(m) } i elem range(m) ==> 0 < i
 func test19(m map[string]int) {}
+
+type intMap map[int]int
+
+// the "comma-ok" form of a lookup is also supported for declared map types
+func test20() {
+	m := make(intMap)
+	m[3] = 10
+
+	v1, ok1 := m[3]
+	assert ok1 && v1 == 10
+
+	v2, ok2 := m[4]
+	assert !ok2 && v2 == 0
+}

--- a/src/test/resources/regressions/features/maps/math-maps-simple1.gobra
+++ b/src/test/resources/regressions/features/maps/math-maps-simple1.gobra
@@ -43,3 +43,21 @@ func test2(m map[int]int) {
 	assert 5 elem domain(y)
 	assert !(8 elem domain(m))
 }
+
+// tests the "comma-ok" form of a lookup, which yields the zero value of the
+// value type for keys that are not contained in the mathematical map
+ghost
+func test3() {
+	m := dict[int]int{ 1: 5 }
+
+	v1, ok1 := m[1]
+	assert ok1 && v1 == 5
+
+	v2, ok2 := m[0]
+	assert !ok2 && v2 == 0
+
+	// the results are computed before they are assigned
+	k := 1
+	k, ok3 := m[k]
+	assert ok3 && k == 5
+}

--- a/src/test/resources/regressions/issues/000893.gobra
+++ b/src/test/resources/regressions/issues/000893.gobra
@@ -1,0 +1,97 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package issue000893
+
+// Test 1: the "comma-ok" form of a map lookup can be used in a let expression
+
+ghost
+requires acc(m, _)
+ensures res == (0 elem m)
+pure func test1(m map[int]int) (res bool) {
+	return let v, ok := m[0] in ok
+}
+
+ghost
+requires acc(m, _)
+requires 0 elem m
+ensures res == m[0]
+pure func test2(m map[int]int) (res int) {
+	return let v, ok := m[0] in v
+}
+
+ghost
+requires acc(m, _)
+ensures res == (0 elem m && m[0] == 42)
+pure func test3(m map[int]int) (res bool) {
+	return let v, ok := m[0] in ok && v == 42
+}
+
+// looking up a key in a nil map never succeeds and returns the zero value
+func test4() {
+	var m map[int]int
+	assert m == nil
+	assert !(let v, ok := m[0] in ok)
+	assert (let v, ok := m[0] in v) == 0
+}
+
+// the "comma-ok" form of a map lookup can also be used in assertions
+
+requires acc(m)
+requires let v, ok := m[0] in ok && v == 42
+func test5(m map[int]int) {
+	assert 0 elem m
+	assert m[0] == 42
+}
+
+requires acc(m)
+requires let x, ok := m[0] in ok
+ensures res
+func test6(m map[int]int) (res bool) {
+	_, ok := m[0]
+	return ok
+}
+
+// the same holds for mathematical maps, for which lookups are only well-defined
+// if the key is contained in the domain of the map
+
+ghost
+requires 0 elem domain(d)
+ensures res
+pure func test7(d dict[int]int) (res bool) {
+	return let v, ok := d[0] in ok
+}
+
+ghost
+requires 0 elem domain(d)
+ensures res == d[0]
+pure func test8(d dict[int]int) (res int) {
+	return let v, ok := d[0] in v
+}
+
+// Test 2: the result of a map lookup can be compared to nil
+
+requires acc(m)
+requires 0 elem m ==> m[0] != nil
+func test9(m map[int]*int) {
+	assert 0 elem m ==> m[0] != nil
+}
+
+requires acc(m)
+requires 0 elem m ==> nil == m[0]
+func test10(m map[int]*int) {
+	assert 0 elem m ==> m[0] == nil
+}
+
+requires acc(m)
+requires 0 elem m ==> m[0] != nil
+func test11(m map[int][]int) {
+	assert 0 elem m ==> m[0] != nil
+}
+
+ghost
+requires 0 elem domain(d)
+ensures res == (d[0] == nil)
+pure func test12(d dict[int]*int) (res bool) {
+	return d[0] == nil
+}

--- a/src/test/resources/regressions/issues/000893.gobra
+++ b/src/test/resources/regressions/issues/000893.gobra
@@ -52,19 +52,18 @@ func test6(m map[int]int) (res bool) {
 	return ok
 }
 
-// the same holds for mathematical maps, for which lookups are only well-defined
-// if the key is contained in the domain of the map
+// the same holds for mathematical maps, for which the zero value of the value
+// type is bound if the key is not contained in the domain of the map
 
 ghost
-requires 0 elem domain(d)
-ensures res
+ensures res == (0 elem domain(d))
 pure func test7(d dict[int]int) (res bool) {
 	return let v, ok := d[0] in ok
 }
 
 ghost
-requires 0 elem domain(d)
-ensures res == d[0]
+ensures 0 elem domain(d) ==> res == d[0]
+ensures !(0 elem domain(d)) ==> res == 0
 pure func test8(d dict[int]int) (res int) {
 	return let v, ok := d[0] in v
 }
@@ -94,4 +93,10 @@ requires 0 elem domain(d)
 ensures res == (d[0] == nil)
 pure func test12(d dict[int]*int) (res bool) {
 	return d[0] == nil
+}
+
+func test13() {
+	d := dict[int]int{1: 5}
+	assert let v, ok := d[1] in ok && v == 5
+	assert let v, ok := d[0] in !ok && v == 0
 }


### PR DESCRIPTION
Fixes both crashes reported in #893, plus two closely related crashes on the "comma-ok" form of a lookup that surfaced while fixing them.

## 1. `let v, ok := m[k] in ...` crashed with `key not found: ok_V1`

A map lookup is typed as `InternalSingleMulti(elem, (elem, bool))`, so the type checker accepts the "comma-ok" form of a short variable declaration inside a `let`, and gives `ok` type `bool`. The desugarer, however, only implemented the single-assignment form: both `PLet` cases zipped `ass.left` with `ass.right`, which silently truncates `[v, ok]` against `[m[0]]`. `ok` was therefore never bound, `varD` fell through to `localVarContextFreeD`, and the free variable `ok_V1` ended up in the Viper expression, where the backend failed to look it up.

`let v, ok := m[k] in ...` now binds `ok` to `k in m` and `v` to the value stored in the map, or to the zero value of the map's value type if the key is not contained in the map. Mathematical maps are handled as well: since a lookup in a mathematical map is only well-defined for keys in its domain, `v` is bound to `k in domain(d) ? d[k] : dflt`, which gives the same behavior as for maps.

The remaining unsupported assignments of a `let` — binding the results of a multi-valued expression, e.g. `let v, ok := x.(T) in ...` — crashed the same way. They are now reported as type errors instead.

## 2. `m[k] != nil` crashed with `got unexpected type InternalSingleMulti(...)`

`nilType` derives the type of an untyped `nil` from the other operand of the comparison and used its raw type. For a map lookup that is `InternalSingleMulti`, which `litD` passed on to `typeD`, hitting its catch-all violation. The trigger is the `nil` literal rather than the pointer element type of the map, so the crash also occurred for maps of slices, interfaces, funcs, ..., and for the other expressions typed as `InternalSingleMulti`: type assertions and receives.

`nilType` now projects the type of the compared operand to its single-valued type, which matches the workaround of first binding the lookup to a `let` variable.

## 3. `v, ok := d[k]` and `v, ok := m[k]` on a declared type crashed the desugarer

Not reported in #893, but the same family of bugs, in the statement counterpart of 1.: `multiassD` only handled lookups whose base has type `in.MapT`, so everything else fell through to `Violation.violation("Multi assignment of ... is not supported")`.

- Lookups in mathematical maps are now supported, with the same semantics as the corresponding `let` expression.
- The case for maps now matches on the underlying type of the base expression, which fixes the crash for lookups in a declared map type such as `type intMap map[int]int`. The encoding already unfolds declared types, so no change was needed there.

Both cases compute the results into temporaries before assigning them, since a target may occur in the lookup, e.g. `k, ok := m[k]`.

## Testing

- `src/test/resources/regressions/issues/000893.gobra` covers the "comma-ok" form of map and `dict` lookups in pure functions and in assertions (including lookups of keys that are not contained in the map, and of a key of a nil map), and comparisons of map lookups against `nil` for maps of pointers, maps of slices, and dictionaries.
- `src/test/resources/regressions/features/let/let_fail2.gobra` covers the assignments of a `let` that are rejected by the type checker.
- `features/maps/math-maps-simple1.gobra` and `features/maps/maps-simple1.gobra` cover the statement form for mathematical maps and for declared map types.
- `sbt "testOnly viper.gobra.GobraTests"`: 1184 passed; the only 2 failures are `features/backends/carbon.gobra` and `features/backends/vs-with-carbon.gobra`, which fail because Boogie is not installed in the environment the tests were run in.