### PR TITLE
Update sbt and its plugins

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
 
-sbt.version = 1.12.4
+sbt.version = 1.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 // Any copyright is dedicated to the Public Domain.
 // http://creativecommons.org/publicdomain/zero/1.0/
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.8")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.12")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.5.0")
+// note that sbt-native-packager moved from the `com.typesafe.sbt` to the `com.github.sbt` organization
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.7")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")


### PR DESCRIPTION
Updates sbt from 1.12.4 to 1.13.0 (the latest 1.x release) and bumps all three sbt plugins to their latest versions:
- sbt-assembly 0.14.8 -> 2.5.0
- sbt-native-packager 1.3.12 -> 1.11.7
- sbt-buildinfo 0.9.0 -> 0.13.1

Besides being several years out of date, the previous versions are no longer available on Maven Central: they are only published to the Bintray-era Ivy repository `repo.scala-sbt.org/scalasbt/sbt-plugin-releases`. Maven Central's earliest published versions are sbt-assembly 2.1.2 and sbt-buildinfo 0.12.0, and `com.typesafe.sbt:sbt-native-packager` is not published there at all. The versions selected here all resolve from Maven Central.