### PR TITLE
Provide optional `perm` parameter to range loops over maps

### DIFF
--- a/src/main/antlr4/GobraParser.g4
+++ b/src/main/antlr4/GobraParser.g4
@@ -511,9 +511,11 @@ assign_op: ass_op=(
     | BIT_CLEAR
   )? ASSIGN;
 
-// Add permission argument to range
+// Add an optional permission amount and an optional enumerated variable to range.
+// The permission amount is the amount of permission to the range expression that is
+// exhaled while iterating over it; it is only supported for maps.
 
 rangeClause: (
 		expressionList ASSIGN
 		| maybeAddressableIdentifierList DECLARE_ASSIGN
-	)? RANGE expression (WITH IDENTIFIER?)?;
+	)? RANGE rangeExp = expression (COMMA perm = expression)? (WITH IDENTIFIER?)?;

--- a/src/main/antlr4/GobraParser.g4
+++ b/src/main/antlr4/GobraParser.g4
@@ -513,7 +513,8 @@ assign_op: ass_op=(
 
 // Add an optional permission amount and an optional enumerated variable to range.
 // The permission amount is the amount of permission to the range expression that is
-// exhaled while iterating over it; it is only supported for maps.
+// exhaled while iterating over it; it is only supported for maps. As in an 'acc'
+// expression, the blank identifier denotes a wildcard amount.
 
 rangeClause: (
 		expressionList ASSIGN

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -846,6 +846,7 @@ sealed trait PActualMisc extends PMisc
   * Range clause of a for statement, i.e. `range exp(, perm)?( with enumerated)?`.
   * `perm` is the (optional) amount of permission to `exp` that is exhaled while iterating over it.
   * It is only supported for maps, where it defaults to a very small, but positive, amount.
+  * As in an `acc` expression, the blank identifier denotes a wildcard amount.
   */
 case class PRange(exp: PExpression, perm: Option[PRangePerm], enumerated: PUnkLikeId) extends PActualMisc
 
@@ -1367,7 +1368,8 @@ case class PTrigger(exps: Vector[PExpression]) extends PGhostMisc
 /**
   * The permission amount of a range clause, i.e. the `p` in `range exp, p`. It is a
   * specification-only annotation, and thus ghost, even though the enclosing for statement
-  * and the range expression itself need not be.
+  * and the range expression itself need not be. A `PWildcardPerm` amount stands for the
+  * `_` written by the user.
   */
 case class PRangePerm(exp: PExpression) extends PGhostMisc
 

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -842,7 +842,12 @@ sealed trait PMisc extends PNode
 
 sealed trait PActualMisc extends PMisc
 
-case class PRange(exp: PExpression, enumerated: PUnkLikeId) extends PActualMisc
+/**
+  * Range clause of a for statement, i.e. `range exp(, perm)?( with enumerated)?`.
+  * `perm` is the (optional) amount of permission to `exp` that is exhaled while iterating over it.
+  * It is only supported for maps, where it defaults to a very small, but positive, amount.
+  */
+case class PRange(exp: PExpression, perm: Option[PExpression], enumerated: PUnkLikeId) extends PActualMisc
 
 sealed trait PParameter extends PMisc {
   def typ: PType

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -847,7 +847,7 @@ sealed trait PActualMisc extends PMisc
   * `perm` is the (optional) amount of permission to `exp` that is exhaled while iterating over it.
   * It is only supported for maps, where it defaults to a very small, but positive, amount.
   */
-case class PRange(exp: PExpression, perm: Option[PExpression], enumerated: PUnkLikeId) extends PActualMisc
+case class PRange(exp: PExpression, perm: Option[PRangePerm], enumerated: PUnkLikeId) extends PActualMisc
 
 sealed trait PParameter extends PMisc {
   def typ: PType
@@ -1363,6 +1363,13 @@ sealed trait PGhostMisc extends PMisc with PGhostNode
 case class PBoundVariable(id: PIdnDef, typ: PType) extends PGhostMisc
 
 case class PTrigger(exps: Vector[PExpression]) extends PGhostMisc
+
+/**
+  * The permission amount of a range clause, i.e. the `p` in `range exp, p`. It is a
+  * specification-only annotation, and thus ghost, even though the enclosing for statement
+  * and the range expression itself need not be.
+  */
+case class PRangePerm(exp: PExpression) extends PGhostMisc
 
 case class PExplicitGhostParameter(actual: PActualParameter) extends PParameter with PGhostMisc with PGhostifier[PActualParameter] {
   override def typ: PType = actual.typ

--- a/src/main/scala/viper/gobra/ast/frontend/Ast.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/Ast.scala
@@ -848,7 +848,7 @@ sealed trait PActualMisc extends PMisc
   * It is only supported for maps, where it defaults to a very small, but positive, amount.
   * As in an `acc` expression, the blank identifier denotes a wildcard amount.
   */
-case class PRange(exp: PExpression, perm: Option[PRangePerm], enumerated: PUnkLikeId) extends PActualMisc
+case class PRange(exp: PExpression, perm: Option[PExpression], enumerated: PUnkLikeId) extends PActualMisc
 
 sealed trait PParameter extends PMisc {
   def typ: PType
@@ -1364,14 +1364,6 @@ sealed trait PGhostMisc extends PMisc with PGhostNode
 case class PBoundVariable(id: PIdnDef, typ: PType) extends PGhostMisc
 
 case class PTrigger(exps: Vector[PExpression]) extends PGhostMisc
-
-/**
-  * The permission amount of a range clause, i.e. the `p` in `range exp, p`. It is a
-  * specification-only annotation, and thus ghost, even though the enclosing for statement
-  * and the range expression itself need not be. A `PWildcardPerm` amount stands for the
-  * `_` written by the user.
-  */
-case class PRangePerm(exp: PExpression) extends PGhostMisc
 
 case class PExplicitGhostParameter(actual: PActualParameter) extends PParameter with PGhostMisc with PGhostifier[PActualParameter] {
   override def typ: PType = actual.typ

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -380,14 +380,12 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
   }
 
   def showRange(n: PRange): Doc = {
-    val perm = n.perm.map(p => "," <+> showRangePerm(p)).getOrElse(emptyDoc)
+    val perm = n.perm.map("," <+> showExpr(_)).getOrElse(emptyDoc)
     n.enumerated match {
       case _: PWildcard => "range" <+> showExpr(n.exp) <> perm
       case _ => "range" <+> showExpr(n.exp) <> perm <+> "with" <+> showId(n.enumerated)
     }
   }
-
-  def showRangePerm(n: PRangePerm): Doc = showExpr(n.exp)
 
   def showMatchClauseStatement(n: PMatchStmtCase): Doc = "case" <+> showMatchPattern(n.pattern) <> ":" <+> nest(line <> ssep(n.stmt map showStmt, line))
 
@@ -778,7 +776,6 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
       case PDottedBase(expr) => showExprOrType(expr)
       case PBoundVariable(v, typ) => showId(v) <> ":" <+> showType(typ)
       case PTrigger(exps) => "{" <> showList(exps)(showExpr) <> "}"
-      case p: PRangePerm => showRangePerm(p)
       case PExplicitGhostParameter(actual) => showParameter(actual)
       case PDomainFunction(id, args, res) =>
         "func" <+> showId(id) <> parens(showParameterList(args)) <> showResult(res)

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -379,9 +379,12 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
       "case" <+> showIdList(shorts) <+> "=" <+> showExpr(recv) <> ":" <> showNestedStmtList(body.stmts)
   }
 
-  def showRange(n: PRange): Doc = n.enumerated match {
-    case _: PWildcard => "range" <+> showExpr(n.exp)
-    case _ => "range" <+> showExpr(n.exp) <+> "with" <+> showId(n.enumerated)
+  def showRange(n: PRange): Doc = {
+    val perm = n.perm.map("," <+> showExpr(_)).getOrElse(emptyDoc)
+    n.enumerated match {
+      case _: PWildcard => "range" <+> showExpr(n.exp) <> perm
+      case _ => "range" <+> showExpr(n.exp) <> perm <+> "with" <+> showId(n.enumerated)
+    }
   }
 
   def showMatchClauseStatement(n: PMatchStmtCase): Doc = "case" <+> showMatchPattern(n.pattern) <> ":" <+> nest(line <> ssep(n.stmt map showStmt, line))

--- a/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
+++ b/src/main/scala/viper/gobra/ast/frontend/PrettyPrinter.scala
@@ -380,12 +380,14 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
   }
 
   def showRange(n: PRange): Doc = {
-    val perm = n.perm.map("," <+> showExpr(_)).getOrElse(emptyDoc)
+    val perm = n.perm.map(p => "," <+> showRangePerm(p)).getOrElse(emptyDoc)
     n.enumerated match {
       case _: PWildcard => "range" <+> showExpr(n.exp) <> perm
       case _ => "range" <+> showExpr(n.exp) <> perm <+> "with" <+> showId(n.enumerated)
     }
   }
+
+  def showRangePerm(n: PRangePerm): Doc = showExpr(n.exp)
 
   def showMatchClauseStatement(n: PMatchStmtCase): Doc = "case" <+> showMatchPattern(n.pattern) <> ":" <+> nest(line <> ssep(n.stmt map showStmt, line))
 
@@ -776,6 +778,7 @@ class DefaultPrettyPrinter extends PrettyPrinter with kiama.output.PrettyPrinter
       case PDottedBase(expr) => showExprOrType(expr)
       case PBoundVariable(v, typ) => showId(v) <> ":" <+> showType(typ)
       case PTrigger(exps) => "{" <> showList(exps)(showExpr) <> "}"
+      case p: PRangePerm => showRangePerm(p)
       case PExplicitGhostParameter(actual) => showParameter(actual)
       case PDomainFunction(id, args, res) =>
         "func" <+> showId(id) <> parens(showParameterList(args)) <> showResult(res)

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -1409,7 +1409,7 @@ object Desugar extends LazyLogging {
       def rangePermD(range: PRange, permVar: in.LocalVar)(src: Source.Parser.Info): Writer[Vector[in.Stmt]] =
         range.perm match {
           case None => unit(Vector[in.Stmt](singleAss(in.Assignee.Var(permVar), in.PermLit(1, MapExhalePermDenom)(src))(src)))
-          case Some(p) =>
+          case Some(PRangePerm(p)) =>
             val permSrc = meta(p, info)
             val checkSrc = permSrc.createAnnotatedInfo(Source.NonPositivePermissionToRangeExpressionAnnotation())
             for { dPerm <- permissionD(ctx, info)(p) } yield Vector[in.Stmt](

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -1420,10 +1420,10 @@ object Desugar extends LazyLogging {
           case None =>
             unit((Vector[in.Stmt](singleAss(in.Assignee.Var(permVar), in.PermLit(1, MapExhalePermDenom)(src))(src)), permVar))
 
-          case Some(PRangePerm(w: PWildcardPerm)) =>
+          case Some(w: PWildcardPerm) =>
             unit((Vector.empty[in.Stmt], in.WildcardPerm(meta(w, info))))
 
-          case Some(PRangePerm(p)) =>
+          case Some(p) =>
             val permSrc = meta(p, info)
             val checkSrc = permSrc.createAnnotatedInfo(Source.NonPositivePermissionToRangeExpressionAnnotation())
             for { dPerm <- permissionD(ctx, info)(p) } yield (Vector[in.Stmt](

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -1398,11 +1398,35 @@ object Desugar extends LazyLogging {
       } yield enc))
 
       /**
+        * Desugars the amount of permission to the range expression that is exhaled while iterating
+        * over it. The result is the sequence of statements assigning that amount to `permVar`.
+        *
+        * By default, a very small (but positive) amount is used, which suffices to guarantee that
+        * the range expression is not modified by the loop body. Users may provide a different
+        * amount with the syntax `range exp, p`, in which case we additionally check that `p` is
+        * strictly positive.
+        */
+      def rangePermD(range: PRange, permVar: in.LocalVar)(src: Source.Parser.Info): Writer[Vector[in.Stmt]] =
+        range.perm match {
+          case None => unit(Vector[in.Stmt](singleAss(in.Assignee.Var(permVar), in.PermLit(1, MapExhalePermDenom)(src))(src)))
+          case Some(p) =>
+            val permSrc = meta(p, info)
+            val checkSrc = permSrc.createAnnotatedInfo(Source.NonPositivePermissionToRangeExpressionAnnotation())
+            for { dPerm <- permissionD(ctx, info)(p) } yield Vector[in.Stmt](
+              singleAss(in.Assignee.Var(permVar), dPerm)(permSrc),
+              // check that the permission amount provided by the user is valid
+              in.Assert(in.ExprAssertion(in.PermLtCmp(in.NoPerm(checkSrc), permVar)(checkSrc))(checkSrc))(checkSrc)
+            )
+        }
+
+      /**
         * This case handles for loops with a range clause of a map expression of the form:
         *
         * <invariants>
         * // visited here is a set containing the already visited keys in the map
-        * for k, v := range x with visited {
+        * // per is the optional permission amount provided by the user;
+        * // it defaults to 1/MapExhalePermDenom
+        * for k, v := range x, per with visited {
         *     body
         * }
         *
@@ -1411,6 +1435,8 @@ object Desugar extends LazyLogging {
         * name declared outside. This is also the go behaviour.
         *
         * c := x
+        * p := per
+        * assert none < p // check if permission provided by user is valid; omitted if per is absent
         *
         * if (|c| == 0) {
         *     var k : T1
@@ -1424,7 +1450,6 @@ object Desugar extends LazyLogging {
         *     inhale k in domain(c)
         *     v := c[k] // [v]
         *     var visited : Set[T1] := Set()
-        *     assert 0 / 1 < per // check if permission provided by user is valid
         *     while (|visited| < |domain(c)|)
         *     invariant |visited| < |domain(c)| ==> k in domain(x) && v == c[k] // [v]
         *     invariant |visited| <= |domain(c)|
@@ -1435,9 +1460,9 @@ object Desugar extends LazyLogging {
         *         inhale key in domain(c) && !(key in visited)
         *         k := key
         *         v := x[k] // [v]
-        *         exhale acc(x, 1/100000)
+        *         exhale acc(x, p)
         *         <body>
-        *         inhale acc(x, 1/100000)
+        *         inhale acc(x, p)
         *         visited := visited union Set(k)
         *
         * In the case where the value variable 'v' is missing all the code annotated with [v]
@@ -1460,7 +1485,7 @@ object Desugar extends LazyLogging {
 
         perm <- freshDeclaredExclusiveVar(in.PermissionT(Addressability.exclusiveVariable), n, info)(src)
 
-        initPerm = singleAss(in.Assignee.Var(perm), in.PermLit(1, MapExhalePermDenom)(src))(src)
+        initPerm <- rangePermD(range, perm)(src)
 
         exhSrc = meta(range.exp, info).createAnnotatedInfo(Source.InsufficientPermissionToRangeExpressionAnnotation())
 
@@ -1507,8 +1532,8 @@ object Desugar extends LazyLogging {
 
         updateVisited = singleAss(visited, in.Union(visited.op, in.SetLit(keyType, Vector(k))(src), visitedT)(src))(src)
 
-        enc = in.Seqn(Vector(
-          singleAss(in.Assignee.Var(c), exp)(src),
+        enc = in.Seqn(Vector[in.Stmt](
+          singleAss(in.Assignee.Var(c), exp)(src)) ++ initPerm ++ Vector[in.Stmt](
           initOldOpenInvs,
           in.If(
             in.EqCmp(in.Length(c)(src), in.IntLit(0)(src))(src),
@@ -1517,7 +1542,6 @@ object Desugar extends LazyLogging {
               (spec.invariants zip dInv).map[in.Stmt]((x: (PExpression, in.Assertion)) => in.Assert(x._2)(meta(x._1, info).createAnnotatedInfo(Source.LoopInvariantNotEstablishedAnnotation))))(src),
             in.Seqn(
               dInvPre ++ dTerPre ++ Vector(
-                initPerm,
                 in.While(
                   in.LessCmp(in.Length(visited.op)(src), in.Length(c)(src))(src),
                   dInv ++ addedInvariants, dTer, in.Block(Vector(continueLoopLabelProxy, k) ++ (if (hasValue) Vector(v) else Vector()),
@@ -1544,7 +1568,7 @@ object Desugar extends LazyLogging {
 
         perm <- freshDeclaredExclusiveVar(in.PermissionT(Addressability.exclusiveVariable), n, info)(src)
 
-        initPerm = singleAss(in.Assignee.Var(perm), in.PermLit(1, MapExhalePermDenom)(src))(src)
+        initPerm <- rangePermD(range, perm)(src)
 
         exhSrc = meta(range.exp, info).createAnnotatedInfo(Source.InsufficientPermissionToRangeExpressionAnnotation())
 
@@ -1591,8 +1615,8 @@ object Desugar extends LazyLogging {
 
         updateVisited = singleAss(visited, in.Union(visited.op, in.SetLit(keyType, Vector(k.op))(src), visitedT)(src))(src)
 
-        enc = in.Seqn(Vector(
-          singleAss(in.Assignee.Var(c), exp)(src),
+        enc = in.Seqn(Vector[in.Stmt](
+          singleAss(in.Assignee.Var(c), exp)(src)) ++ initPerm ++ Vector[in.Stmt](
           initOldOpenInvs,
           in.If(
             in.EqCmp(in.Length(c)(src), in.IntLit(0)(src))(src),
@@ -1601,7 +1625,6 @@ object Desugar extends LazyLogging {
               (spec.invariants zip dInv).map[in.Stmt]((x: (PExpression, in.Assertion)) => in.Assert(x._2)(meta(x._1, info).createAnnotatedInfo(Source.LoopInvariantNotEstablishedAnnotation))))(src),
             in.Seqn(
               dInvPre ++ dTerPre ++ Vector(
-                initPerm,
                 in.While(
                   in.LessCmp(in.Length(visited.op)(src), in.Length(c)(src))(src),
                   dInv ++ addedInvariants, dTer, in.Block(Vector(continueLoopLabelProxy, tempk),

--- a/src/main/scala/viper/gobra/frontend/Desugar.scala
+++ b/src/main/scala/viper/gobra/frontend/Desugar.scala
@@ -1399,24 +1399,38 @@ object Desugar extends LazyLogging {
 
       /**
         * Desugars the amount of permission to the range expression that is exhaled while iterating
-        * over it. The result is the sequence of statements assigning that amount to `permVar`.
+        * over it. The result is the statements that have to be executed before the loop, together
+        * with the expression denoting the amount.
         *
         * By default, a very small (but positive) amount is used, which suffices to guarantee that
         * the range expression is not modified by the loop body. Users may provide a different
-        * amount with the syntax `range exp, p`, in which case we additionally check that `p` is
+        * amount with the syntax `range exp, p`. Such an amount is stored in `permVar`, so that the
+        * same amount is exhaled before and inhaled after the loop body, and is checked to be
         * strictly positive.
+        *
+        * The exception is a wildcard amount, `range exp, _`, which is not stored: as in an `acc`
+        * expression, every occurrence of a wildcard denotes a fresh positive amount that is small
+        * enough to be available. In particular, the amount inhaled after the body need not be the
+        * one exhaled before it, so a wildcard is only useful for loops whose invariant holds a
+        * wildcard amount itself. There is nothing to check, since wildcards are positive by
+        * construction (and cannot be compared to other amounts).
         */
-      def rangePermD(range: PRange, permVar: in.LocalVar)(src: Source.Parser.Info): Writer[Vector[in.Stmt]] =
+      def rangePermD(range: PRange, permVar: in.LocalVar)(src: Source.Parser.Info): Writer[(Vector[in.Stmt], in.Expr)] =
         range.perm match {
-          case None => unit(Vector[in.Stmt](singleAss(in.Assignee.Var(permVar), in.PermLit(1, MapExhalePermDenom)(src))(src)))
+          case None =>
+            unit((Vector[in.Stmt](singleAss(in.Assignee.Var(permVar), in.PermLit(1, MapExhalePermDenom)(src))(src)), permVar))
+
+          case Some(PRangePerm(w: PWildcardPerm)) =>
+            unit((Vector.empty[in.Stmt], in.WildcardPerm(meta(w, info))))
+
           case Some(PRangePerm(p)) =>
             val permSrc = meta(p, info)
             val checkSrc = permSrc.createAnnotatedInfo(Source.NonPositivePermissionToRangeExpressionAnnotation())
-            for { dPerm <- permissionD(ctx, info)(p) } yield Vector[in.Stmt](
+            for { dPerm <- permissionD(ctx, info)(p) } yield (Vector[in.Stmt](
               singleAss(in.Assignee.Var(permVar), dPerm)(permSrc),
               // check that the permission amount provided by the user is valid
               in.Assert(in.ExprAssertion(in.PermLtCmp(in.NoPerm(checkSrc), permVar)(checkSrc))(checkSrc))(checkSrc)
-            )
+            ), permVar)
         }
 
       /**
@@ -1485,13 +1499,13 @@ object Desugar extends LazyLogging {
 
         perm <- freshDeclaredExclusiveVar(in.PermissionT(Addressability.exclusiveVariable), n, info)(src)
 
-        initPerm <- rangePermD(range, perm)(src)
+        (initPerm, permAmount) <- rangePermD(range, perm)(src)
 
         exhSrc = meta(range.exp, info).createAnnotatedInfo(Source.InsufficientPermissionToRangeExpressionAnnotation())
 
         // exhale acc(x, p)
-        exhalePerm = in.Exhale(in.Access(in.Accessible.ExprAccess(c), perm)(exhSrc))(exhSrc)
-        inhalePerm = in.Inhale(in.Access(in.Accessible.ExprAccess(c), perm)(exhSrc))(src)
+        exhalePerm = in.Exhale(in.Access(in.Accessible.ExprAccess(c), permAmount)(exhSrc))(exhSrc)
+        inhalePerm = in.Inhale(in.Access(in.Accessible.ExprAccess(c), permAmount)(exhSrc))(src)
 
         hasValue = shorts.length > 1 && !(shorts(1).isInstanceOf[PWildcard])
 
@@ -1568,13 +1582,13 @@ object Desugar extends LazyLogging {
 
         perm <- freshDeclaredExclusiveVar(in.PermissionT(Addressability.exclusiveVariable), n, info)(src)
 
-        initPerm <- rangePermD(range, perm)(src)
+        (initPerm, permAmount) <- rangePermD(range, perm)(src)
 
         exhSrc = meta(range.exp, info).createAnnotatedInfo(Source.InsufficientPermissionToRangeExpressionAnnotation())
 
         // exhale acc(x, p)
-        exhalePerm = in.Exhale(in.Access(in.Accessible.ExprAccess(c), perm)(exhSrc))(exhSrc)
-        inhalePerm = in.Inhale(in.Access(in.Accessible.ExprAccess(c), perm)(exhSrc))(src)
+        exhalePerm = in.Exhale(in.Access(in.Accessible.ExprAccess(c), permAmount)(exhSrc))(exhSrc)
+        inhalePerm = in.Inhale(in.Access(in.Accessible.ExprAccess(c), permAmount)(exhSrc))(src)
 
         hasValue = ass.length > 1 && !(ass(1).isInstanceOf[PBlankIdentifier])
 

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -2074,7 +2074,7 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
           case blank: PBlankIdentifier => PWildcardPerm().at(blank)
           case exp => exp
         }
-        Some(PRangePerm(amount).at(permCtx)).pos()
+        Some(amount).pos()
       } else None
       // enumerated will be used no matter what, so we just make it a wildcard if it is not
       // present in the range clause

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -2067,7 +2067,9 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
     } else if (has(ctx.rangeClause())) {
       // for <assignees (:= | =)>? range <expr> (, <perm>)? (with enumerated)?
       val expr = visitNode[PExpression](ctx.rangeClause().rangeExp).at(ctx.rangeClause())
-      val perm = visitNodeOrNone[PExpression](ctx.rangeClause().perm)
+      val perm = if (has(ctx.rangeClause().perm)) {
+        Some(PRangePerm(visitNode[PExpression](ctx.rangeClause().perm)).at(ctx.rangeClause().perm)).pos()
+      } else None
       // enumerated will be used no matter what, so we just make it a wildcard if it is not
       // present in the range clause
       val enumerated: PUnkLikeId = if (has(ctx.rangeClause().IDENTIFIER())) {

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -2065,17 +2065,16 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
       val post = visitNodeOrNone[PSimpleStmt](ctx.forClause().postStmt)
       PForStmt(pre, cond, post, spec, block).at(specCtx)
     } else if (has(ctx.rangeClause())) {
-      // for <assignees (:= | =)>? range <expr> (with enumerated)?
-      val expr = visitNode[PExpression](ctx.rangeClause().expression()).at(ctx.rangeClause())
+      // for <assignees (:= | =)>? range <expr> (, <perm>)? (with enumerated)?
+      val expr = visitNode[PExpression](ctx.rangeClause().rangeExp).at(ctx.rangeClause())
+      val perm = visitNodeOrNone[PExpression](ctx.rangeClause().perm)
       // enumerated will be used no matter what, so we just make it a wildcard if it is not
       // present in the range clause
-      val enumerated = visitChildren(ctx.rangeClause()) match {
-        case Vector(_, _, "range", _, "with", i) if i.toString() == "_" => PWildcard().at(ctx.rangeClause().IDENTIFIER())
-        case Vector("range", _, "with", i) if i.toString() == "_" => PWildcard().at(ctx.rangeClause().IDENTIFIER())
-        case Vector(_, _, "range", _) | Vector("range", _) => PWildcard().at(ctx.rangeClause())
-        case _ => idnUnk.get(ctx.rangeClause().IDENTIFIER()).at(ctx.rangeClause.IDENTIFIER())
-      }
-      val range = PRange(expr, enumerated).at(ctx.rangeClause())
+      val enumerated: PUnkLikeId = if (has(ctx.rangeClause().IDENTIFIER())) {
+        // 'idnUnkLike' maps the blank identifier to a wildcard
+        idnUnkLike.get(ctx.rangeClause().IDENTIFIER()).at(ctx.rangeClause().IDENTIFIER())
+      } else PWildcard().at(ctx.rangeClause())
+      val range = PRange(expr, perm, enumerated).at(ctx.rangeClause())
       if (has(ctx.rangeClause().DECLARE_ASSIGN())) {
         // :=
         val (idnUnkLikeList(vars), addressable) = visitMaybeAddressableIdentifierList(ctx.rangeClause().maybeAddressableIdentifierList())

--- a/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
+++ b/src/main/scala/viper/gobra/frontend/ParseTreeTranslator.scala
@@ -2068,7 +2068,13 @@ class ParseTreeTranslator(pom: PositionManager, source: Source, specOnly : Boole
       // for <assignees (:= | =)>? range <expr> (, <perm>)? (with enumerated)?
       val expr = visitNode[PExpression](ctx.rangeClause().rangeExp).at(ctx.rangeClause())
       val perm = if (has(ctx.rangeClause().perm)) {
-        Some(PRangePerm(visitNode[PExpression](ctx.rangeClause().perm)).at(ctx.rangeClause().perm)).pos()
+        val permCtx = ctx.rangeClause().perm
+        // as in an 'acc' expression, the blank identifier denotes a wildcard permission
+        val amount = visitNode[PExpression](permCtx) match {
+          case blank: PBlankIdentifier => PWildcardPerm().at(blank)
+          case exp => exp
+        }
+        Some(PRangePerm(amount).at(permCtx)).pos()
       } else None
       // enumerated will be used no matter what, so we just make it a wildcard if it is not
       // present in the range clause

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/IdTyping.scala
@@ -301,7 +301,7 @@ trait IdTyping extends BaseTyping { this: TypeInfoImpl =>
         case PVarDecl(typ, right, left, _) => typ.map(symbType).getOrElse(getBlankAssigneeType(w, left, right))
         case PConstSpec(typ, right, left) => typ.map(symbType).getOrElse(getBlankAssigneeType(w, left, right))
         case PShortForRange(range, shorts, _, _, _) => getBlankAssigneeTypeRange(w, shorts, range)
-        case PRange(exp, enumerated) => if (w eq enumerated) rangeEnumeratorType(underlyingType(exprType(exp)))
+        case PRange(exp, _, enumerated) => if (w eq enumerated) rangeEnumeratorType(underlyingType(exprType(exp)))
           else violation("did not find expression corresponding to " + w)
         case _ => ???
       }

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/MiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/MiscTyping.scala
@@ -31,11 +31,16 @@ trait MiscTyping extends BaseTyping { this: TypeInfoImpl =>
         case t => message(n, s"type error: got $t but expected rangeable type")
       })
       // the permission amount is only used by the encoding of ranging over a map, where it is
-      // exhaled to guarantee that the map is not modified while iterating over it. The amount
-      // itself is checked in `wellDefGhostMisc`.
+      // exhaled to guarantee that the map is not modified while iterating over it. It is a
+      // specification-only annotation, and thus must not have any effect of its own.
       val permCheck = perm.fold(noMessages) { p =>
-        error(p, "type error: a permission amount may only be provided when ranging over a map",
-          !underlyingType(exprType(exp)).isInstanceOf[MapT])
+        val isPermExpr = isExpr(p).out
+        if (isPermExpr.nonEmpty) isPermExpr
+        else isPureExpr(p) ++
+          error(p, s"type error: got ${exprType(p)} but expected perm or integer division expression",
+            !assignableTo(exprType(p), PermissionT, isEnclosingMayInit(n))) ++
+          error(p, "type error: a permission amount may only be provided when ranging over a map",
+            !underlyingType(exprType(exp)).isInstanceOf[MapT])
       }
       rangeableCheck ++ permCheck
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/MiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/MiscTyping.scala
@@ -31,16 +31,11 @@ trait MiscTyping extends BaseTyping { this: TypeInfoImpl =>
         case t => message(n, s"type error: got $t but expected rangeable type")
       })
       // the permission amount is only used by the encoding of ranging over a map, where it is
-      // exhaled to guarantee that the map is not modified while iterating over it.
+      // exhaled to guarantee that the map is not modified while iterating over it. The amount
+      // itself is checked in `wellDefGhostMisc`.
       val permCheck = perm.fold(noMessages) { p =>
-        val isPermExpr = isExpr(p).out
-        if (isPermExpr.nonEmpty) isPermExpr
-        else {
-          error(p, s"type error: got ${exprType(p)} but expected perm or integer division expression",
-            !assignableTo(exprType(p), PermissionT, isEnclosingMayInit(n))) ++
-            error(p, "type error: a permission amount may only be provided when ranging over a map",
-              !underlyingType(exprType(exp)).isInstanceOf[MapT])
-        }
+        error(p, "type error: a permission amount may only be provided when ranging over a map",
+          !underlyingType(exprType(exp)).isInstanceOf[MapT])
       }
       rangeableCheck ++ permCheck
 

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/MiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/MiscTyping.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.frontend.info.implementation.typing
 
-import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, message, noMessages}
+import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error, message, noMessages}
 import viper.gobra.ast.frontend._
 import viper.gobra.frontend.info.base.SymbolTable._
 import viper.gobra.frontend.info.base.Type._
@@ -24,11 +24,25 @@ trait MiscTyping extends BaseTyping { this: TypeInfoImpl =>
 
   private[typing] def wellDefActualMisc(misc: PActualMisc): Messages = misc match {
 
-    case n@PRange(exp, _) => isExpr(exp).out ++ (underlyingType(exprType(exp)) match {
-      case _: ArrayT | PointerT(_: ArrayT) | _: SliceT | _: GhostSliceT | _: MapT |
-          ChannelT(_, ChannelModus.Recv | ChannelModus.Bi) => noMessages
-      case t => message(n, s"type error: got $t but expected rangeable type")
-    })
+    case n@PRange(exp, perm, _) =>
+      val rangeableCheck = isExpr(exp).out ++ (underlyingType(exprType(exp)) match {
+        case _: ArrayT | PointerT(_: ArrayT) | _: SliceT | _: GhostSliceT | _: MapT |
+            ChannelT(_, ChannelModus.Recv | ChannelModus.Bi) => noMessages
+        case t => message(n, s"type error: got $t but expected rangeable type")
+      })
+      // the permission amount is only used by the encoding of ranging over a map, where it is
+      // exhaled to guarantee that the map is not modified while iterating over it.
+      val permCheck = perm.fold(noMessages) { p =>
+        val isPermExpr = isExpr(p).out
+        if (isPermExpr.nonEmpty) isPermExpr
+        else {
+          error(p, s"type error: got ${exprType(p)} but expected perm or integer division expression",
+            !assignableTo(exprType(p), PermissionT, isEnclosingMayInit(n))) ++
+            error(p, "type error: a permission amount may only be provided when ranging over a map",
+              !underlyingType(exprType(exp)).isInstanceOf[MapT])
+        }
+      }
+      rangeableCheck ++ permCheck
 
     case n: PParameter => isType(n.typ).out
     case n: PReceiver => isType(n.typ).out
@@ -121,7 +135,7 @@ trait MiscTyping extends BaseTyping { this: TypeInfoImpl =>
 
   private[typing] def actualMiscType(misc: PActualMisc): Type = misc match {
 
-    case PRange(exp, _) => underlyingType(exprType(exp)) match {
+    case PRange(exp, _, _) => underlyingType(exprType(exp)) match {
       case ArrayT(_, elem) => InternalSingleMulti(IntT(config.typeBounds.Int), InternalTupleT(Vector(IntT(config.typeBounds.Int), elem)))
       case PointerT(ArrayT(_, elem)) => InternalSingleMulti(IntT(config.typeBounds.Int), InternalTupleT(Vector(IntT(config.typeBounds.Int), elem)))
       case SliceT(elem) => InternalSingleMulti(IntT(config.typeBounds.Int), InternalTupleT(Vector(IntT(config.typeBounds.Int), elem)))

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
@@ -10,7 +10,7 @@ import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error, message, n
 import viper.gobra.ast.frontend._
 import viper.gobra.frontend.info.base.SymbolTable
 import viper.gobra.frontend.info.base.SymbolTable.{BuiltInMPredicate, GhostTypeMember, MPredicateImpl, MPredicateSpec}
-import viper.gobra.frontend.info.base.Type.{AdtClauseT, AssertionT, BooleanT, DeclaredT, FunctionT, PredT, Type, UnknownType}
+import viper.gobra.frontend.info.base.Type.{AdtClauseT, AssertionT, BooleanT, DeclaredT, FunctionT, PermissionT, PredT, Type, UnknownType}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.frontend.info.implementation.typing.BaseTyping
 import viper.gobra.ast.frontend.{AstPattern => ap}
@@ -29,6 +29,12 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
     }
     case PBoundVariable(_, _) => noMessages
     case PTrigger(exprs) => exprs.flatMap(isWeaklyPureExpr)
+    case n@PRangePerm(exp) =>
+      val isPermExpr = isExpr(exp).out
+      if (isPermExpr.nonEmpty) isPermExpr
+      else isPureExpr(exp) ++
+        error(exp, s"type error: got ${exprType(exp)} but expected perm or integer division expression",
+          !assignableTo(exprType(exp), PermissionT, isEnclosingMayInit(n)))
     case PExplicitGhostParameter(_) => noMessages
     case p: PPredConstructorBase => p match {
       case PFPredBase(id) => entity(id) match {
@@ -113,6 +119,7 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
       }
     case PBoundVariable(_, typ) => typeSymbType(typ)
     case PTrigger(_) => BooleanT
+    case PRangePerm(_) => PermissionT
     case PExplicitGhostParameter(param) => miscType(param)
     case b: PPredConstructorBase => b match {
       case PDottedBase(recvWithId) => exprOrTypeType(recvWithId)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/GhostMiscTyping.scala
@@ -10,7 +10,7 @@ import org.bitbucket.inkytonik.kiama.util.Messaging.{Messages, error, message, n
 import viper.gobra.ast.frontend._
 import viper.gobra.frontend.info.base.SymbolTable
 import viper.gobra.frontend.info.base.SymbolTable.{BuiltInMPredicate, GhostTypeMember, MPredicateImpl, MPredicateSpec}
-import viper.gobra.frontend.info.base.Type.{AdtClauseT, AssertionT, BooleanT, DeclaredT, FunctionT, PermissionT, PredT, Type, UnknownType}
+import viper.gobra.frontend.info.base.Type.{AdtClauseT, AssertionT, BooleanT, DeclaredT, FunctionT, PredT, Type, UnknownType}
 import viper.gobra.frontend.info.implementation.TypeInfoImpl
 import viper.gobra.frontend.info.implementation.typing.BaseTyping
 import viper.gobra.ast.frontend.{AstPattern => ap}
@@ -29,12 +29,6 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
     }
     case PBoundVariable(_, _) => noMessages
     case PTrigger(exprs) => exprs.flatMap(isWeaklyPureExpr)
-    case n@PRangePerm(exp) =>
-      val isPermExpr = isExpr(exp).out
-      if (isPermExpr.nonEmpty) isPermExpr
-      else isPureExpr(exp) ++
-        error(exp, s"type error: got ${exprType(exp)} but expected perm or integer division expression",
-          !assignableTo(exprType(exp), PermissionT, isEnclosingMayInit(n)))
     case PExplicitGhostParameter(_) => noMessages
     case p: PPredConstructorBase => p match {
       case PFPredBase(id) => entity(id) match {
@@ -119,7 +113,6 @@ trait GhostMiscTyping extends BaseTyping { this: TypeInfoImpl =>
       }
     case PBoundVariable(_, typ) => typeSymbType(typ)
     case PTrigger(_) => BooleanT
-    case PRangePerm(_) => PermissionT
     case PExplicitGhostParameter(param) => miscType(param)
     case b: PPredConstructorBase => b match {
       case PDottedBase(recvWithId) => exprOrTypeType(recvWithId)

--- a/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
+++ b/src/main/scala/viper/gobra/frontend/info/implementation/typing/ghost/separation/GhostLessPrinter.scala
@@ -78,6 +78,12 @@ class GhostLessPrinter(classifier: GhostClassifier) extends DefaultPrettyPrinter
   }
 
   /**
+    * The permission amount and the enumerated variable of a range clause are both
+    * specification-only, so neither survives ghost erasure.
+    */
+  override def showRange(n: PRange): Doc = super.showRange(PRange(n.exp, None, PWildcard()))
+
+  /**
     * Filters and shows assignment, variable declaration, and short variable declaration statements by filtering their lhs and rhs
     */
   private def showAssign[N <: PNode](right: Vector[PExpression], left: Vector[N], copy: (Vector[PExpression], Vector[N], Vector[Boolean]) => PStatement): Doc = {

--- a/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
+++ b/src/main/scala/viper/gobra/reporting/DefaultErrorBackTranslator.scala
@@ -6,7 +6,7 @@
 
 package viper.gobra.reporting
 
-import viper.gobra.reporting.Source.{AutoImplProofAnnotation, CertainSource, CertainSynthesized, ImportPreNotEstablished, InsufficientPermissionToRangeExpressionAnnotation, InvalidImplTermMeasureAnnotation, InvariantMightBeOpenAnnotation, InvariantNotRestoredAnnotation, IsInvariantAnnotation, LoopInvariantNotEstablishedAnnotation, MainPreNotEstablished, OverflowCheckAnnotation, OverwriteErrorAnnotation, ReceiverNotNilCheckAnnotation}
+import viper.gobra.reporting.Source.{AutoImplProofAnnotation, CertainSource, CertainSynthesized, ImportPreNotEstablished, InsufficientPermissionToRangeExpressionAnnotation, InvalidImplTermMeasureAnnotation, InvariantMightBeOpenAnnotation, InvariantNotRestoredAnnotation, IsInvariantAnnotation, LoopInvariantNotEstablishedAnnotation, MainPreNotEstablished, NonPositivePermissionToRangeExpressionAnnotation, OverflowCheckAnnotation, OverwriteErrorAnnotation, ReceiverNotNilCheckAnnotation}
 import viper.gobra.reporting.Source.Verifier./
 import viper.silver
 import viper.silver.ast.Not
@@ -199,6 +199,9 @@ class DefaultErrorBackTranslator(
 
       case _ / InsufficientPermissionToRangeExpressionAnnotation() =>
         x.reasons.foldLeft(InsufficientPermissionToRangeExpressionError(x.info): VerificationError) { case (err, reason) => err dueTo reason }
+
+      case _ / NonPositivePermissionToRangeExpressionAnnotation() =>
+        x.reasons.foldLeft(NonPositivePermissionToRangeExpressionError(x.info): VerificationError) { case (err, reason) => err dueTo reason }
 
       case _ / LoopInvariantNotEstablishedAnnotation =>
         x.reasons.foldLeft(LoopInvariantEstablishmentError(x.info): VerificationError) { case (err, reason) => err dueTo reason }

--- a/src/main/scala/viper/gobra/reporting/Source.scala
+++ b/src/main/scala/viper/gobra/reporting/Source.scala
@@ -32,6 +32,7 @@ object Source {
   case object LoopInvariantNotEstablishedAnnotation extends Annotation
   case class NoPermissionToRangeExpressionAnnotation() extends Annotation
   case class InsufficientPermissionToRangeExpressionAnnotation() extends Annotation
+  case class NonPositivePermissionToRangeExpressionAnnotation() extends Annotation
   case class AutoImplProofAnnotation(subT: String, superT: String) extends Annotation
   case class InvalidImplTermMeasureAnnotation() extends Annotation
   case class IsInvariantAnnotation() extends Annotation

--- a/src/main/scala/viper/gobra/reporting/VerifierError.scala
+++ b/src/main/scala/viper/gobra/reporting/VerifierError.scala
@@ -325,6 +325,11 @@ case class InsufficientPermissionToRangeExpressionError(info: Source.Verifier.In
   override def localMessage: String = s"Range expression should be immutable inside the loop body"
 }
 
+case class NonPositivePermissionToRangeExpressionError(info: Source.Verifier.Info) extends VerificationError {
+  override def localId: String = "non_positive_permission_to_range_expression"
+  override def localMessage: String = s"The permission amount ${info.origin.tag.trim} provided in the range clause might not be strictly positive"
+}
+
 case class MapMakePreconditionError(info: Source.Verifier.Info) extends VerificationError {
   override def localId: String = "make_precondition_error"
   override def localMessage: String = s"The provided length to ${info.origin.tag.trim} might be negative"

--- a/src/test/resources/regressions/features/loops/range_maps-fail2.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps-fail2.gobra
@@ -1,0 +1,29 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// The permission amount exhaled by a range loop must be strictly positive, otherwise it
+// does not guarantee that the range expression is not modified by the loop body.
+
+requires p >= noPerm
+requires acc(x, p)
+ensures acc(x, p)
+decreases
+func mightBeNone(x map[int]int, ghost p perm) {
+	invariant acc(x, p)
+	decreases len(domain(x)) - len(visited)
+	//:: ExpectedOutput(non_positive_permission_to_range_expression)
+	for k := range x, p with visited {
+	}
+}
+
+decreases
+func isNone() {
+	x := map[int]int{1: 1, 2: 2}
+	invariant acc(x)
+	decreases len(domain(x)) - len(visited)
+	//:: ExpectedOutput(non_positive_permission_to_range_expression)
+	for k := range x, noPerm with visited {
+	}
+}

--- a/src/test/resources/regressions/features/loops/range_maps-fail3.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps-fail3.gobra
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// Only the encoding of ranging over a map exhales permission to the range expression,
+// so a permission amount may not be provided for other rangeable types.
+
+func slicePerm() {
+	x := []int{1, 2, 3}
+	invariant acc(x)
+	//:: ExpectedOutput(type_error)
+	for i := range x, 1/2 with i0 {
+	}
+}

--- a/src/test/resources/regressions/features/loops/range_maps-fail4.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps-fail4.gobra
@@ -1,0 +1,14 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// The permission amount provided in a range clause must be a permission expression.
+
+func notAPermission() {
+	x := map[int]int{1: 1, 2: 2}
+	invariant acc(x)
+	//:: ExpectedOutput(type_error)
+	for k := range x, true with visited {
+	}
+}

--- a/src/test/resources/regressions/features/loops/range_maps-fail5.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps-fail5.gobra
@@ -1,0 +1,18 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// The permission amount provided by the user is the amount that is exhaled, so it must be
+// available when entering the loop.
+
+requires acc(x, 1/2)
+ensures acc(x, 1/2)
+decreases
+func tooMuch(x map[int]int) {
+	invariant acc(x, 1/2)
+	decreases len(domain(x)) - len(visited)
+	//:: ExpectedOutput(insufficient_permission_to_range_expression)
+	for k := range x, 3/4 with visited {
+	}
+}

--- a/src/test/resources/regressions/features/loops/range_maps-fail6.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps-fail6.gobra
@@ -1,0 +1,42 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// The permission amount of a range clause is specification-only, and thus ghost code: it
+// must be a pure expression, and it may not call non-ghost impure functions.
+
+decreases
+func impurePerm() (ghost p perm) {
+	return 1/4
+}
+
+ghost
+decreases
+func ghostImpurePerm() perm {
+	return 1/4
+}
+
+requires acc(x)
+ensures acc(x)
+decreases
+func callsNonGhostImpure(x map[int]int) {
+	invariant acc(x)
+	decreases len(domain(x)) - len(visited)
+	// reported both as an impure expression and as a call to a non-ghost impure function
+	// from ghost code
+	//:: ExpectedOutput(type_error)
+	for k := range x, impurePerm() with visited {
+	}
+}
+
+requires acc(x)
+ensures acc(x)
+decreases
+func callsGhostImpure(x map[int]int) {
+	invariant acc(x)
+	decreases len(domain(x)) - len(visited)
+	//:: ExpectedOutput(type_error)
+	for k := range x, ghostImpurePerm() with visited {
+	}
+}

--- a/src/test/resources/regressions/features/loops/range_maps-fail6.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps-fail6.gobra
@@ -3,8 +3,8 @@
 
 package pkg
 
-// The permission amount of a range clause is specification-only, and thus ghost code: it
-// must be a pure expression, and it may not call non-ghost impure functions.
+// The permission amount of a range clause is specification-only, so it must not have any
+// effect of its own: it has to be a pure expression, whether or not it is ghost.
 
 decreases
 func impurePerm() (ghost p perm) {
@@ -23,8 +23,6 @@ decreases
 func callsNonGhostImpure(x map[int]int) {
 	invariant acc(x)
 	decreases len(domain(x)) - len(visited)
-	// reported both as an impure expression and as a call to a non-ghost impure function
-	// from ghost code
 	//:: ExpectedOutput(type_error)
 	for k := range x, impurePerm() with visited {
 	}

--- a/src/test/resources/regressions/features/loops/range_maps-fail7.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps-fail7.gobra
@@ -1,0 +1,33 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// The default amount is a fixed fraction, which is not known to be smaller than a
+// wildcard. This is the case a wildcard amount, `range x, _`, is meant for.
+
+requires acc(x, _)
+ensures acc(x, _)
+decreases
+func defaultAmountWithWildcardAtHand(x map[int]int) {
+	invariant acc(x, _)
+	decreases len(domain(x)) - len(visited)
+	//:: ExpectedOutput(insufficient_permission_to_range_expression)
+	for k := range x with visited {
+	}
+}
+
+// Conversely, every occurrence of a wildcard denotes a fresh amount, so the amount inhaled
+// after the loop body does not restore the one exhaled before it. A wildcard amount is
+// therefore of no use to a loop whose invariant holds write permission.
+
+requires acc(x)
+ensures acc(x)
+decreases
+func wildcardAmountWithWriteAtHand(x map[int]int) {
+	//:: ExpectedOutput(invariant_preservation_error:permission_error)
+	invariant acc(x)
+	decreases len(domain(x)) - len(visited)
+	for k := range x, _ with visited {
+	}
+}

--- a/src/test/resources/regressions/features/loops/range_maps-fail7.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps-fail7.gobra
@@ -3,8 +3,9 @@
 
 package pkg
 
-// The default amount is a fixed fraction, which is not known to be smaller than a
-// wildcard. This is the case a wildcard amount, `range x, _`, is meant for.
+// The default amount is a fixed fraction, which is not known to be smaller than an
+// existentially quantified permission amount.
+// This is the case a wildcard amount, `range x, _`, is meant for.
 
 requires acc(x, _)
 ensures acc(x, _)

--- a/src/test/resources/regressions/features/loops/range_maps2.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps2.gobra
@@ -68,3 +68,31 @@ func noWithClause() {
 		assert k elem domain(x)
 	}
 }
+
+// The permission amount is ghost code, so it may mention ghost variables and call ghost
+// pure functions.
+
+ghost
+decreases
+pure func half() perm {
+	return 1/2
+}
+
+requires acc(x)
+ensures acc(x)
+decreases
+func ghostPerm(x map[int]int) {
+	ghost var p perm = half() / 2
+
+	invariant acc(x)
+	decreases len(domain(x)) - len(visited)
+	for k := range x, p with visited {
+		assert k elem domain(x)
+	}
+
+	invariant acc(x)
+	decreases len(domain(x)) - len(visited)
+	for k := range x, half() with visited {
+		assert k elem domain(x)
+	}
+}

--- a/src/test/resources/regressions/features/loops/range_maps2.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps2.gobra
@@ -69,6 +69,22 @@ func noWithClause() {
 	}
 }
 
+// A wildcard amount is always small enough to be available, so it is the amount to use
+// when all that is at hand is a wildcard itself. Note that the amount inhaled after the
+// loop body is a fresh wildcard rather than the one exhaled before it, so this only works
+// for loops whose invariant holds a wildcard amount too.
+
+requires acc(x, _)
+ensures acc(x, _)
+decreases
+func wildcardPerm(x map[int]int) {
+	invariant acc(x, _)
+	decreases len(domain(x)) - len(visited)
+	for k := range x, _ with visited {
+		assert k elem domain(x)
+	}
+}
+
 // The permission amount is ghost code, so it may mention ghost variables and call ghost
 // pure functions.
 

--- a/src/test/resources/regressions/features/loops/range_maps2.gobra
+++ b/src/test/resources/regressions/features/loops/range_maps2.gobra
@@ -1,0 +1,70 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+package pkg
+
+// Ranging over a map exhales a fixed, very small, amount of permission to the map to
+// guarantee that it is not modified while iterating over it. That fixed amount may exceed
+// the permission at hand, in which case users may provide a smaller amount themselves
+// with the syntax `range x, p`.
+
+requires p > noPerm
+requires acc(x, p)
+ensures acc(x, p)
+decreases
+func symbolicPerm(x map[int]int, ghost p perm) {
+	invariant acc(x, p)
+	decreases len(domain(x)) - len(visited)
+	for k, v := range x, p/2 with visited {
+		assert k elem domain(x)
+		assert v == x[k]
+	}
+}
+
+// The permission exhaled by the loop is not available in the loop body, so the amount
+// provided by the user also determines how much permission the body may rely on.
+
+requires acc(x)
+ensures acc(x)
+decreases
+func exhalesHalf(x map[int]int) {
+	invariant acc(x)
+	decreases len(domain(x)) - len(visited)
+	for k := range x, 1/2 with visited {
+		// exactly 1/2 was exhaled, so the loop body still holds the other half
+		assert acc(x, 1/2)
+		assert k elem domain(x)
+	}
+}
+
+// The permission amount may also be provided in the assignment form of the range clause,
+// with or without a value variable.
+
+func otherRangeClauses() {
+	x := map[int]int{1: 1, 2: 2}
+
+	invariant acc(x)
+	decreases len(domain(x)) - len(visited)
+	for _ = range x, 1/4 with visited {
+	}
+
+	var k int
+	var v int
+	invariant acc(x)
+	decreases len(domain(x)) - len(visited)
+	for k, v = range x, perm(1/4) with visited {
+		assert k elem domain(x)
+		assert v == x[k]
+	}
+}
+
+// The permission amount may also be provided without a `with` clause.
+
+func noWithClause() {
+	x := map[int]int{1: 1, 2: 2}
+
+	invariant acc(x)
+	for k := range x, 1/4 {
+		assert k elem domain(x)
+	}
+}

--- a/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
+++ b/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
@@ -2760,6 +2760,14 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
     }
   }
 
+  test("Parser: should be able to parse a range clause with a wildcard permission amount") {
+    frontend.parseStmtOrFail("for k := range m, _ { }") should matchPattern {
+      case PShortForRange(
+        PRange(PNamedOperand(PIdnUse("m")), Some(PRangePerm(PWildcardPerm())), PWildcard()),
+        Vector(PIdnUnk("k")), Vector(false), _, _) =>
+    }
+  }
+
   test("Parser: should be able to parse a range clause with a named permission amount") {
     // the loop body must not be mistaken for a composite literal of type 'p'
     frontend.parseStmtOrFail("for k := range m, p { }") should matchPattern {

--- a/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
+++ b/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
@@ -2746,6 +2746,43 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
     }
   }
 
+  test("Parser: should be able to parse a range clause without a permission amount") {
+    frontend.parseStmtOrFail("for k := range m { }") should matchPattern {
+      case PShortForRange(PRange(PNamedOperand(PIdnUse("m")), None, PWildcard()), Vector(PIdnUnk("k")), Vector(false), _, _) =>
+    }
+  }
+
+  test("Parser: should be able to parse a range clause with a permission amount") {
+    frontend.parseStmtOrFail("for k := range m, 1/2 { }") should matchPattern {
+      case PShortForRange(
+        PRange(PNamedOperand(PIdnUse("m")), Some(PDiv(PIntLit(one, Decimal), PIntLit(two, Decimal))), PWildcard()),
+        Vector(PIdnUnk("k")), Vector(false), _, _) if one == 1 && two == 2 =>
+    }
+  }
+
+  test("Parser: should be able to parse a range clause with a named permission amount") {
+    // the loop body must not be mistaken for a composite literal of type 'p'
+    frontend.parseStmtOrFail("for k := range m, p { }") should matchPattern {
+      case PShortForRange(
+        PRange(PNamedOperand(PIdnUse("m")), Some(PNamedOperand(PIdnUse("p"))), PWildcard()),
+        Vector(PIdnUnk("k")), Vector(false), _, _) =>
+    }
+  }
+
+  test("Parser: should be able to parse a range clause with a permission amount and a with clause") {
+    frontend.parseStmtOrFail("for k, v = range m, p with visited { }") should matchPattern {
+      case PAssForRange(
+        PRange(PNamedOperand(PIdnUse("m")), Some(PNamedOperand(PIdnUse("p"))), PIdnUnk("visited")),
+        Vector(PNamedOperand(PIdnUse("k")), PNamedOperand(PIdnUse("v"))), _, _) =>
+    }
+  }
+
+  test("Parser: should be able to parse a range clause with a permission amount and a blank with clause") {
+    frontend.parseStmtOrFail("for range m, perm(1/2) with _ { }") should matchPattern {
+      case PAssForRange(PRange(PNamedOperand(PIdnUse("m")), Some(_), PWildcard()), Vector(PBlankIdentifier()), _, _) =>
+    }
+  }
+
   test("Parser: should be able to parse an int ghost type declaration") {
     frontend.parseMemberOrFail("ghost type MyInt int") should matchPattern {
       case Vector(PExplicitGhostMember(PTypeDef(PIntType(), PIdnDef("MyInt")))) =>

--- a/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
+++ b/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
@@ -2755,7 +2755,7 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
   test("Parser: should be able to parse a range clause with a permission amount") {
     frontend.parseStmtOrFail("for k := range m, 1/2 { }") should matchPattern {
       case PShortForRange(
-        PRange(PNamedOperand(PIdnUse("m")), Some(PRangePerm(PDiv(PIntLit(one, Decimal), PIntLit(two, Decimal)))), PWildcard()),
+        PRange(PNamedOperand(PIdnUse("m")), Some(PDiv(PIntLit(one, Decimal), PIntLit(two, Decimal))), PWildcard()),
         Vector(PIdnUnk("k")), Vector(false), _, _) if one == 1 && two == 2 =>
     }
   }
@@ -2763,7 +2763,7 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
   test("Parser: should be able to parse a range clause with a wildcard permission amount") {
     frontend.parseStmtOrFail("for k := range m, _ { }") should matchPattern {
       case PShortForRange(
-        PRange(PNamedOperand(PIdnUse("m")), Some(PRangePerm(PWildcardPerm())), PWildcard()),
+        PRange(PNamedOperand(PIdnUse("m")), Some(PWildcardPerm()), PWildcard()),
         Vector(PIdnUnk("k")), Vector(false), _, _) =>
     }
   }
@@ -2772,7 +2772,7 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
     // the loop body must not be mistaken for a composite literal of type 'p'
     frontend.parseStmtOrFail("for k := range m, p { }") should matchPattern {
       case PShortForRange(
-        PRange(PNamedOperand(PIdnUse("m")), Some(PRangePerm(PNamedOperand(PIdnUse("p")))), PWildcard()),
+        PRange(PNamedOperand(PIdnUse("m")), Some(PNamedOperand(PIdnUse("p"))), PWildcard()),
         Vector(PIdnUnk("k")), Vector(false), _, _) =>
     }
   }
@@ -2780,7 +2780,7 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
   test("Parser: should be able to parse a range clause with a permission amount and a with clause") {
     frontend.parseStmtOrFail("for k, v = range m, p with visited { }") should matchPattern {
       case PAssForRange(
-        PRange(PNamedOperand(PIdnUse("m")), Some(PRangePerm(PNamedOperand(PIdnUse("p")))), PIdnUnk("visited")),
+        PRange(PNamedOperand(PIdnUse("m")), Some(PNamedOperand(PIdnUse("p"))), PIdnUnk("visited")),
         Vector(PNamedOperand(PIdnUse("k")), PNamedOperand(PIdnUse("v"))), _, _) =>
     }
   }

--- a/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
+++ b/src/test/scala/viper/gobra/parsing/ParserUnitTests.scala
@@ -2755,7 +2755,7 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
   test("Parser: should be able to parse a range clause with a permission amount") {
     frontend.parseStmtOrFail("for k := range m, 1/2 { }") should matchPattern {
       case PShortForRange(
-        PRange(PNamedOperand(PIdnUse("m")), Some(PDiv(PIntLit(one, Decimal), PIntLit(two, Decimal))), PWildcard()),
+        PRange(PNamedOperand(PIdnUse("m")), Some(PRangePerm(PDiv(PIntLit(one, Decimal), PIntLit(two, Decimal)))), PWildcard()),
         Vector(PIdnUnk("k")), Vector(false), _, _) if one == 1 && two == 2 =>
     }
   }
@@ -2764,7 +2764,7 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
     // the loop body must not be mistaken for a composite literal of type 'p'
     frontend.parseStmtOrFail("for k := range m, p { }") should matchPattern {
       case PShortForRange(
-        PRange(PNamedOperand(PIdnUse("m")), Some(PNamedOperand(PIdnUse("p"))), PWildcard()),
+        PRange(PNamedOperand(PIdnUse("m")), Some(PRangePerm(PNamedOperand(PIdnUse("p")))), PWildcard()),
         Vector(PIdnUnk("k")), Vector(false), _, _) =>
     }
   }
@@ -2772,7 +2772,7 @@ class ParserUnitTests extends AnyFunSuite with Matchers with Inside {
   test("Parser: should be able to parse a range clause with a permission amount and a with clause") {
     frontend.parseStmtOrFail("for k, v = range m, p with visited { }") should matchPattern {
       case PAssForRange(
-        PRange(PNamedOperand(PIdnUse("m")), Some(PNamedOperand(PIdnUse("p"))), PIdnUnk("visited")),
+        PRange(PNamedOperand(PIdnUse("m")), Some(PRangePerm(PNamedOperand(PIdnUse("p")))), PIdnUnk("visited")),
         Vector(PNamedOperand(PIdnUse("k")), PNamedOperand(PIdnUse("v"))), _, _) =>
     }
   }


### PR DESCRIPTION
To prevent mutating the map while it is being traversed by a range loop, Gobra exhales a small but fixed permission to the map before iteration. This prevents us from traversing maps in cases where we only have `_` or an amount which is only known to be positive.

This PR extends the syntax for `range` loops over maps, where we can pass an extra optional parameter with a permission amount or `_`, which stands for the permission amount we exhale when traversing the map (instead of using the default)

```
// if p is passed here, gobra exhales acc(m, p), instead of the default perm amount
for k, v := range m, p {

}

// _ is also allowed in the perm amount
for k, v := range m, _ {

}
```
