### PR TITLE
Checks non-nilness when indexing a pointer to an array

### DIFF
--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -2611,11 +2611,19 @@ object Desugar extends LazyLogging {
       for {
         dbase <- exprD(ctx, info)(base)
         dindex <- exprD(ctx, info)(index)
-        baseUnderlyingType = underlyingType(dbase.typ)
+        // indexing a pointer to an array implicitly dereferences the pointer, i.e., `p[i]` is
+        // shorthand for `(*p)[i]`. The dereference is made explicit such that all further
+        // processing can uniformly treat the base as an array:
+        derefBase = underlyingType(dbase.typ) match {
+          case t@ in.PointerT(elem, _) if underlyingType(elem).isInstanceOf[in.ArrayT] =>
+            in.Deref(dbase, t)(src)
+          case _ => dbase
+        }
+        baseUnderlyingType = underlyingType(derefBase.typ)
         // the index of a map may require an implicit conversion, e.g., when the key type of the map is an
         // interface type and `index` has a concrete type
         dkey = indexType(baseUnderlyingType).fold(dindex)(implicitConversion(dindex.typ, _, dindex))
-      } yield in.IndexedExp(dbase, dkey, baseUnderlyingType)(src)
+      } yield in.IndexedExp(derefBase, dkey, baseUnderlyingType)(src)
     }
 
     def indexedExprD(expr : PIndexedExp)(ctx : FunctionContext, info : TypeInfo) : Writer[in.IndexedExp] =
@@ -2891,11 +2899,18 @@ object Desugar extends LazyLogging {
                 in.SequenceTake(drop, sub)(src)
             }
             case baseT @ (_: in.ArrayT | _: in.SliceT | in.PointerT(_: in.ArrayT, _)) =>
+              // slicing a pointer to an array implicitly dereferences the pointer, i.e., `p[i:j]`
+              // is shorthand for `(*p)[i:j]`. The dereference is made explicit such that all
+              // further processing can uniformly treat the base as an array:
+              val (derefBase, derefBaseT) = baseT match {
+                case t@ in.PointerT(elem, _) => (in.Deref(dbase, t)(src), underlyingType(elem))
+                case t => (dbase, t)
+              }
               (dlow, dhigh) match {
-                case (None, None) => in.Slice(dbase, in.IntLit(0)(src), in.Length(dbase)(src), dcap, baseT)(src)
-                case (Some(lo), None) => in.Slice(dbase, lo, in.Length(dbase)(src), dcap, baseT)(src)
-                case (None, Some(hi)) => in.Slice(dbase, in.IntLit(0)(src), hi, dcap, baseT)(src)
-                case (Some(lo), Some(hi)) => in.Slice(dbase, lo, hi, dcap, baseT)(src)
+                case (None, None) => in.Slice(derefBase, in.IntLit(0)(src), in.Length(derefBase)(src), dcap, derefBaseT)(src)
+                case (Some(lo), None) => in.Slice(derefBase, lo, in.Length(derefBase)(src), dcap, derefBaseT)(src)
+                case (None, Some(hi)) => in.Slice(derefBase, in.IntLit(0)(src), hi, dcap, derefBaseT)(src)
+                case (Some(lo), Some(hi)) => in.Slice(derefBase, lo, hi, dcap, derefBaseT)(src)
               }
             case baseT: in.StringT =>
               Violation.violation(dcap.isEmpty, s"expected dcap to be None when slicing strings, but got $dcap instead")

--- a/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.reporting
 
-import viper.gobra.reporting.Source.{AutoImplProofAnnotation, CertainSource, CertainSynthesized, ImportPreNotEstablished, InsufficientPermissionToRangeExpressionAnnotation, InvalidImplTermMeasureAnnotation, InvariantMightBeOpenAnnotation, InvariantNotRestoredAnnotation, IsInvariantAnnotation, LoopInvariantNotEstablishedAnnotation, MainPreNotEstablished, OverflowCheckAnnotation, OverwriteErrorAnnotation, ReceiverNotNilCheckAnnotation}
+import viper.gobra.reporting.Source.{AutoImplProofAnnotation, CertainSource, CertainSynthesized, ImportPreNotEstablished, InsufficientPermissionToRangeExpressionAnnotation, InvalidImplTermMeasureAnnotation, InvariantMightBeOpenAnnotation, IndexInBoundsCheckAnnotation, InvariantNotRestoredAnnotation, IsInvariantAnnotation, LoopInvariantNotEstablishedAnnotation, MainPreNotEstablished, OverflowCheckAnnotation, OverwriteErrorAnnotation, ReceiverNotNilCheckAnnotation}
 import viper.gobra.reporting.Source.Verifier./
 import viper.silver
 import viper.silver.ast.Not
@@ -96,6 +96,7 @@ object DefaultErrorBackTranslator {
     val transformVerificationErrorReason: VerificationErrorReason => VerificationErrorReason = {
       case AssertionFalseError(info / OverflowCheckAnnotation) => OverflowErrorReason(info)
       case AssertionFalseError(info / ReceiverNotNilCheckAnnotation) => ReceiverIsNilReason(info)
+      case AssertionFalseError(info / IndexInBoundsCheckAnnotation) => IndexOutOfBoundsReason(info)
       case x => x
     }
 

--- a/src/main/scala/viper/gobra/reporting/Source.scala
+++ b/src/main/scala/viper/gobra/reporting/Source.scala
@@ -27,6 +27,7 @@ object Source {
   sealed trait Annotation
   case object OverflowCheckAnnotation extends Annotation
   case object ReceiverNotNilCheckAnnotation extends Annotation
+  case object IndexInBoundsCheckAnnotation extends Annotation
   case object ImportPreNotEstablished extends Annotation
   case object MainPreNotEstablished extends Annotation
   case object LoopInvariantNotEstablishedAnnotation extends Annotation

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -503,6 +503,11 @@ case class ReceiverIsNilReason(node: Source.Verifier.Info) extends VerificationE
   override def message: String = s"The receiver ${node.origin.tag.trim} might be nil"
 }
 
+case class IndexOutOfBoundsReason(node: Source.Verifier.Info) extends VerificationErrorReason {
+  override def id: String = "index_out_of_bounds_error"
+  override def message: String = s"The index ${node.origin.tag.trim} might be out of bounds"
+}
+
 case class DynamicValueNotASubtypeReason(node: Source.Verifier.Info) extends VerificationErrorReason {
   override def id: String = "failed_type_assertion"
   override def message: String = s"Dynamic value might not be a subtype of the target type."

--- a/src/main/scala/viper/gobra/translator/context/Context.scala
+++ b/src/main/scala/viper/gobra/translator/context/Context.scala
@@ -89,15 +89,15 @@ trait Context {
 
   // triggers are patterns that are never evaluated; panic-absence checks would wrap them in
   // function applications that are invalid as triggers:
-  def triggerExpr(x: in.TriggerExpr): CodeWriter[vpr.Exp] = typeEncoding.triggerExpr(this.withoutNilChecks)(x)
+  def triggerExpr(x: in.TriggerExpr): CodeWriter[vpr.Exp] = typeEncoding.triggerExpr(this.withoutPanicChecks)(x)
 
-  def assertion(x: in.Assertion): CodeWriter[vpr.Exp] = typeEncoding.finalAssertion(this.withoutNilChecks)(x)
+  def assertion(x: in.Assertion): CodeWriter[vpr.Exp] = typeEncoding.finalAssertion(this.withoutPanicChecks)(x)
 
-  def invariant(x: in.Assertion): (CodeWriter[Unit], vpr.Exp) = typeEncoding.invariant(this.withoutNilChecks)(x)
+  def invariant(x: in.Assertion): (CodeWriter[Unit], vpr.Exp) = typeEncoding.invariant(this.withoutPanicChecks)(x)
 
-  def precondition(x: in.Assertion): MemberWriter[vpr.Exp] = typeEncoding.precondition(this.withoutNilChecks)(x)
+  def precondition(x: in.Assertion): MemberWriter[vpr.Exp] = typeEncoding.precondition(this.withoutPanicChecks)(x)
 
-  def postcondition(x: in.Assertion): MemberWriter[vpr.Exp] = typeEncoding.postcondition(this.withoutNilChecks)(x)
+  def postcondition(x: in.Assertion): MemberWriter[vpr.Exp] = typeEncoding.postcondition(this.withoutPanicChecks)(x)
 
   def reference(x: in.Location): CodeWriter[vpr.Exp] = typeEncoding.reference(this)(x)
 
@@ -153,10 +153,10 @@ trait Context {
     * L-value rooted in a nil pointer or an out-of-range index denotes an unconstrained value, and
     * the permission system already prevents deriving any facts about actual memory from it.
     */
-  def emitNilChecks: Boolean
+  def emitPanicChecks: Boolean
 
-  /** Returns a context that does not generate panic checks. See [[emitNilChecks]]. */
-  def withoutNilChecks: Context = if (emitNilChecks) :=(emitNilChecksN = false) else this
+  /** Returns a context that does not generate panic checks. See [[emitPanicChecks]]. */
+  def withoutPanicChecks: Context = if (emitPanicChecks) :=(emitPanicChecksN = false) else this
 
   // mapping
   def addVars(vars: vpr.LocalVarDecl*): Context
@@ -186,9 +186,9 @@ trait Context {
           typeEncodingN: TypeEncoding = typeEncoding,
           defaultEncodingN: DefaultEncoding = defaultEncoding,
           initialFreshCounterValueN: Option[Int] = None,
-          emitNilChecksN: Boolean = emitNilChecks,
+          emitPanicChecksN: Boolean = emitPanicChecks,
         ): Context = {
-    update(fieldN, arrayN, seqToSetN, seqToMultisetN, seqMultiplicityN, optionN, optionToSeqN, sliceN, fixpointN, tupleN, equalityN, conditionN, unknownValueN, typeEncodingN, defaultEncodingN, initialFreshCounterValueN, emitNilChecksN)
+    update(fieldN, arrayN, seqToSetN, seqToMultisetN, seqMultiplicityN, optionN, optionToSeqN, sliceN, fixpointN, tupleN, equalityN, conditionN, unknownValueN, typeEncodingN, defaultEncodingN, initialFreshCounterValueN, emitPanicChecksN)
   }
 
   protected def update(
@@ -208,7 +208,7 @@ trait Context {
           typeEncodingN: TypeEncoding,
           defaultEncodingN: DefaultEncoding,
           initialFreshCounterValueN: Option[Int],
-          emitNilChecksN: Boolean,
+          emitPanicChecksN: Boolean,
         ): Context
 
 

--- a/src/main/scala/viper/gobra/translator/context/Context.scala
+++ b/src/main/scala/viper/gobra/translator/context/Context.scala
@@ -87,7 +87,9 @@ trait Context {
 
   def expression(x: in.Expr): CodeWriter[vpr.Exp] = typeEncoding.finalExpression(this)(x)
 
-  def triggerExpr(x: in.TriggerExpr): CodeWriter[vpr.Exp] = typeEncoding.triggerExpr(this)(x)
+  // triggers are patterns that are never evaluated; panic-absence checks would wrap them in
+  // function applications that are invalid as triggers:
+  def triggerExpr(x: in.TriggerExpr): CodeWriter[vpr.Exp] = typeEncoding.triggerExpr(this.withoutNilChecks)(x)
 
   def assertion(x: in.Assertion): CodeWriter[vpr.Exp] = typeEncoding.finalAssertion(this.withoutNilChecks)(x)
 
@@ -139,19 +141,21 @@ trait Context {
     case t => t
   }
 
-  // nil checks
+  // panic checks
 
   /**
-    * Whether usages of L-values generate nil-dereference checks (see [[TypeEncoding.checkNotNil]]).
-    * Nil-dereference checks are only meaningful in actual code, where a nil dereference causes a
-    * runtime panic. They are suppressed in specifications and intrinsically ghost statements
-    * (assert, inhale, exhale, fold, unfold), which are never executed: there, an L-value rooted
-    * in a nil pointer denotes an unconstrained value, and the permission system already prevents
-    * deriving any facts about actual memory from it.
+    * Whether usages of L-values generate panic checks, i.e. checks for the absence of runtime panics: nil-dereference checks
+    * (see [[TypeEncoding.checkNotNil]]) and index-bounds checks
+    * (see [[TypeEncoding.checkIndicesInBounds]]).
+    * These checks are only meaningful in actual code, where a nil dereference or an out-of-bounds
+    * index causes a runtime panic. They are suppressed in specifications and intrinsically ghost
+    * statements (assert, inhale, exhale, fold, unfold), which are never executed: there, an
+    * L-value rooted in a nil pointer or an out-of-range index denotes an unconstrained value, and
+    * the permission system already prevents deriving any facts about actual memory from it.
     */
   def emitNilChecks: Boolean
 
-  /** Returns a context that does not generate nil-dereference checks. See [[emitNilChecks]]. */
+  /** Returns a context that does not generate panic checks. See [[emitNilChecks]]. */
   def withoutNilChecks: Context = if (emitNilChecks) :=(emitNilChecksN = false) else this
 
   // mapping

--- a/src/main/scala/viper/gobra/translator/context/ContextImpl.scala
+++ b/src/main/scala/viper/gobra/translator/context/ContextImpl.scala
@@ -40,7 +40,7 @@ class ContextImpl(
                    override val defaultEncoding: DefaultEncoding,
                    override val table: LookupTable,
                    override val internalFreshNames: Context.FreshNameIterator = ContextImpl.FreshNameIteratorImpl(0),
-                   override val emitNilChecks: Boolean = true,
+                   override val emitPanicChecks: Boolean = true,
                  ) extends Context {
 
   def this(conf: TranslatorConfig, table: LookupTable) = {
@@ -82,7 +82,7 @@ class ContextImpl(
                    typeEncodingN: TypeEncoding,
                    defaultEncodingN: DefaultEncoding,
                    initialFreshCounterValueN: Option[Int],
-                   emitNilChecksN: Boolean,
+                   emitPanicChecksN: Boolean,
                  ): Context = new ContextImpl(
     fieldN,
     arrayN,
@@ -104,7 +104,7 @@ class ContextImpl(
       case None => internalFreshNames
       case Some(n) => ContextImpl.FreshNameIteratorImpl(n)
     },
-    emitNilChecksN,
+    emitPanicChecksN,
   )
 
   override def addVars(vars: LocalVarDecl*): Context = this

--- a/src/main/scala/viper/gobra/translator/encodings/arrays/ArrayEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/arrays/ArrayEncoding.scala
@@ -176,7 +176,9 @@ class ArrayEncoding extends TypeEncoding with SharedArrayEmbedding {
     case n@ in.Length(e :: ctx.Array(len, t) / m) =>
       m match {
         case Exclusive => ctx.expression(e).map(ex.length(_, cptParam(len, t)(ctx))(n)(ctx))
-        case Shared => ctx.safeReference(e.asInstanceOf[in.Location]).map(sh.length(_, cptParam(len, t)(ctx))(n)(ctx))
+        // in Go, `len` of an operand of array type is a constant and the operand is not
+        // evaluated; hence, no panic-absence checks apply (cf. [[TypeEncoding.safeReference]]):
+        case Shared => ctx.reference(e.asInstanceOf[in.Location]).map(sh.length(_, cptParam(len, t)(ctx))(n)(ctx))
       }
 
     case in.Length(exp :: ctx.*(t: in.ArrayT)) =>

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -525,7 +525,7 @@ object TypeEncoding {
     */
   final def checkNotNil(loc: in.Location, res: vpr.Exp)(ctx: Context): CodeWriter[vpr.Exp] = {
     outermostDeref(loc) match {
-      case Some(d) if ctx.emitNilChecks =>
+      case Some(d) if ctx.emitPanicChecks =>
         for {
           cond <- dereferencedPointerNotNil(d)(ctx)
           checked <- cl.assertWithDefaultReason(cond, res, LoadError)(ctx)
@@ -563,7 +563,7 @@ object TypeEncoding {
     * an explicit obligation (in Go, indexing panics if the index is out of range).
     */
   final def checkIndicesInBounds(loc: in.Location, res: vpr.Exp)(ctx: Context): CodeWriter[vpr.Exp] = {
-    if (!ctx.emitNilChecks) cl.unit(res) // the obligation only applies to actual code
+    if (!ctx.emitPanicChecks) cl.unit(res) // the obligation only applies to actual code
     else {
       // The conditions are emitted innermost-first and every condition is guarded by the
       // conjunction of the inner conditions: the well-definedness of an outer condition may

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -15,6 +15,7 @@ import viper.gobra.theory.Addressability.{Exclusive, Shared}
 import viper.gobra.translator.library.Generator
 import viper.gobra.translator.context.Context
 import viper.gobra.translator.util.ViperWriter.{CodeWriter, MemberWriter}
+import viper.gobra.util.Violation
 import viper.silver.verifier.{errors => vprerr}
 import viper.silver.{ast => vpr}
 
@@ -337,17 +338,22 @@ trait TypeEncoding extends Generator {
   }
 
   /**
-    * Checks whether an L-value is safe, i.e. does not cause a runtime panic due to dereferencing nil.
-    * Instead of checking that a dereference is safe immediately, the encoding checks that usages of l-values are safe.
+    * Checks whether an L-value is safe, i.e. does not cause a runtime panic due to dereferencing
+    * nil or accessing an index out of bounds.
+    * Instead of checking that a dereference or an indexed access is safe immediately, the encoding
+    * checks that usages of l-values are safe.
     * Usages of L-values are: (1) taking a reference, (2) taking a slice, (3) converting to R-value
     *
-    * SafeRef[loc: T@] => assert [p != nil]; Ref[loc]    where *p is the root of loc (if any, see checkNotNil)
+    * SafeRef[loc: T@] => assert [p != nil]; assert [0 <= idx_k && idx_k < length_k]; Ref[loc]
+    *   where *p is the root of loc (if any, see checkNotNil)
+    *   and idx_k are the indices of the indexed accesses of loc (see checkIndicesInBounds)
     */
   final def safeReference(ctx: Context): in.Location ==> CodeWriter[vpr.Exp] = {
     val r = reference(ctx); { case loc@r(w) =>
       for {
         vprLoc <- w
-        checked <- checkNotNil(loc, vprLoc)(ctx)
+        checkedNil <- checkNotNil(loc, vprLoc)(ctx)
+        checked <- checkIndicesInBounds(loc, checkedNil)(ctx)
       } yield checked
     }
   }
@@ -542,6 +548,83 @@ object TypeEncoding {
     ctx.expression(in.UneqCmp(
       d.exp,
       in.NilLit(in.PointerT(d.typ, Exclusive))(annotatedInfo)
+    )(annotatedInfo))
+  }
+
+  /**
+    * Checks that the indices on the access path of `l` are within bounds.
+    *
+    * assert [0 <= idx && idx < length]; res    for every indexed access `base[idx]` of loc
+    *
+    * Reads and writes of indexed elements are already guarded without an explicit obligation:
+    * their permission footprints range over the in-bounds indices only, and exclusive arrays are
+    * read with Viper's sequence indexing, which carries its own bounds conditions. Taking the
+    * address of an element, however, is encoded with total domain functions and, thus, requires
+    * an explicit obligation (in Go, indexing panics if the index is out of range).
+    */
+  final def checkIndicesInBounds(loc: in.Location, res: vpr.Exp)(ctx: Context): CodeWriter[vpr.Exp] = {
+    if (!ctx.emitNilChecks) cl.unit(res) // the obligation only applies to actual code
+    else {
+      // The conditions are emitted innermost-first and every condition is guarded by the
+      // conjunction of the inner conditions: the well-definedness of an outer condition may
+      // depend on the inner indices being in bounds (e.g., reading the length of `s[i]` for the
+      // bound of `j` in `&s[i][j]` requires permission, which the caller only holds for an
+      // in-bounds `i`) and an out-of-bounds inner index should be reported as such.
+      indexedExps(loc).reverse.foldLeft(cl.unit((res, None: Option[vpr.Exp]))){ case (w, e) =>
+        val (pos, info, errT) = e.vprMeta
+        for {
+          rg <- w
+          (r, guard) = rg
+          c <- indexInBounds(e)(ctx)
+          guarded = guard.fold(c)(g => vpr.Implies(g, c)(pos, info, errT))
+          checked <- cl.assertWithDefaultReason(guarded, r, LoadError)(ctx)
+        } yield (checked, Some(guard.fold(c)(g => vpr.And(g, c)(pos, info, errT))))
+      }.map(_._1)
+    }
+  }
+
+  /**
+    * Returns the indexed accesses on the access path of `l`, outermost first. Only accesses that
+    * can panic in Go are returned, i.e. indexed accesses of (pointers to) arrays and of slices;
+    * reading a missing map key, e.g., yields the zero value instead of panicking. The operand of
+    * a dereference is not part of the access path: it is read as an expression, whose own
+    * obligations arise from the expression encoding. A non-location base (e.g. a slice expression)
+    * ends the access path but the indexed access itself is still checked.
+    */
+  private def indexedExps(l: in.Location): List[in.IndexedExp] = l match {
+    case e: in.IndexedExp =>
+      val rest = e.base match {
+        case base: in.Location => indexedExps(base)
+        case _ => Nil
+      }
+      e.baseUnderlyingType match {
+        case _: in.ArrayT | _: in.SliceT => e :: rest
+        case _ => rest
+      }
+    case in.FieldRef(recv: in.Location, _) => indexedExps(recv)
+    case _ => Nil
+  }
+
+  /**
+    * Encodes that the index of `e` is within bounds: [ 0 <= e.index && e.index < length ], where
+    * `length` is the array type's length for (pointers to) arrays and the slice's length for
+    * slices (in Go, indexing is bounded by the length; only slicing is bounded by the capacity).
+    *
+    * The annotation is attached to `e.index` such that the error names the index.
+    */
+  private def indexInBounds(e: in.IndexedExp)(ctx: Context): CodeWriter[vpr.Exp] = {
+    val annotatedInfo = e.index.info match {
+      case s: Source.Parser.Single => s.createAnnotatedInfo(Source.IndexInBoundsCheckAnnotation)
+      case i => i
+    }
+    val length: in.Expr = e.baseUnderlyingType match {
+      case t: in.ArrayT => in.IntLit(t.length)(annotatedInfo)
+      case _: in.SliceT => in.Length(e.base)(annotatedInfo)
+      case t => Violation.violation(s"unexpected base type $t of an indexed location")
+    }
+    ctx.expression(in.And(
+      in.AtMostCmp(in.IntLit(0)(annotatedInfo), e.index)(annotatedInfo),
+      in.LessCmp(e.index, length)(annotatedInfo)
     )(annotatedInfo))
   }
 

--- a/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/combinators/TypeEncoding.scala
@@ -571,14 +571,14 @@ object TypeEncoding {
       // bound of `j` in `&s[i][j]` requires permission, which the caller only holds for an
       // in-bounds `i`) and an out-of-bounds inner index should be reported as such.
       indexedExps(loc).reverse.foldLeft(cl.unit((res, None: Option[vpr.Exp]))){ case (w, e) =>
-        val (pos, info, errT) = e.vprMeta
         for {
           rg <- w
           (r, guard) = rg
           c <- indexInBounds(e)(ctx)
-          guarded = guard.fold(c)(g => vpr.Implies(g, c)(pos, info, errT))
+          // the wrappers reuse the condition's meta such that its annotation is preserved:
+          guarded = guard.fold(c)(g => vpr.Implies(g, c)(c.pos, c.info, c.errT))
           checked <- cl.assertWithDefaultReason(guarded, r, LoadError)(ctx)
-        } yield (checked, Some(guard.fold(c)(g => vpr.And(g, c)(pos, info, errT))))
+        } yield (checked, Some(guard.fold(c)(g => vpr.And(g, c)(c.pos, c.info, c.errT))))
       }.map(_._1)
     }
   }

--- a/src/test/resources/regressions/issues/000491-4.gobra
+++ b/src/test/resources/regressions/issues/000491-4.gobra
@@ -147,4 +147,16 @@ func addrOfReslicedElemOutOfBounds(s []byte) (r *byte) {
 	return
 }
 
+// Triggers are patterns that are never evaluated and, thus, must not generate
+// panic-absence checks, also in expression positions within actual code.
+requires forall i int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i])
+func quantifierWithAddrTriggerInCode(s []byte) {
+	b := forall i int :: { &s[i] } 0 <= i && i < len(s) ==> s[i] >= 0
+	_ = b
+}
 
+// In Go, `len` of an operand of array type is a constant and the operand is not
+// evaluated; hence, neither bounds nor nil-ness of the operand are checked.
+func lengthOfNestedArray(a *[4][8]byte, idx int) int {
+	return len(a[idx])
+}

--- a/src/test/resources/regressions/issues/000491-4.gobra
+++ b/src/test/resources/regressions/issues/000491-4.gobra
@@ -58,7 +58,19 @@ func addrOfSliceElem(s []byte) (r *byte) {
 	return
 }
 
+requires len(s) > 0
+func addrOfSliceElemNoPerm(s []byte) (r *byte) {
+	r = &s[0] // succeeds
+	return
+}
 
+// Indexing is bounded by the length: in Go, even taking the address of an element
+// panics for an out-of-range index (only slicing is bounded by the capacity).
+func addrOfSliceElemPossiblyEmpty(s []byte) (r *byte) {
+	//:: ExpectedOutput(load_error:index_out_of_bounds_error)
+	r = &s[0] // fails as it might be out of bound
+	return
+}
 
 // Taking the address of an element only requires the implicitly dereferenced
 // pointer to be non-nil.
@@ -98,8 +110,24 @@ func sliceOfArrayPointer(p *[8]byte) []byte {
 	return p[1:3]
 }
 
+requires p != nil
+func addrOfArrayElemDynamicIndex(p *[8]byte, idx int) (r *byte) {
+	//:: ExpectedOutput(load_error:index_out_of_bounds_error)
+	r = &p[idx]
+	return
+}
 
+requires p != nil && 0 <= idx && idx < 8
+func addrOfArrayElemDynamicIndexInBounds(p *[8]byte, idx int) (r *byte) {
+	r = &p[idx]
+	return
+}
 
+// The internal footprint of make ranges up to the capacity and must not be
+// affected by the length-bounded obligation.
+func makeWithLargerCap() []byte {
+	return make([]byte, 2, 10)
+}
 
 type definedArrayPtr *[8]byte
 
@@ -111,5 +139,12 @@ func addrOfDefinedArrayPtrElemOfNil(p definedArrayPtr) (r *byte) {
 	return
 }
 
+// The base of an indexed access does not have to be an assignable location.
+requires len(s) >= 2
+func addrOfReslicedElemOutOfBounds(s []byte) (r *byte) {
+	//:: ExpectedOutput(load_error:index_out_of_bounds_error)
+	r = &s[0:2][5]
+	return
+}
 
 

--- a/src/test/resources/regressions/issues/000491-4.gobra
+++ b/src/test/resources/regressions/issues/000491-4.gobra
@@ -46,3 +46,70 @@ func addrOfFieldOfNil(p *Pair) (r *int) {
 	r = &p.x
 	return
 }
+
+// []byte and *[N]byte behave differently: indexing a slice never dereferences a
+// pointer (the slice header itself carries the element addresses), whereas
+// indexing a pointer to an array implicitly dereferences the pointer.
+
+requires len(s) > 0
+requires forall i int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i])
+func addrOfSliceElem(s []byte) (r *byte) {
+	r = &s[0]
+	return
+}
+
+
+
+// Taking the address of an element only requires the implicitly dereferenced
+// pointer to be non-nil.
+requires p != nil
+func addrOfArrayElem(p *[8]byte) (r *byte) {
+	r = &p[0]
+	return
+}
+
+// p might be nil, so dereferencing it might panic.
+func addrOfArrayElemOfNil(p *[8]byte) (r *byte) {
+	//:: ExpectedOutput(load_error:receiver_is_nil_error)
+	r = &p[0]
+	return
+}
+
+// Unlike for structs, permission to the array does not (yet) entail that the pointer is
+// non-nil: the shared-array footprint consists of quantified permissions over embedded
+// locations rather than field permissions on the dereferenced pointer itself, so Viper's
+// permission-implies-non-null reasoning does not apply.
+requires acc(p)
+func addrOfArrayElemWithPermission(p *[8]byte) (r *byte) {
+	//:: ExpectedOutput(load_error:receiver_is_nil_error)
+	r = &p[0]
+	return
+}
+
+// Like indexing, slicing a pointer to an array implicitly dereferences the pointer.
+func sliceOfNilArrayPointer(p *[8]byte) []byte {
+	//:: ExpectedOutput(load_error:receiver_is_nil_error)
+	return p[1:3]
+}
+
+requires p != nil
+preserves forall i int :: { &p[i] } 0 <= i && i < len(p) ==> acc(&p[i])
+func sliceOfArrayPointer(p *[8]byte) []byte {
+	return p[1:3]
+}
+
+
+
+
+type definedArrayPtr *[8]byte
+
+// The implicit dereference also applies to defined types whose underlying type
+// is a pointer to an array.
+func addrOfDefinedArrayPtrElemOfNil(p definedArrayPtr) (r *byte) {
+	//:: ExpectedOutput(load_error:receiver_is_nil_error)
+	r = &p[0]
+	return
+}
+
+
+

--- a/src/test/resources/regressions/issues/000491-4.gobra
+++ b/src/test/resources/regressions/issues/000491-4.gobra
@@ -123,6 +123,32 @@ func addrOfArrayElemDynamicIndexInBounds(p *[8]byte, idx int) (r *byte) {
 	return
 }
 
+// Computing the address of a nested element reads the inner slice header, which
+// requires permission and, thus, an in-bounds inner index; an out-of-bounds inner
+// index therefore surfaces as a permission failure on the inner access.
+requires forall i int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i])
+func addrOfNestedSliceElemInnerOutOfBounds(s [][]byte, idx int) (r *byte) {
+	//:: ExpectedOutput(assignment_error:permission_error)
+	r = &s[idx][0]
+	return
+}
+
+requires len(s) > 0
+requires forall i int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i])
+func addrOfNestedSliceElemOuterOutOfBounds(s [][]byte) (r *byte) {
+	//:: ExpectedOutput(load_error:index_out_of_bounds_error)
+	r = &s[0][5]
+	return
+}
+
+requires len(s) > 0
+requires forall i int :: { &s[i] } 0 <= i && i < len(s) ==> acc(&s[i])
+requires 5 < len(s[0])
+func addrOfNestedSliceElem(s [][]byte) (r *byte) {
+	r = &s[0][5]
+	return
+}
+
 // The internal footprint of make ranges up to the capacity and must not be
 // affected by the length-bounded obligation.
 func makeWithLargerCap() []byte {


### PR DESCRIPTION
Indexing a pointer to an array implicitly dereferences the pointer ('p[i]' is shorthand for '(*p)[i]'), but the desugarer does not introduce an explicit dereference node for it. Consequently, the structural search for the outermost dereference did not find any dereference and usages such as '&p[0]' generated no nil-ness proof obligation at all, unlike the analogous field accesses.

The added test cases document the different behavior of []byte and *[N]byte, including that permission to the array does not (yet) entail non-nilness of the pointer (cf. `addrOfArrayElemWithPermission`), in contrast to structs, since the shared-array footprint consists of quantified permissions over embedded locations rather than field permissions on the dereferenced pointer.