### PR TITLE
Improve Stats Writing in the Presence of Crashes

### DIFF
--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -67,7 +67,7 @@ trait GoVerifier extends StrictLogging {
     var warningCount: Int = 0
     var allVerifierErrors: Vector[VerifierError] = Vector()
     var allTimeoutErrors: Vector[TimeoutError] = Vector()
-    var abortedPackages: Vector[String] = Vector()
+    var allExceptionErrors: Vector[ExceptionError] = Vector()
     val isVerifyingMultiplePackages = config.packageInfoInputMap.size != 1
 
     def writeStatsReport(): Unit = config.gobraDirectory match {
@@ -135,7 +135,7 @@ trait GoVerifier extends StrictLogging {
           // abort the verification of the remaining packages.
           logger.error(s"The verification of package $pkgId was aborted by an exception.", e)
           statsCollector.report(VerificationTaskFinishedMessage(pkgId))
-          abortedPackages = abortedPackages :+ pkgId
+          allExceptionErrors = allExceptionErrors :+ ExceptionError(pkgId, e)
       }
       // Keep the on-disk report current after every package: a later kill
       // that bypasses shutdown hooks (e.g. SIGKILL) then loses at most the
@@ -173,14 +173,13 @@ trait GoVerifier extends StrictLogging {
     if(allTimeoutErrors.nonEmpty) {
       logger.info(s"The verification of ${allTimeoutErrors.size} member${addPlural(allTimeoutErrors.size)} timed out.")
     }
-    if (abortedPackages.nonEmpty) {
-      logger.error(s"The verification of ${abortedPackages.size} package${addPlural(abortedPackages.size)} was aborted by an exception: ${abortedPackages.mkString(", ")}")
+    if (allExceptionErrors.nonEmpty) {
+      val pkgs = allExceptionErrors.map(_.pkgId).mkString(", ")
+      logger.error(s"The verification of ${allExceptionErrors.size} package${addPlural(allExceptionErrors.size)} was aborted by an exception: $pkgs")
     }
 
-    val allErrors = allVerifierErrors ++ allTimeoutErrors
-    if (allErrors.nonEmpty) VerifierResult.Failure(allErrors)
-    else if (abortedPackages.nonEmpty) VerifierResult.Aborted
-    else VerifierResult.Success
+    val allErrors = allVerifierErrors ++ allTimeoutErrors ++ allExceptionErrors
+    if (allErrors.isEmpty) VerifierResult.Success else VerifierResult.Failure(allErrors)
   }
 
   protected[this] def verify(pkgInfo: PackageInfo, config: Config)(implicit executor: GobraExecutionContext): Future[VerifierResult]

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -441,7 +441,19 @@ object GobraRunner extends GobraFrontend with StrictLogging {
         logger.error(e.getLocalizedMessage, e)
         exitCode = 1
     } finally {
-      executor.terminate()
+      try {
+        executor.terminate()
+      } catch {
+        // An exception here must not prevent `sys.exit`: exiting the JVM runs
+        // the shutdown hooks (in particular the one in `verifyAllPackages`
+        // that writes the statistics file) and ends verification threads that
+        // would otherwise keep a JVM without a main thread alive forever.
+        // Observed in CI: `DefaultVerificationExecutionContext.terminate`
+        // times out after 1s when worker threads hang; the escaping exception
+        // skipped `sys.exit`, leaving a zombie JVM and no statistics file.
+        case e: Throwable =>
+          logger.error(s"Terminating the execution context failed: ${e.getMessage}")
+      }
       sys.exit(exitCode)
     }
   }

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -31,6 +31,7 @@ import viper.silver.{ast => vpr}
 import java.time.format.DateTimeFormatter
 import java.time.LocalTime
 import scala.concurrent.{Await, Future, TimeoutException}
+import scala.util.control.NonFatal
 
 object GoVerifier {
 
@@ -66,6 +67,7 @@ trait GoVerifier extends StrictLogging {
     var warningCount: Int = 0
     var allVerifierErrors: Vector[VerifierError] = Vector()
     var allTimeoutErrors: Vector[TimeoutError] = Vector()
+    var abortedPackages: Vector[String] = Vector()
     val isVerifyingMultiplePackages = config.packageInfoInputMap.size != 1
 
     // write report to file on shutdown, this makes sure a report is produced even if a run is shutdown
@@ -125,6 +127,13 @@ trait GoVerifier extends StrictLogging {
           val errors = statsCollector.getTimeoutErrors(pkgId)
           errors.foreach(err => logger.error(err.formattedMessage))
           allTimeoutErrors = allTimeoutErrors ++ errors
+        case NonFatal(e) =>
+          // A crash while verifying one package (e.g. silicon's
+          // ProverInteractionFailed when a prover process dies) must not
+          // abort the verification of the remaining packages.
+          logger.error(s"The verification of package $pkgId was aborted by an exception.", e)
+          statsCollector.report(VerificationTaskFinishedMessage(pkgId))
+          abortedPackages = abortedPackages :+ pkgId
       }
     })
 
@@ -158,9 +167,14 @@ trait GoVerifier extends StrictLogging {
     if(allTimeoutErrors.nonEmpty) {
       logger.info(s"The verification of ${allTimeoutErrors.size} member${addPlural(allTimeoutErrors.size)} timed out.")
     }
+    if (abortedPackages.nonEmpty) {
+      logger.error(s"The verification of ${abortedPackages.size} package${addPlural(abortedPackages.size)} was aborted by an exception: ${abortedPackages.mkString(", ")}")
+    }
 
     val allErrors = allVerifierErrors ++ allTimeoutErrors
-    if (allErrors.isEmpty) VerifierResult.Success else VerifierResult.Failure(allErrors)
+    if (allErrors.nonEmpty) VerifierResult.Failure(allErrors)
+    else if (abortedPackages.nonEmpty) VerifierResult.Aborted
+    else VerifierResult.Success
   }
 
   protected[this] def verify(pkgInfo: PackageInfo, config: Config)(implicit executor: GobraExecutionContext): Future[VerifierResult]

--- a/src/main/scala/viper/gobra/Gobra.scala
+++ b/src/main/scala/viper/gobra/Gobra.scala
@@ -70,20 +70,22 @@ trait GoVerifier extends StrictLogging {
     var abortedPackages: Vector[String] = Vector()
     val isVerifyingMultiplePackages = config.packageInfoInputMap.size != 1
 
+    def writeStatsReport(): Unit = config.gobraDirectory match {
+      case Some(path) =>
+        val statsFile = path.resolve("stats.json").toFile
+        logger.info("Writing report to " + statsFile.getPath)
+        val wroteFile = statsCollector.writeJsonReportToFile(statsFile)
+        if (!wroteFile) {
+          logger.error(s"Could not write to the file $statsFile. Check whether the permissions to the file allow writing to it.")
+        }
+      case _ =>
+    }
+
     // write report to file on shutdown, this makes sure a report is produced even if a run is shutdown
     // by some signal.
     Runtime.getRuntime.addShutdownHook(new Thread() {
       override def run(): Unit = {
-        config.gobraDirectory match {
-          case Some(path) =>
-            val statsFile = path.resolve("stats.json").toFile
-            logger.info("Writing report to " + statsFile.getPath)
-            val wroteFile = statsCollector.writeJsonReportToFile(statsFile)
-            if (!wroteFile) {
-              logger.error(s"Could not write to the file $statsFile. Check whether the permissions to the file allow writing to it.")
-            }
-          case _ =>
-        }
+        writeStatsReport()
         // Report timeouts that were not previously reported
         statsCollector.getTimeoutErrorsForNonFinishedTasks.foreach(err => logger.error(err.formattedMessage))
       }
@@ -135,6 +137,10 @@ trait GoVerifier extends StrictLogging {
           statsCollector.report(VerificationTaskFinishedMessage(pkgId))
           abortedPackages = abortedPackages :+ pkgId
       }
+      // Keep the on-disk report current after every package: a later kill
+      // that bypasses shutdown hooks (e.g. SIGKILL) then loses at most the
+      // statistics of the package that was in flight.
+      writeStatsReport()
     })
 
     // Print statistics for caching
@@ -458,13 +464,8 @@ object GobraRunner extends GobraFrontend with StrictLogging {
       try {
         executor.terminate()
       } catch {
-        // An exception here must not prevent `sys.exit`: exiting the JVM runs
-        // the shutdown hooks (in particular the one in `verifyAllPackages`
-        // that writes the statistics file) and ends verification threads that
-        // would otherwise keep a JVM without a main thread alive forever.
-        // Observed in CI: `DefaultVerificationExecutionContext.terminate`
-        // times out after 1s when worker threads hang; the escaping exception
-        // skipped `sys.exit`, leaving a zombie JVM and no statistics file.
+        // An exception here must not prevent `sys.exit` such that exiting the
+        // JVM runs the shutdown hooks.
         case e: Throwable =>
           logger.error(s"Terminating the execution context failed: ${e.getMessage}")
       }

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -61,6 +61,12 @@ case class TimeoutError(message: String) extends VerifierError {
   val id = "timeout_error"
 }
 
+case class ExceptionError(pkgId: String, throwable: Throwable) extends VerifierError {
+  val position: Option[SourcePosition] = None
+  val id = "exception_error"
+  val message = s"Verifying package $pkgId resulted in the exception ${throwable.getMessage}."
+}
+
 case class ConsistencyError(message: String, position: Option[SourcePosition]) extends VerifierError {
   val id = "consistency_error"
 }


### PR DESCRIPTION
I'm trying to figure out while Gobra crashes in CI for one of my projects due to failed prover interactions, which could be related to OOM situations. While Gobra would provide many insights as part of the produced stats file, this file is not written as the exception bypasses proper shutdown (and skips the verification of all other packages).
This PR addresses this issue by catching non-fatal exceptions while verifying packages and writing the stats file after each package to have at least some data even in the case of fatal exceptions.