### PR TITLE
Adapt to the new signature of desugarSourceQuantifiedPermissionSyntax

### DIFF
--- a/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
+++ b/src/main/scala/viper/gobra/translator/encodings/typeless/AssertionEncoding.scala
@@ -106,9 +106,21 @@ class AssertionEncoding extends Encoding {
         newBody <- pure(ctx.assertion(body))(ctx)
         newForall = vpr.Forall(newVars, newTriggers, newBody)(pos, info, errT)
         desugaredForall = vpr.utility.QuantifiedPermissions.desugarSourceQuantifiedPermissionSyntax(newForall)
-        triggeredForall = desugaredForall.map(_.autoTrigger)
+        triggeredForall = desugaredForall map autoTriggerDesugared
         reducedForall = triggeredForall.reduce[vpr.Exp] { (a, b) => vpr.And(a, b)(pos, info, errT) }
       } yield reducedForall
+  }
+
+  /** Adds triggers to the quantifiers produced by desugaring the quantified permission syntax.
+    * Desugaring a quantified inhale-exhale assertion desugars the inhaling and the exhaling view
+    * separately and wraps the resulting quantifiers in inhale-exhale assertions, which is why we
+    * have to look through these wrappers.
+    */
+  private def autoTriggerDesugared(desugared: vpr.Exp): vpr.Exp = desugared match {
+    case forall: vpr.Forall => forall.autoTrigger
+    case n: vpr.InhaleExhaleExp =>
+      vpr.InhaleExhaleExp(autoTriggerDesugared(n.in), autoTriggerDesugared(n.ex))(n.pos, n.info, n.errT)
+    case other => other
   }
 
   override def statement(ctx: Context): in.Stmt ==> CodeWriter[vpr.Stmt] = {


### PR DESCRIPTION
Updates ViperServer from 840fff63278dd655ce5032d4370cda1da3ee92c2 to 99be0e6df388579d77368a41f29a8bae1a2c4400, which pulls in Viper 2026.8.

Silver's `QuantifiedPermissions.desugarSourceQuantifiedPermissionSyntax` now returns `Seq[Exp]` instead of `Seq[Forall]` (viperproject/silver#923): a quantified inhale-exhale assertion is desugared by transforming its inhaling and its exhaling view separately and wrapping the resulting quantifiers in `InhaleExhaleExp`s. As a consequence, `AssertionEncoding` could no longer call `autoTrigger` directly on the desugared assertions. It now auto-triggers the quantifiers while looking through the inhale-exhale wrappers, which leaves the encoding of all other quantified permission assertions unchanged.
