### PR TITLE
Fix nil intf receiver for mpred

### DIFF
--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostStmtTyping.scala
@@ -54,7 +54,11 @@ trait GhostStmtTyping extends BaseTyping { this: TypeInfoImpl =>
       case fp: st.FPredicate => fp.decl.body.isEmpty
       case mp: st.MPredicateImpl => mp.decl.body.isEmpty
       case _: st.MPredicateSpec =>
-        // counter-intuitive: interface well-definedness will make sure that implementations implement the declared predicates
+        // While the predicate declaration in an interface has no body, folding its instances is
+        // permitted: the fold resolves the body via the receiver's dynamic type, over which the
+        // encoding dispatches to the statically known implementations of the interface. Folding
+        // fails at verification time if the dynamic type cannot be resolved to a known
+        // implementation, e.g., for a nil receiver.
         false
     }
 

--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
@@ -621,12 +621,13 @@ class InterfaceEncoding extends LeafTypeEncoding {
       // which, e.g., cannot be folded without rendering the Viper program inconsistent:
       val implementedItfs = implementedItfNodes.map(_._2.withAddressability(Addressability.Exclusive))
       val unimplementedItfNodes = for {
-        m <- ctx.table.getMPredicates.toSet[in.MPredicateLikeMember].collect{ case m: in.MPredicate => m }
-        itf <- m.receiver.typ match {
-          case itf: in.InterfaceT if !implementedItfs.contains(itf.withAddressability(Addressability.Exclusive)) =>
-            Set(itf.withAddressability(Addressability.Exclusive))
-          case _ => Set.empty[in.InterfaceT]
-        }
+        (m, itf) <- ctx.table.getMPredicates.toSet[in.MPredicateLikeMember]
+          .collect{ case m: in.MPredicate => m }
+          // restrict the predicates to those that have an unimplemented interface receiver:
+          .collect{ m => m.receiver.typ match {
+            case itf: in.InterfaceT if !implementedItfs.contains(itf.withAddressability(Addressability.Exclusive)) =>
+              (m, itf.withAddressability(Addressability.Exclusive))
+          }}
       } yield (m.name, itf, SortedSet.empty[in.Type])
 
       val itfNodes = implementedItfNodes ++ unimplementedItfNodes

--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
@@ -622,12 +622,10 @@ class InterfaceEncoding extends LeafTypeEncoding {
       val implementedItfs = implementedItfNodes.map(_._2.withAddressability(Addressability.Exclusive))
       val unimplementedItfNodes = for {
         (m, itf) <- ctx.table.getMPredicates.toSet[in.MPredicateLikeMember]
-          .collect{ case m: in.MPredicate => m }
           // restrict the predicates to those that have an unimplemented interface receiver:
-          .collect{ m => m.receiver.typ match {
-            case itf: in.InterfaceT if !implementedItfs.contains(itf.withAddressability(Addressability.Exclusive)) =>
-              (m, itf.withAddressability(Addressability.Exclusive))
-          }}
+          .collect{ case m@in.MPredicate(in.Parameter.In(_, itf: in.InterfaceT), _, _, _) if !implementedItfs.contains(itf.withAddressability(Addressability.Exclusive)) =>
+            (m, itf.withAddressability(Addressability.Exclusive))
+          }
       } yield (m.name, itf, SortedSet.empty[in.Type])
 
       val itfNodes = implementedItfNodes ++ unimplementedItfNodes

--- a/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/interfaces/InterfaceEncoding.scala
@@ -610,10 +610,26 @@ class InterfaceEncoding extends LeafTypeEncoding {
     predicateFamilyTupleRes.getOrElse{
       implicit val tuple3Ordering: Ordering[(in.MPredicateProxy, in.InterfaceT, SortedSet[in.Type])] = Ordering.by(_._1)
 
-      val itfNodes = for {
+      val implementedItfNodes = for {
         (itf, impls) <- ctx.table.getImplementations.toSet
         itfProxy <- ctx.table.lookupMembers(itf).collect{ case m: in.MPredicateProxy => m }
       } yield (itfProxy, itf, impls)
+
+      // predicates of interfaces without any known implementation form a singleton family such
+      // that their instances are also encoded via the (dispatching) family predicate. Otherwise,
+      // such instances would refer to the abstract predicate emitted for the interface member,
+      // which, e.g., cannot be folded without rendering the Viper program inconsistent:
+      val implementedItfs = implementedItfNodes.map(_._2.withAddressability(Addressability.Exclusive))
+      val unimplementedItfNodes = for {
+        m <- ctx.table.getMPredicates.toSet[in.MPredicateLikeMember].collect{ case m: in.MPredicate => m }
+        itf <- m.receiver.typ match {
+          case itf: in.InterfaceT if !implementedItfs.contains(itf.withAddressability(Addressability.Exclusive)) =>
+            Set(itf.withAddressability(Addressability.Exclusive))
+          case _ => Set.empty[in.InterfaceT]
+        }
+      } yield (m.name, itf, SortedSet.empty[in.Type])
+
+      val itfNodes = implementedItfNodes ++ unimplementedItfNodes
 
       val edges = for {
         (itfProxy, itf, impls) <- itfNodes

--- a/src/main/scala/viper/gobra/util/Algorithms.scala
+++ b/src/main/scala/viper/gobra/util/Algorithms.scala
@@ -43,7 +43,7 @@ object Algorithms {
         case (node, id) :: stack =>
           if (ids(node) >= 0) dfs(stack, ids)
           else {
-            val newStack = graph(node).foldLeft(stack){ case (st, x) => (x, id) :: st }
+            val newStack = graph.getOrElse(node, Set.empty).foldLeft(stack){ case (st, x) => (x, id) :: st }
             val newIds = ids.updated(node, id)
             dfs(newStack, newIds)
           }

--- a/src/test/resources/regressions/features/predicates/mpredicates-nil-receiver.gobra
+++ b/src/test/resources/regressions/features/predicates/mpredicates-nil-receiver.gobra
@@ -1,0 +1,101 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+// tests how mpredicates with `nil` receivers behave.
+
+package pkg
+
+type cell struct {
+	val int
+}
+
+// mpredicate with a pointer receiver whose body guards the dereference:
+pred (c *cell) optMem() {
+	c != nil ==> acc(&c.val)
+}
+
+// analogous to methods, an mpredicate instance with a nil receiver of a
+// pointer type is well-defined:
+func foldWithNilReceiver() {
+	var c *cell = nil
+	fold c.optMem()
+	assert c.optMem()
+	unfold c.optMem()
+}
+
+// mpredicate whose body dereferences the receiver unconditionally:
+pred (c *cell) mem() {
+	acc(&c.val)
+}
+
+// the instance is still well-defined for a nil receiver, but its body
+// cannot be established:
+func foldStrictWithNilReceiver() {
+	var c *cell = nil
+	//:: ExpectedOutput(fold_error:permission_error)
+	fold c.mem()
+}
+
+requires c.optMem()
+func consumeCellOptMem(c *cell) {
+}
+
+// an mpredicate instance with a nil receiver can be held and passed around
+// like any other instance:
+func callWithNilReceiver() {
+	var c *cell = nil
+	fold c.optMem()
+	consumeCellOptMem(c)
+}
+
+type intf interface {
+	pred mem()
+
+	requires mem()
+	foo()
+}
+
+type impl struct{}
+
+pred (i *impl) mem() {
+	true
+}
+
+requires i.mem()
+func (i *impl) foo() {
+}
+*impl implements intf
+
+requires i.mem()
+func consumeInterfaceMem(i intf) {
+}
+
+// a nil interface value must not be usable as the receiver of an interface
+// mpredicate instance:
+func callWithNilInterface() {
+	var i intf = nil
+	//:: ExpectedOutput(precondition_error:permission_error)
+	consumeInterfaceMem(i)
+}
+
+// folding an interface mpredicate requires establishing the predicate of the
+// receiver's dynamic type; for a nil interface value, this fails:
+func foldWithNilInterface() {
+	var i intf = nil
+	//:: ExpectedOutput(fold_error:permission_error)
+	fold i.mem()
+}
+
+func foldWithNonNilInterface() {
+	var i intf = &impl{}
+	fold i.mem() // succeeds
+	i.foo()
+}
+
+// calling a method on a nil interface value panics in Go (independently
+// of the callee's precondition):
+requires i.mem() // `i` might be nil
+func callMethodOnNilInterface(i intf) {
+	//:: ExpectedOutput(precondition_error:receiver_is_nil_error)
+	i.foo()
+}


### PR DESCRIPTION
Experimenting with nil mpred receivers revealed a bug where Gobra reports a Violation if there are no implementations for an interface and a nil receiver of this interface is used to fold a predicate.
While Gobra supports folding a predicate using an interface receiver, the encoding branches over the interface's implementation to perform the fold according to the dynamic type. However, if there are no implementations, Gobra uses an abstract predicate instead, whose fold operation fails. This PR changes Gobra to emit empty predicate families for interfaces without any implementations. Thus, the interface predicate will be non-abstract, branch over the empty set of implementations, and, thus, land in the unknown case which results in a fold error.